### PR TITLE
fix(history): Loading history was too slow

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -319,7 +319,6 @@ const onFetchHistorySuccess = (state, action) => {
   const { history } = action.payload;
   const { addresses } = action.payload;
   const tokensHistory = {};
-  const tokensBalance = {};
   // iterate through all txs received and map all tokens this wallet has, with
   // its history and balance
   for (const tx of Object.values(history)) {
@@ -334,10 +333,14 @@ const onFetchHistorySuccess = (state, action) => {
       }
       // add this tx to the history of the corresponding token
       tokenHistory.push(getTxHistoryFromTx(tx, tokenUid, tokenTxBalance));
-      const totalBalance = getBalance(tokenUid);
-      // update token total balance
-      tokensBalance[tokenUid] = totalBalance;
     }
+  }
+
+  const tokensBalance = {};
+  for (const tokenUid of Object.keys(tokensHistory)) {
+    const totalBalance = getBalance(tokenUid);
+    // update token total balance
+    tokensBalance[tokenUid] = totalBalance;
   }
 
   // in the end, sort (in place) all tx lists in descending order by timestamp


### PR DESCRIPTION
Closes #54: Wallet is taking too long to open after downloading all transactions

The problem was an `O(n^2)` algorithm, where `n` is the number of transactions in the history.