### PR TITLE
fix: use spawn instead of fork

### DIFF
--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -28,6 +28,7 @@ import {
   race,
   take,
   fork,
+  spawn,
 } from 'redux-saga/effects';
 import { eventChannel } from 'redux-saga';
 import { getUniqueId } from 'react-native-device-info';
@@ -249,7 +250,7 @@ export function* loadTokens() {
     }, []);
 
   // We don't need to wait for the metadatas response, so just fork it
-  yield fork(fetchTokensMetadata, registeredTokens);
+  yield spawn(fetchTokensMetadata, registeredTokens);
 
   // Since we already know here what tokens are registered, we can dispatch actions
   // to asynchronously load the balances of each one. The `put` effect will just dispatch

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -249,7 +249,10 @@ export function* loadTokens() {
       return [...acc, token.uid];
     }, []);
 
-  // We don't need to wait for the metadatas response, so just fork it
+  // We don't need to wait for the metadatas response, so we can just
+  // spawn a new "thread" to handle it.
+  //
+  // `spawn` is similar to `fork`, but it creates a `detached` fork
   yield spawn(fetchTokensMetadata, registeredTokens);
 
   // Since we already know here what tokens are registered, we can dispatch actions


### PR DESCRIPTION
### Acceptance Criteria
- Token metadata should download without blocking the `loadTokens` generator


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
