### PR TITLE
fix: force using npm install in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - "8"
+os: linux
+
+install:
+  - npm install
 
 script:
   - make i18n


### PR DESCRIPTION
The problem we have on Travis is that it's now using `yarn --frozen-lockfile` to install dependencies, whereas before it was just `yarn`. What this parameter does is look if there are dependencies that should be updated on `package-lock.json` and fails if there are.

My fix is forcing Travis to use `npm install` instead. That's what we've been using in our laptops anyway. The only thing to discuss is whether we should do this same `package-lock.json` check. I think we've been "ignoring" this file, so not sure if it's worth doing it.

PS - I'm not sure why Travis is using `yarn` and not `npm`. The default should be `npm`. From their [docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#using-yarn): 
> If both package.json and yarn.lock are present in the current directory, we run the following command instead of npm install: yarn --frozen-lockfile

We don't have a `yarn.lock` file, so it should default to `npm`.