### PR TITLE
fix: wait for wallet load

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -449,7 +449,6 @@ export const startWallet = (words, pin) => async (dispatch) => {
     });
   });
 
-
   Keychain.setGenericPassword(KEYCHAIN_USER, pin, {
     accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY,
     acessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY

--- a/src/actions.js
+++ b/src/actions.js
@@ -412,6 +412,10 @@ export const startWallet = (words, pin) => async (dispatch) => {
     walletUtil.storeEncryptedWords(words, pin);
 
     dispatch(setServerInfo({ version: null, network: networkName }));
+    // Connection might have already been established before we setup
+    // the state event listener, so we initialize it to the current
+    // state of the connection to prevent a potential race condition
+    dispatch(setIsOnline(wallet.conn.isOnline));
 
     wallet.on('new-tx', (tx) => {
       fetchNewTxTokenBalance(wallet, tx).then(async (updatedBalanceMap) => {


### PR DESCRIPTION
## Motivation

We currently have a race condition on the wallet service facade where if the WebSocket connects too quickly, we will display an offline message to the user until the next reconnection

### Acceptance Criteria
- We should set up wallet event listeners before starting the wallet on both facades
- We should be already listening for WebSocket events before the wallet start to prevent race conditions


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
