### PR TITLE
fix: UI in many screens was broken because of flex 1

### DIFF
--- a/src/components/AmountTextInput.js
+++ b/src/components/AmountTextInput.js
@@ -66,7 +66,6 @@ class AmountTextInput extends React.Component {
 
 const style = StyleSheet.create({
   input: {
-    flex: 1,
     height: 38,
     lineHeight: 38,
     fontSize: 32,

--- a/src/screens/SendAmountInput.js
+++ b/src/screens/SendAmountInput.js
@@ -156,7 +156,8 @@ class SendAmountInput extends React.Component {
                   onAmountUpdate={this.onAmountChange}
                   value={this.state.amount}
                   allowOnlyInteger={this.isNFT()}
-                  style={{ flex: 1 }}
+                  style={{ flex: 1 }}  // we need this so the placeholder doesn't break in android devices
+                                       // after erasing the text https://github.com/facebook/react-native/issues/30666
                 />
                 {IS_MULTI_TOKEN
                   ? <TokenBox onPress={this.onTokenBoxPress} label={this.state.token.symbol} />

--- a/src/screens/SendAmountInput.js
+++ b/src/screens/SendAmountInput.js
@@ -156,8 +156,9 @@ class SendAmountInput extends React.Component {
                   onAmountUpdate={this.onAmountChange}
                   value={this.state.amount}
                   allowOnlyInteger={this.isNFT()}
-                  style={{ flex: 1 }}  // we need this so the placeholder doesn't break in android devices
-                                       // after erasing the text https://github.com/facebook/react-native/issues/30666
+                  style={{ flex: 1 }} // we need this so the placeholder doesn't break in android
+                                      // devices after erasing the text
+                                      // https://github.com/facebook/react-native/issues/30666
                 />
                 {IS_MULTI_TOKEN
                   ? <TokenBox onPress={this.onTokenBoxPress} label={this.state.token.symbol} />

--- a/src/screens/SendAmountInput.js
+++ b/src/screens/SendAmountInput.js
@@ -156,6 +156,7 @@ class SendAmountInput extends React.Component {
                   onAmountUpdate={this.onAmountChange}
                   value={this.state.amount}
                   allowOnlyInteger={this.isNFT()}
+                  style={{ flex: 1 }}
                 />
                 {IS_MULTI_TOKEN
                   ? <TokenBox onPress={this.onTokenBoxPress} label={this.state.token.symbol} />


### PR DESCRIPTION
### Summary

We've added a `flex: 1` to the AmountInput component to fix a bug in the android app in the SendAmountInput screen when deleting all the text (the bug is described here https://github.com/facebook/react-native/issues/30666).

This fix ended up breaking many screens in all devices (this can be seen in the videos added in this PR https://github.com/HathorNetwork/hathor-wallet-mobile/pull/168 or in the images below). 

The fix was to remove the generic `flex: 1` and add it as a custom style only for the SendAmountInput screen. This makes all the screens to work in both android and iOS.

### Acceptance Criteria
- All screens should have the UI working fine, including the TextInput in the SendAmountInput screen in the android.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

Bug in iOS:

![image](https://user-images.githubusercontent.com/3298774/169052566-4d7d09e7-4940-4b09-8313-4a21012a1c34.png)

Bug in Android:

![image](https://user-images.githubusercontent.com/3298774/169052643-4eead203-d048-461a-906d-99c6abf87f71.png)

Correct screen after the fix:

![image](https://user-images.githubusercontent.com/3298774/169052764-4edba3a3-4266-42c5-8b09-d85926bc3dac.png)
