### PR TITLE
chore: upgrade wallet lib to v0.32.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,9 +1638,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.32.0.tgz",
-      "integrity": "sha512-HPIbfUsFG1o0YXWEtk0B46oL6eC2fkrgtglVMKErVyf49QdLTnw/N59aA2qLHuZAum9RDnBwzQN6lFaaA242PA==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.32.1.tgz",
+      "integrity": "sha512-MWqTMsgZGmX2CMb+aiCWztBjJhAQtuzd/ZbRPRp2dqjE/fOemMlkbjdmGvzLJQqAztgxM0X4hvRRpps3joZX7Q==",
       "requires": {
         "axios": "0.18.1",
         "bitcore-lib": "8.25.25",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.8.2",
     "@fortawesome/free-solid-svg-icons": "^5.8.2",
     "@fortawesome/react-native-fontawesome": "^0.1.0",
-    "@hathor/wallet-lib": "^0.32.0",
+    "@hathor/wallet-lib": "^0.32.1",
     "@react-native-community/async-storage": "^1.4.0",
     "@sentry/react-native": "^1.5.0",
     "@tradle/react-native-http": "^2.0.1",


### PR DESCRIPTION
### Acceptance Criteria
- The wallet mobile should use the v0.32.1 @hathor/wallet-lib


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
