### PR TITLE
fix: new token information missing after re-open

### DIFF
--- a/src/screens/CreateTokenConfirm.js
+++ b/src/screens/CreateTokenConfirm.js
@@ -125,6 +125,7 @@ class CreateTokenConfirm extends React.Component {
     const token = { uid: tx.hash, name: this.name, symbol: this.symbol };
     this.props.newToken(token);
     this.props.updateSelectedToken(token);
+    hathorLib.tokens.addToken(token.uid, token.name, token.symbol);
   }
 
   /**


### PR DESCRIPTION
# Acceptance criteria

When creating a new token, the token should be registered automatically and this information should persist after wallet reloads