### PR TITLE
fix: old remove event listener syntax was raising an error

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -240,6 +240,7 @@ class _AppStackWrapper extends React.Component {
   componentWillUnmount = () => {
     if (this.appStateChangeEventSub) {
       this.appStateChangeEventSub.remove();
+      this.appStateChangeEventSub = null;
     }
     this.props.resetData();
   }

--- a/src/App.js
+++ b/src/App.js
@@ -212,6 +212,9 @@ class _AppStackWrapper extends React.Component {
 
   appState = 'active';
 
+  // Event subscription for app state change
+  appStateChangeEventSub = null;
+
   style = StyleSheet.create({
     auxView: {
       backgroundColor: 'white',
@@ -226,7 +229,7 @@ class _AppStackWrapper extends React.Component {
 
   componentDidMount = () => {
     this.getBiometry();
-    AppState.addEventListener('change', this._handleAppStateChange);
+    this.appStateChangeEventSub = AppState.addEventListener('change', this._handleAppStateChange);
     this.updateReduxTokens();
     // We need the version of the app in the user agent to get some stats from the logs
     // this method getVersion returns a string in the format <major>.<minor>.<patch>
@@ -235,7 +238,9 @@ class _AppStackWrapper extends React.Component {
   }
 
   componentWillUnmount = () => {
-    AppState.removeEventListener('change', this._handleAppStateChange);
+    if (this.appStateChangeEventSub) {
+      this.appStateChangeEventSub.remove();
+    }
     this.props.resetData();
   }
 

--- a/src/components/QRCodeReader.js
+++ b/src/components/QRCodeReader.js
@@ -28,6 +28,8 @@ class QRCodeReader extends React.Component {
     this.willFocusEvent = null;
     // Will blur event (used to remove event listener on unmount)
     this.willBlurEvent = null;
+    // Event subscription for app state change
+    this.appStateChangeEventSub = null;
 
     /**
      * focusedScree {boolean} if this screen is being shown
@@ -53,10 +55,12 @@ class QRCodeReader extends React.Component {
     this.willFocusEvent = navigation.addListener('willFocus', () => {
       this.reactivateQrCodeScanner();
       this.setState({ focusedScreen: true, appState: AppState.currentState });
-      AppState.addEventListener('change', this._handleAppStateChange);
+      this.appStateChangeEventSub = AppState.addEventListener('change', this._handleAppStateChange);
     });
     this.willBlurEvent = navigation.addListener('willBlur', () => {
-      AppState.removeEventListener('change', this._handleAppStateChange);
+      if (this.appStateChangeEventSub) {
+        this.appStateChangeEventSub.remove();
+      }
       this.setState({ focusedScreen: false });
     });
   }
@@ -64,7 +68,9 @@ class QRCodeReader extends React.Component {
   componentWillUnmount() {
     this.willFocusEvent.remove();
     this.willBlurEvent.remove();
-    AppState.removeEventListener('change', this._handleAppStateChange);
+    if (this.appStateChangeEventSub) {
+      this.appStateChangeEventSub.remove();
+    }
   }
 
   _handleAppStateChange = (nextAppState) => {

--- a/src/components/QRCodeReader.js
+++ b/src/components/QRCodeReader.js
@@ -58,9 +58,7 @@ class QRCodeReader extends React.Component {
       this.appStateChangeEventSub = AppState.addEventListener('change', this._handleAppStateChange);
     });
     this.willBlurEvent = navigation.addListener('willBlur', () => {
-      if (this.appStateChangeEventSub) {
-        this.appStateChangeEventSub.remove();
-      }
+      this._handleAppStateChangeEventSubRemove();
       this.setState({ focusedScreen: false });
     });
   }
@@ -68,8 +66,17 @@ class QRCodeReader extends React.Component {
   componentWillUnmount() {
     this.willFocusEvent.remove();
     this.willBlurEvent.remove();
+    this._handleAppStateChangeEventSubRemove();
+  }
+
+  /**
+   * Remove event listener for app state change event
+   * and remove the reference to the event subscription
+   */
+  _handleAppStateChangeEventSubRemove() {
     if (this.appStateChangeEventSub) {
       this.appStateChangeEventSub.remove();
+      this.appStateChangeEventSub = null;
     }
   }
 


### PR DESCRIPTION
### Summary

The method `removeEventListener` in the `AppState` was deprecated but was raising an error when using the QRCode.

React native documentation: https://reactnative.dev/docs/appstate#removeeventlistener

Error:

![image](https://user-images.githubusercontent.com/3298774/169827948-59191eca-469d-48c5-992a-d8b1294d6b1f.png)

### Acceptance Criteria
- The AppState remove listener method won't use the deprecated one anymore and the QRCode reader will continue working fine.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
