### PR TITLE
feat: set user agent in the lib config

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import {
 } from 'react-navigation';
 import { Provider, connect } from 'react-redux';
 import * as Keychain from 'react-native-keychain';
+import DeviceInfo from 'react-native-device-info';
 
 import hathorLib from '@hathor/wallet-lib';
 import IconTabBar from './icon-font';
@@ -227,6 +228,10 @@ class _AppStackWrapper extends React.Component {
     this.getBiometry();
     AppState.addEventListener('change', this._handleAppStateChange);
     this.updateReduxTokens();
+    // We need the version of the app in the user agent to get some stats from the logs
+    // this method getVersion returns a string in the format <major>.<minor>.<patch>
+    const version = DeviceInfo.getVersion();
+    hathorLib.config.setUserAgent(`Hathor Wallet Mobile / ${version}`);
   }
 
   componentWillUnmount = () => {


### PR DESCRIPTION
This PR depends on the new lib release, after this PR: https://github.com/HathorNetwork/hathor-wallet-lib/pull/365

### Acceptance Criteria
- We should set the user agent in the lib config, so we can have the wallet mobile version in the logs.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
