### PR TITLE
fix: reset wallet from lockscreen was sending the user to the loading…

### DIFF
--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -409,14 +409,13 @@ msgid "Loading your transactions"
 msgstr "Indlæser dine transaktioner"
 
 #: src/screens/LoadHistoryScreen.js:78
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "**${ _this.props.loadedData.transactions } transactions** found"
-msgstr "**${ _this2.props.loadedData.transactions } transaktioner** fundet"
+msgstr "**${ _this.props.loadedData.transactions } transaktioner** fundet"
 
 #: src/screens/LoadHistoryScreen.js:81
-#, fuzzy
 msgid "**${ _this.props.loadedData.addresses } addresses** found"
-msgstr "**${ _this2.props.loadedData.addresses } adresser** fundet"
+msgstr "**${ _this.props.loadedData.addresses } adresser** fundet"
 
 #: src/screens/MainScreen.js:127
 msgid "No transactions"

--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -165,27 +165,27 @@ msgstr "Ny PIN gemt"
 msgid "CHANGE PIN"
 msgstr "SKIFT PIN"
 
-#: src/screens/ChoosePinScreen.js:133
+#: src/screens/ChoosePinScreen.js:136
 msgid "Enter your new PIN code"
 msgstr "Indtast din nye PIN-kode"
 
-#: src/screens/ChoosePinScreen.js:145
+#: src/screens/ChoosePinScreen.js:148
 msgid "Enter your new PIN code again"
 msgstr "Indtast din nye PIN-kode igen"
 
-#: src/screens/ChoosePinScreen.js:69
+#: src/screens/ChoosePinScreen.js:72
 msgid "Create a new PIN code,"
 msgstr "Opret en ny PIN-kode,"
 
-#: src/screens/ChoosePinScreen.js:72
+#: src/screens/ChoosePinScreen.js:75
 msgid "To confirm the PIN,"
 msgstr "For at bekræfte pinkoden,"
 
-#: src/screens/ChoosePinScreen.js:159
+#: src/screens/ChoosePinScreen.js:162
 msgid "PIN codes don't match. Try again."
 msgstr "PIN-koder stemmer ikke overens. Prøv igen."
 
-#: src/screens/ChoosePinScreen.js:182
+#: src/screens/ChoosePinScreen.js:185
 msgid "Start the Wallet"
 msgstr "Start Wallet"
 
@@ -404,17 +404,18 @@ msgstr "Ord"
 msgid "Enter your seed words separated by space"
 msgstr "Indtast dine seed-ord adskilt med mellemrum"
 
-#: src/screens/LoadHistoryScreen.js:90
+#: src/screens/LoadHistoryScreen.js:75
 msgid "Loading your transactions"
 msgstr "Indlæser dine transaktioner"
 
-#: src/screens/LoadHistoryScreen.js:93
-#, javascript-format
-msgid "**${ _this2.props.loadedData.transactions } transactions** found"
+#: src/screens/LoadHistoryScreen.js:78
+#, fuzzy, javascript-format
+msgid "**${ _this.props.loadedData.transactions } transactions** found"
 msgstr "**${ _this2.props.loadedData.transactions } transaktioner** fundet"
 
-#: src/screens/LoadHistoryScreen.js:96
-msgid "**${ _this2.props.loadedData.addresses } addresses** found"
+#: src/screens/LoadHistoryScreen.js:81
+#, fuzzy
+msgid "**${ _this.props.loadedData.addresses } addresses** found"
 msgstr "**${ _this2.props.loadedData.addresses } adresser** fundet"
 
 #: src/screens/MainScreen.js:127
@@ -478,23 +479,23 @@ msgstr "Modtaget"
 msgid "Waiting confirmation"
 msgstr "Venter på bekræftelse"
 
-#: src/screens/PinScreen.js:220
+#: src/screens/PinScreen.js:235
 msgid "Incorrect PIN Code. Try again."
 msgstr "Forkert PIN-kode. Prøv igen."
 
-#: src/screens/PinScreen.js:65
+#: src/screens/PinScreen.js:72
 msgid "Enter your PIN Code "
 msgstr "Indtast din pinkode "
 
-#: src/screens/PinScreen.js:66
+#: src/screens/PinScreen.js:73
 msgid "Unlock Hathor Wallet"
 msgstr "Lås Hathor-wallet op"
 
-#: src/screens/PinScreen.js:232
+#: src/screens/PinScreen.js:247
 msgid "Cancel"
 msgstr "Annuller"
 
-#: src/screens/PinScreen.js:235 src/screens/RecoverPin.js:108
+#: src/screens/PinScreen.js:250 src/screens/RecoverPin.js:108
 #: src/screens/Settings.js:133
 msgid "Reset wallet"
 msgstr "Nulstil wallet"
@@ -638,11 +639,11 @@ msgstr "SEND ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Din overførsel behandles"
 
-#: src/sagas/wallet.js:105 src/screens/SendConfirmScreen.js:117
+#: src/sagas/wallet.js:109 src/screens/SendConfirmScreen.js:117
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Indtast din 6-cifrede pin for at godkende overførslen"
 
-#: src/sagas/wallet.js:106 src/screens/SendConfirmScreen.js:118
+#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:118
 msgid "Authorize operation"
 msgstr "Autoriserer overførslen"
 

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -164,27 +164,27 @@ msgstr "Novo PIN salvo"
 msgid "CHANGE PIN"
 msgstr "MUDAR PIN"
 
-#: src/screens/ChoosePinScreen.js:133
+#: src/screens/ChoosePinScreen.js:136
 msgid "Enter your new PIN code"
 msgstr "Digite seu novo PIN"
 
-#: src/screens/ChoosePinScreen.js:145
+#: src/screens/ChoosePinScreen.js:148
 msgid "Enter your new PIN code again"
 msgstr "Digite seu novo PIN novamente"
 
-#: src/screens/ChoosePinScreen.js:69
+#: src/screens/ChoosePinScreen.js:72
 msgid "Create a new PIN code,"
 msgstr "Criar um novo PIN,"
 
-#: src/screens/ChoosePinScreen.js:72
+#: src/screens/ChoosePinScreen.js:75
 msgid "To confirm the PIN,"
 msgstr "Para confirmar o PIN,"
 
-#: src/screens/ChoosePinScreen.js:159
+#: src/screens/ChoosePinScreen.js:162
 msgid "PIN codes don't match. Try again."
 msgstr "Os PINs estão diferentes. Tente novamente."
 
-#: src/screens/ChoosePinScreen.js:182
+#: src/screens/ChoosePinScreen.js:185
 msgid "Start the Wallet"
 msgstr "Iniciar a Wallet"
 
@@ -406,17 +406,18 @@ msgstr "Palavras"
 msgid "Enter your seed words separated by space"
 msgstr "Digite suas palavras separadas por espaços"
 
-#: src/screens/LoadHistoryScreen.js:90
+#: src/screens/LoadHistoryScreen.js:75
 msgid "Loading your transactions"
 msgstr "Carregando suas transações"
 
-#: src/screens/LoadHistoryScreen.js:93
-#, javascript-format
-msgid "**${ _this2.props.loadedData.transactions } transactions** found"
+#: src/screens/LoadHistoryScreen.js:78
+#, fuzzy, javascript-format
+msgid "**${ _this.props.loadedData.transactions } transactions** found"
 msgstr "**${ _this2.props.loadedData.transactions } transações** encontradas"
 
-#: src/screens/LoadHistoryScreen.js:96
-msgid "**${ _this2.props.loadedData.addresses } addresses** found"
+#: src/screens/LoadHistoryScreen.js:81
+#, fuzzy
+msgid "**${ _this.props.loadedData.addresses } addresses** found"
 msgstr "**${ _this2.props.loadedData.addresses } endereços** encontrados"
 
 #: src/screens/MainScreen.js:127
@@ -482,23 +483,23 @@ msgstr "Recebido"
 msgid "Waiting confirmation"
 msgstr "Aguardando confirmação"
 
-#: src/screens/PinScreen.js:220
+#: src/screens/PinScreen.js:235
 msgid "Incorrect PIN Code. Try again."
 msgstr "PIN incorreto. Tente novamente."
 
-#: src/screens/PinScreen.js:65
+#: src/screens/PinScreen.js:72
 msgid "Enter your PIN Code "
 msgstr "Digite seu PIN "
 
-#: src/screens/PinScreen.js:66
+#: src/screens/PinScreen.js:73
 msgid "Unlock Hathor Wallet"
 msgstr "Desbloqueie sua Hathor Wallet"
 
-#: src/screens/PinScreen.js:232
+#: src/screens/PinScreen.js:247
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/screens/PinScreen.js:235 src/screens/RecoverPin.js:108
+#: src/screens/PinScreen.js:250 src/screens/RecoverPin.js:108
 #: src/screens/Settings.js:133
 msgid "Reset wallet"
 msgstr "Resetar a wallet"
@@ -643,11 +644,11 @@ msgstr "ENVIAR ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Sua transferência está sendo processada"
 
-#: src/sagas/wallet.js:106 src/screens/SendConfirmScreen.js:117
+#: src/sagas/wallet.js:109 src/screens/SendConfirmScreen.js:117
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Digite seu PIN de 6 dígitos para autorizar a operação"
 
-#: src/sagas/wallet.js:107 src/screens/SendConfirmScreen.js:118
+#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:118
 msgid "Authorize operation"
 msgstr "Autorizar operação"
 

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -411,14 +411,13 @@ msgid "Loading your transactions"
 msgstr "Carregando suas transações"
 
 #: src/screens/LoadHistoryScreen.js:78
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "**${ _this.props.loadedData.transactions } transactions** found"
-msgstr "**${ _this2.props.loadedData.transactions } transações** encontradas"
+msgstr "**${ _this.props.loadedData.transactions } transações** encontradas"
 
 #: src/screens/LoadHistoryScreen.js:81
-#, fuzzy
 msgid "**${ _this.props.loadedData.addresses } addresses** found"
-msgstr "**${ _this2.props.loadedData.addresses } endereços** encontrados"
+msgstr "**${ _this.props.loadedData.addresses } endereços** encontrados"
 
 #: src/screens/MainScreen.js:127
 msgid "No transactions"
@@ -436,7 +435,7 @@ msgstr "Carregando transações"
 
 #: src/screens/MainScreen.js:156
 msgid "There was an error loading your transaction history"
-msgstr "Ocorreu um erro ao carregar seu histórico de transações."
+msgstr "Ocorreu um erro ao carregar seu histórico de transações"
 
 #: src/screens/MainScreen.js:159
 msgid "Please |tryAgain:try again|"

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -9,8 +9,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.2.4\n"
 
 #: src/errorHandler.js:51
@@ -163,27 +163,27 @@ msgstr "Новый PIN-код сохранен"
 msgid "CHANGE PIN"
 msgstr "ИЗМЕНИТЬ PIN-код"
 
-#: src/screens/ChoosePinScreen.js:133
+#: src/screens/ChoosePinScreen.js:136
 msgid "Enter your new PIN code"
 msgstr "Введите новый PIN-код"
 
-#: src/screens/ChoosePinScreen.js:145
+#: src/screens/ChoosePinScreen.js:148
 msgid "Enter your new PIN code again"
 msgstr "Введите новый PIN-код еще раз"
 
-#: src/screens/ChoosePinScreen.js:69
+#: src/screens/ChoosePinScreen.js:72
 msgid "Create a new PIN code,"
 msgstr "Создать новый PIN-код,"
 
-#: src/screens/ChoosePinScreen.js:72
+#: src/screens/ChoosePinScreen.js:75
 msgid "To confirm the PIN,"
 msgstr "Для подтверждения PIN-кода,"
 
-#: src/screens/ChoosePinScreen.js:159
+#: src/screens/ChoosePinScreen.js:162
 msgid "PIN codes don't match. Try again."
 msgstr "PIN-коды не совпадают. Попробуйте еще раз."
 
-#: src/screens/ChoosePinScreen.js:182
+#: src/screens/ChoosePinScreen.js:185
 msgid "Start the Wallet"
 msgstr "Запустить кошелек"
 
@@ -402,17 +402,18 @@ msgstr "Слова"
 msgid "Enter your seed words separated by space"
 msgstr "Введите seed-фразу"
 
-#: src/screens/LoadHistoryScreen.js:90
+#: src/screens/LoadHistoryScreen.js:75
 msgid "Loading your transactions"
 msgstr "Загрузка ваших транзакций"
 
-#: src/screens/LoadHistoryScreen.js:93
-#, javascript-format
-msgid "**${ _this2.props.loadedData.transactions } transactions** found"
+#: src/screens/LoadHistoryScreen.js:78
+#, fuzzy, javascript-format
+msgid "**${ _this.props.loadedData.transactions } transactions** found"
 msgstr "**${ _this2.props.loadedData.transactions } транзакций** найдено"
 
-#: src/screens/LoadHistoryScreen.js:96
-msgid "**${ _this2.props.loadedData.addresses } addresses** found"
+#: src/screens/LoadHistoryScreen.js:81
+#, fuzzy
+msgid "**${ _this.props.loadedData.addresses } addresses** found"
 msgstr "**${ _this2.props.loadedData.addresses } адресов** найдено"
 
 #: src/screens/MainScreen.js:127
@@ -477,23 +478,23 @@ msgstr "Получено"
 msgid "Waiting confirmation"
 msgstr "Ожидание подтверждения"
 
-#: src/screens/PinScreen.js:220
+#: src/screens/PinScreen.js:235
 msgid "Incorrect PIN Code. Try again."
 msgstr "Неверный PIN-код. Попробуйте еще раз."
 
-#: src/screens/PinScreen.js:65
+#: src/screens/PinScreen.js:72
 msgid "Enter your PIN Code "
 msgstr "Введите свой PIN-код "
 
-#: src/screens/PinScreen.js:66
+#: src/screens/PinScreen.js:73
 msgid "Unlock Hathor Wallet"
 msgstr "Разблокировать Hathor Wallet"
 
-#: src/screens/PinScreen.js:232
+#: src/screens/PinScreen.js:247
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/screens/PinScreen.js:235 src/screens/RecoverPin.js:108
+#: src/screens/PinScreen.js:250 src/screens/RecoverPin.js:108
 #: src/screens/Settings.js:133
 msgid "Reset wallet"
 msgstr "Сбросить кошелек"
@@ -637,11 +638,11 @@ msgstr "ОТПРАВИТЬ ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Ваш перевод обрабатывается"
 
-#: src/sagas/wallet.js:105 src/screens/SendConfirmScreen.js:117
+#: src/sagas/wallet.js:109 src/screens/SendConfirmScreen.js:117
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Введите 6-значный PIN-код для авторизации операции"
 
-#: src/sagas/wallet.js:106 src/screens/SendConfirmScreen.js:118
+#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:118
 msgid "Authorize operation"
 msgstr "Авторизовать операцию"
 

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -407,14 +407,13 @@ msgid "Loading your transactions"
 msgstr "Загрузка ваших транзакций"
 
 #: src/screens/LoadHistoryScreen.js:78
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "**${ _this.props.loadedData.transactions } transactions** found"
-msgstr "**${ _this2.props.loadedData.transactions } транзакций** найдено"
+msgstr "**${ _this.props.loadedData.transactions } транзакций** найдено"
 
 #: src/screens/LoadHistoryScreen.js:81
-#, fuzzy
 msgid "**${ _this.props.loadedData.addresses } addresses** found"
-msgstr "**${ _this2.props.loadedData.addresses } адресов** найдено"
+msgstr "**${ _this.props.loadedData.addresses } адресов** найдено"
 
 #: src/screens/MainScreen.js:127
 msgid "No transactions"

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -153,27 +153,27 @@ msgstr ""
 msgid "CHANGE PIN"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:133
+#: src/screens/ChoosePinScreen.js:136
 msgid "Enter your new PIN code"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:145
+#: src/screens/ChoosePinScreen.js:148
 msgid "Enter your new PIN code again"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:69
+#: src/screens/ChoosePinScreen.js:72
 msgid "Create a new PIN code,"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:72
+#: src/screens/ChoosePinScreen.js:75
 msgid "To confirm the PIN,"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:159
+#: src/screens/ChoosePinScreen.js:162
 msgid "PIN codes don't match. Try again."
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:182
+#: src/screens/ChoosePinScreen.js:185
 msgid "Start the Wallet"
 msgstr ""
 
@@ -389,17 +389,17 @@ msgstr ""
 msgid "Enter your seed words separated by space"
 msgstr ""
 
-#: src/screens/LoadHistoryScreen.js:90
+#: src/screens/LoadHistoryScreen.js:75
 msgid "Loading your transactions"
 msgstr ""
 
-#: src/screens/LoadHistoryScreen.js:93
+#: src/screens/LoadHistoryScreen.js:78
 #, javascript-format
-msgid "**${ _this2.props.loadedData.transactions } transactions** found"
+msgid "**${ _this.props.loadedData.transactions } transactions** found"
 msgstr ""
 
-#: src/screens/LoadHistoryScreen.js:96
-msgid "**${ _this2.props.loadedData.addresses } addresses** found"
+#: src/screens/LoadHistoryScreen.js:81
+msgid "**${ _this.props.loadedData.addresses } addresses** found"
 msgstr ""
 
 #: src/screens/MainScreen.js:127
@@ -467,23 +467,23 @@ msgstr ""
 msgid "Waiting confirmation"
 msgstr ""
 
-#: src/screens/PinScreen.js:220
+#: src/screens/PinScreen.js:235
 msgid "Incorrect PIN Code. Try again."
 msgstr ""
 
-#: src/screens/PinScreen.js:65
+#: src/screens/PinScreen.js:72
 msgid "Enter your PIN Code "
 msgstr ""
 
-#: src/screens/PinScreen.js:66
+#: src/screens/PinScreen.js:73
 msgid "Unlock Hathor Wallet"
 msgstr ""
 
-#: src/screens/PinScreen.js:232
+#: src/screens/PinScreen.js:247
 msgid "Cancel"
 msgstr ""
 
-#: src/screens/PinScreen.js:235
+#: src/screens/PinScreen.js:250
 #: src/screens/RecoverPin.js:108
 #: src/screens/Settings.js:133
 msgid "Reset wallet"
@@ -628,12 +628,12 @@ msgstr ""
 msgid "Your transfer is being processed"
 msgstr ""
 
-#: src/sagas/wallet.js:106
+#: src/sagas/wallet.js:109
 #: src/screens/SendConfirmScreen.js:117
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr ""
 
-#: src/sagas/wallet.js:107
+#: src/sagas/wallet.js:110
 #: src/screens/SendConfirmScreen.js:118
 msgid "Authorize operation"
 msgstr ""

--- a/src/App.js
+++ b/src/App.js
@@ -176,7 +176,13 @@ const AppStack = createStackNavigator({
   About,
   Security,
   ChangePin,
-  ResetWallet,
+  ResetWallet: {
+    screen: ResetWallet,
+    // Dismissing the screen on ResetWallet would lead to a
+    // MainScreen with broken state if started from the PinScreen,
+    // so just disable the swipeDown animation
+    navigationOptions: disableSwipeDown,
+  },
   PaymentRequestDetail,
   RegisterToken: RegisterTokenStack,
   ChangeToken,

--- a/src/App.js
+++ b/src/App.js
@@ -344,7 +344,14 @@ class _AppStackWrapper extends React.Component {
         screen = <RecoverPin navigation={this.props.navigation} />;
       }
 
-      if (this.props.walletStartState === WALLET_STATUS.LOADING || this.props.isScreenLocked) {
+      const currentRouteIdx = this.props.navigation.state.index;
+      const currentRoute = this.props.navigation.state.routes[currentRouteIdx];
+
+      // We need to hide the loading screen if the wallet is being reset, otherwise
+      // the loading screen will be on top of the reset screen.
+      if (currentRoute.routeName !== 'ResetWallet'
+          && (this.props.walletStartState === WALLET_STATUS.LOADING
+              || this.props.isScreenLocked)) {
         return (
           <View style={this.style.auxView}>
             { screen }

--- a/src/App.js
+++ b/src/App.js
@@ -344,14 +344,9 @@ class _AppStackWrapper extends React.Component {
         screen = <RecoverPin navigation={this.props.navigation} />;
       }
 
-      const currentRouteIdx = this.props.navigation.state.index;
-      const currentRoute = this.props.navigation.state.routes[currentRouteIdx];
-
       // We need to hide the loading screen if the wallet is being reset, otherwise
       // the loading screen will be on top of the reset screen.
-      if (currentRoute.routeName !== 'ResetWallet'
-          && (this.props.walletStartState === WALLET_STATUS.LOADING
-              || this.props.isScreenLocked)) {
+      if (this.props.walletStartState === WALLET_STATUS.LOADING || this.props.isScreenLocked) {
         return (
           <View style={this.style.auxView}>
             { screen }

--- a/src/App.js
+++ b/src/App.js
@@ -344,8 +344,6 @@ class _AppStackWrapper extends React.Component {
         screen = <RecoverPin navigation={this.props.navigation} />;
       }
 
-      // We need to hide the loading screen if the wallet is being reset, otherwise
-      // the loading screen will be on top of the reset screen.
       if (this.props.walletStartState === WALLET_STATUS.LOADING || this.props.isScreenLocked) {
         return (
           <View style={this.style.auxView}>

--- a/src/actions.js
+++ b/src/actions.js
@@ -478,11 +478,6 @@ export const reloadWalletRequested = () => ({
   type: types.RELOAD_WALLET_REQUESTED,
 });
 
-export const startWalletLock = (payload) => ({
-  type: types.ON_START_WALLET_LOCK,
-  payload,
-});
-
 export const startWalletRequested = (payload) => ({
   type: types.START_WALLET_REQUESTED,
   payload,

--- a/src/actions.js
+++ b/src/actions.js
@@ -177,15 +177,6 @@ export const updateHeight = (height, htrBalance) => (
   { type: types.UPDATE_HEIGHT, payload: { height, htrBalance } }
 );
 
-/**
- * words {String} wallet words
- * pin {String} Pin chosen by user
- */
-export const setInitWallet = (words, pin) => (
-  { type: types.SET_INIT_WALLET, payload: { words, pin } }
-);
-
-export const clearInitWallet = () => ({ type: types.SET_INIT_WALLET, payload: null });
 
 export const updateTokenHistory = (token, newHistory) => (
   { type: types.UPDATE_TOKEN_HISTORY, payload: { token, newHistory } }

--- a/src/actions.js
+++ b/src/actions.js
@@ -68,6 +68,7 @@ export const types = {
   START_WALLET_REQUESTED: 'START_WALLET_REQUESTED',
   START_WALLET_SUCCESS: 'START_WALLET_SUCCESS',
   START_WALLET_FAILED: 'START_WALLET_FAILED',
+  START_WALLET_NOT_STARTED: 'START_WALLET_NOT_STARTED',
   WALLET_STATE_READY: 'WALLET_STATE_READY',
   WALLET_STATE_ERROR: 'WALLET_STATE_ERROR',
   WALLET_RELOADING: 'WALLET_RELOADING',
@@ -476,6 +477,10 @@ export const tokenInvalidateBalance = (tokenId) => ({
 
 export const reloadWalletRequested = () => ({
   type: types.RELOAD_WALLET_REQUESTED,
+});
+
+export const startWalletNotStarted = () => ({
+  type: types.START_WALLET_NOT_STARTED,
 });
 
 export const startWalletRequested = (payload) => ({

--- a/src/actions.js
+++ b/src/actions.js
@@ -470,10 +470,6 @@ export const reloadWalletRequested = () => ({
   type: types.RELOAD_WALLET_REQUESTED,
 });
 
-export const startWalletNotStarted = () => ({
-  type: types.START_WALLET_NOT_STARTED,
-});
-
 export const startWalletRequested = (payload) => ({
   type: types.START_WALLET_REQUESTED,
   payload,

--- a/src/actions.js
+++ b/src/actions.js
@@ -478,6 +478,11 @@ export const reloadWalletRequested = () => ({
   type: types.RELOAD_WALLET_REQUESTED,
 });
 
+export const startWalletLock = (payload) => ({
+  type: types.ON_START_WALLET_LOCK,
+  payload,
+});
+
 export const startWalletRequested = (payload) => ({
   type: types.START_WALLET_REQUESTED,
   payload,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -367,17 +367,10 @@ const onSetUseWalletService = (state, action) => ({
   useWalletService: action.payload,
 });
 
-const onResetWallet = (state, action) => {
-  if (state.wallet) {
-    // Stop wallet
-    state.wallet.stop();
-  }
-
-  return {
-    ...state,
-    wallet: null,
-  };
-};
+const onResetWallet = (state) => ({
+  ...state,
+  wallet: null,
+});
 
 const onSetErrorModal = (state, action) => ({
   ...state,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -584,6 +584,7 @@ export const onStartWalletRequested = (state, action) => ({
 export const onStartWalletSuccess = (state) => ({
   ...state,
   walletStartState: WALLET_STATUS.READY,
+  initWallet: null,
 });
 
 /**

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -177,6 +177,8 @@ const reducer = (state = initialState, action) => {
       return onStartWalletSuccess(state);
     case types.START_WALLET_FAILED:
       return onStartWalletFailed(state);
+    case types.START_WALLET_NOT_STARTED:
+      return onStartWalletNotStarted(state);
     case types.WALLET_BEST_BLOCK_UPDATE:
       return onWalletBestBlockUpdate(state, action);
     default:
@@ -557,6 +559,11 @@ export const onTokenFetchHistoryRequested = (state, action) => {
     },
   };
 };
+
+export const onStartWalletNotStarted = (state) => ({
+  ...state,
+  walletStartState: WALLET_STATUS.NOT_STARTED,
+});
 
 export const onStartWalletFailed = (state) => ({
   ...state,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -92,7 +92,7 @@ const initialState = {
   // screen
   tempPin: null,
   isShowingPinScreen: false,
-  walletStartState: WALLET_STATUS.LOADING,
+  walletStartState: WALLET_STATUS.NOT_STARTED,
 };
 
 const reducer = (state = initialState, action) => {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -116,10 +116,6 @@ const reducer = (state = initialState, action) => {
       return onSetServerInfo(state, action);
     case types.SET_LOCK_SCREEN:
       return onSetLockScreen(state, action);
-    case types.SET_INIT_WALLET:
-      return onSetInitWallet(state, action);
-    case types.CLEAR_INIT_WALLET:
-      return onSetInitWallet(state, action);
     case types.SET_ERROR_MODAL:
       return onSetErrorModal(state, action);
     case types.SET_WALLET:

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -555,7 +555,7 @@ export const onStartWalletFailed = (state) => ({
 
 export const onStartWalletLock = (state) => ({
   ...state,
-  walletStartState: WALLET_STATUS.LOADING,
+  walletStartState: WALLET_STATUS.NOT_STARTED,
 });
 
 /**

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -50,10 +50,6 @@ import { WALLET_STATUS } from './sagas/wallet';
  *   network {str} network of the connected server (e.g., mainnet, testnet)
  * }
  * lockScreen {bool} Indicates screen is locked
- * initWallet {Object} Information on wallet initialization (if not needed, set to null) {
- *   words {str} wallet words
- *   pin {str} pin selected by user
- * }
  *
  * showErrorModal {boolean} if app should show a modal after the error alert
  * errorReported {boolean} if user reported the error to Sentry
@@ -74,7 +70,6 @@ const initialState = {
   isOnline: false,
   serverInfo: { version: '', network: '' },
   lockScreen: true,
-  initWallet: null,
   height: 0,
   showErrorModal: false,
   errorReported: false,
@@ -327,14 +322,6 @@ const onSetLockScreen = (state, action) => ({
   lockScreen: action.payload,
 });
 
-/**
- * Update information about wallet initialization
- */
-const onSetInitWallet = (state, action) => ({
-  ...state,
-  initWallet: action.payload,
-});
-
 const onSetRecoveringPin = (state, action) => ({
   ...state,
   recoveringPin: action.payload,
@@ -582,16 +569,11 @@ export const onStartWalletLock = (state) => ({
 export const onStartWalletRequested = (state, action) => ({
   ...state,
   walletStartState: WALLET_STATUS.LOADING,
-  initWallet: {
-    words: action.payload.words,
-    pin: action.payload.pin,
-  },
 });
 
 export const onStartWalletSuccess = (state) => ({
   ...state,
   walletStartState: WALLET_STATUS.READY,
-  initWallet: null,
 });
 
 /**

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -228,7 +228,10 @@ export function* startWallet(action) {
   // is dispatched, we need to cleanup all attached forks (that will cause the event
   // listeners to be cleaned).
   const { reload } = yield race({
-    start: take(types.START_WALLET_REQUESTED),
+    start: take([
+      types.START_WALLET_REQUESTED,
+      types.RESET_WALLET,
+    ]),
     reload: take(types.RELOAD_WALLET_REQUESTED),
   });
 

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -609,8 +609,8 @@ export function* onResetWallet() {
 
   // Wallet was not initialized yet, this might happen if resetWallet
   // is called from the PinScreen. There is no event listeners to cleanup
-  // so we can call the cleanWallet method directly.
-  walletUtil.cleanWallet();
+  // so we can call the cleanLoadedData method directly.
+  walletUtil.cleanLoadedData({ cleanAccessData: true });
 }
 
 export function* saga() {

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -619,7 +619,7 @@ export function* onResetWallet() {
   walletUtil.cleanLoadedData({ cleanAccessData: true });
 }
 
-export function* onStartWalletfailed() {
+export function* onStartWalletFailed() {
   const wallet = yield select((state) => state.wallet);
 
   if (!wallet) {
@@ -646,7 +646,7 @@ export function* saga() {
     takeLatest('WALLET_CONN_STATE_UPDATE', onWalletConnStateUpdate),
     takeLatest('WALLET_RELOADING', onWalletReloadData),
     takeLatest('RESET_WALLET', onResetWallet),
-    takeLatest('START_WALLET_FAILED', onStartWalletfailed),
+    takeLatest('START_WALLET_FAILED', onStartWalletFailed),
     takeEvery('WALLET_NEW_TX', handleTx),
     takeEvery('WALLET_UPDATE_TX', handleTx),
     takeEvery('WALLET_BEST_BLOCK_UPDATE', bestBlockUpdate),

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -596,11 +596,29 @@ export function* onWalletReloadData() {
   }
 }
 
+export function* onResetWallet() {
+  const wallet = yield select((state) => state.wallet);
+
+  if (wallet) {
+    // wallet.stop() will remove all event listeners and call
+    // hathorLib.wallet.cleanWallet
+    wallet.stop({ cleanStorage: true });
+
+    return;
+  }
+
+  // Wallet was not initialized yet, this might happen if resetWallet
+  // is called from the PinScreen. There is no event listeners to cleanup
+  // so we can call the cleanWallet method directly.
+  walletUtil.cleanWallet();
+}
+
 export function* saga() {
   yield all([
     takeLatest('START_WALLET_REQUESTED', errorHandler(startWallet, startWalletFailed())),
     takeLatest('WALLET_CONN_STATE_UPDATE', onWalletConnStateUpdate),
     takeLatest('WALLET_RELOADING', onWalletReloadData),
+    takeLatest('RESET_WALLET', onResetWallet),
     takeEvery('WALLET_NEW_TX', handleTx),
     takeEvery('WALLET_UPDATE_TX', handleTx),
     takeEvery('WALLET_BEST_BLOCK_UPDATE', bestBlockUpdate),

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -71,6 +71,7 @@ import NavigationService from '../NavigationService';
 import { setKeychainPin } from '../utils';
 
 export const WALLET_STATUS = {
+  NOT_STARTED: 'not_started',
   READY: 'ready',
   FAILED: 'failed',
   LOADING: 'loading',
@@ -78,6 +79,8 @@ export const WALLET_STATUS = {
 
 export function* startWallet(action) {
   const { words, pin } = action.payload;
+
+  NavigationService.navigate('LoadHistoryScreen');
 
   const networkName = 'mainnet';
   const uniqueDeviceId = getUniqueId();

--- a/src/screens/ChoosePinScreen.js
+++ b/src/screens/ChoosePinScreen.js
@@ -18,7 +18,7 @@ import { t } from 'ttag';
 import NewHathorButton from '../components/NewHathorButton';
 import HathorHeader from '../components/HathorHeader';
 import PinInput from '../components/PinInput';
-import { setInitWallet, unlockScreen } from '../actions';
+import { startWalletRequested, unlockScreen } from '../actions';
 import { PIN_SIZE } from '../constants';
 
 import baseStyle from '../styles/init';
@@ -26,7 +26,10 @@ import baseStyle from '../styles/init';
 
 const mapDispatchToProps = (dispatch) => ({
   unlockScreen: () => dispatch(unlockScreen()),
-  setInitWallet: (words, pin) => dispatch(setInitWallet(words, pin)),
+  startWalletRequested: (words, pin) => dispatch(startWalletRequested({
+    words,
+    pin
+  })),
 });
 
 class ChoosePinScreen extends React.Component {
@@ -78,7 +81,7 @@ class ChoosePinScreen extends React.Component {
   goToNextScreen = () => {
     // we are just initializing the wallet, so make sure it's not locked when going to AppStack
     this.props.unlockScreen();
-    this.props.setInitWallet(this.words, this.state.pin1);
+    this.props.startWalletRequested(this.words, this.state.pin1);
     this.props.navigation.navigate('Home');
   }
 

--- a/src/screens/LoadHistoryScreen.js
+++ b/src/screens/LoadHistoryScreen.js
@@ -52,17 +52,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 class LoadHistoryScreen extends React.Component {
   componentDidMount() {
-    // This setTimeout exists to prevent blocking the main thread
-    setTimeout(() => this.initializeWallet(), 0);
     this.props.resetLoadedData();
-  }
-
-  initializeWallet() {
-    if (this.props.initWallet) {
-      const { words, pin } = this.props.initWallet;
-
-      this.props.startWallet(words, pin);
-    }
   }
 
   render() {

--- a/src/screens/LoadHistoryScreen.js
+++ b/src/screens/LoadHistoryScreen.js
@@ -27,14 +27,9 @@ import TextFmt from '../components/TextFmt';
  *   active {boolean} indicates we're loading the tx history
  *   error {boolean} error loading history
  * }
- * initWallet {Object} Information on wallet initialization (if not needed, set to null)
- *   words {str} wallet words
- *   pin {str} pin selected by user
- * }
  */
 const mapStateToProps = (state) => ({
   loadHistoryStatus: state.loadHistoryStatus,
-  initWallet: state.initWallet,
   loadedData: state.loadedData,
   useWalletService: state.useWalletService,
   wallet: state.wallet,

--- a/src/screens/LoadWalletErrorScreen.js
+++ b/src/screens/LoadWalletErrorScreen.js
@@ -11,16 +11,17 @@ import {
   View,
 } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
-import { startWalletRequested } from '../actions';
+import { onStartWalletLock, lockScreen } from '../actions';
 import SimpleButton from '../components/SimpleButton';
 
 export default () => {
   const dispatch = useDispatch();
-  const { words, pin } = useSelector((state) => state.initWallet);
-  const onReload = useCallback(() => dispatch(startWalletRequested({
-    words,
-    pin,
-  })), [dispatch]);
+  const onReload = useCallback(() => {
+    // This will set the walletState to LOADING
+    dispatch(onStartWalletLock());
+    // Display the PinScreen
+    dispatch(lockScreen());
+  }, [dispatch]);
 
   return (
     <View style={{

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -26,7 +26,6 @@ import {
   setTempPin,
   onStartWalletLock,
   startWalletRequested,
-  startWalletNotStarted,
 } from '../actions';
 import { PIN_SIZE } from '../constants';
 
@@ -50,7 +49,6 @@ const mapDispatchToProps = (dispatch) => ({
     words,
     pin
   })),
-  startWalletNotStarted: () => dispatch(startWalletNotStarted()),
 });
 
 class PinScreen extends React.Component {
@@ -223,8 +221,6 @@ class PinScreen extends React.Component {
     this.props.setLoadHistoryStatus(this.props.loadHistoryActive, false);
     // show lock screen again
     this.props.lockScreen();
-    // set the wallet state as NOT_STARTED so the LoadingScreen will hide.
-    this.props.startWalletNotStarted();
     // navigate to dashboard (will be hidden under lock screen)
     this.props.navigation.navigate('Dashboard');
   }

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -26,6 +26,7 @@ import {
   setRecoveringPin,
   setTempPin,
   onStartWalletLock,
+  startWalletRequested,
 } from '../actions';
 import { PIN_SIZE } from '../constants';
 
@@ -46,6 +47,10 @@ const mapDispatchToProps = (dispatch) => ({
   setInitWallet: (words, pin) => dispatch(setInitWallet(words, pin)),
   setTempPin: (pin) => dispatch(setTempPin(pin)),
   onStartWalletLock: () => dispatch(onStartWalletLock()),
+  startWalletRequested: (words, pin) => dispatch(startWalletRequested({
+    words,
+    pin
+  })),
 });
 
 class PinScreen extends React.Component {
@@ -146,7 +151,7 @@ class PinScreen extends React.Component {
         // We are saving HathorWallet object in redux, so if the app has lost redux information
         // and is in locked screen we must start the HathorWallet object again
         const words = getWalletWords(pin);
-        this.props.setInitWallet(words, pin);
+        this.props.startWalletRequested(words, pin);
       }
       this.props.unlockScreen();
     } else {

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -22,7 +22,6 @@ import {
   lockScreen,
   unlockScreen,
   setLoadHistoryStatus,
-  setInitWallet,
   setRecoveringPin,
   setTempPin,
   onStartWalletLock,
@@ -45,7 +44,6 @@ const mapDispatchToProps = (dispatch) => ({
   unlockScreen: () => dispatch(unlockScreen()),
   lockScreen: () => dispatch(lockScreen()),
   setLoadHistoryStatus: (active, error) => dispatch(setLoadHistoryStatus(active, error)),
-  setInitWallet: (words, pin) => dispatch(setInitWallet(words, pin)),
   setTempPin: (pin) => dispatch(setTempPin(pin)),
   onStartWalletLock: () => dispatch(onStartWalletLock()),
   startWalletRequested: (words, pin) => dispatch(startWalletRequested({

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -207,9 +207,7 @@ class PinScreen extends React.Component {
     });
     // make sure we won't show loadHistory screen
     this.props.setLoadHistoryStatus(false, false);
-    // Start wallet might be set to LOADING, we also need to
-    // set it to READY so the loading screen will hide
-    this.props.startWalletSuccess();
+
     // unlock so we remove this lock screen
     this.props.unlockScreen();
   }

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -25,6 +25,8 @@ import {
   setInitWallet,
   setRecoveringPin,
   setTempPin,
+  startWalletSuccess,
+  startWalletLock,
 } from '../actions';
 import { PIN_SIZE } from '../constants';
 
@@ -44,6 +46,8 @@ const mapDispatchToProps = (dispatch) => ({
   setLoadHistoryStatus: (active, error) => dispatch(setLoadHistoryStatus(active, error)),
   setInitWallet: (words, pin) => dispatch(setInitWallet(words, pin)),
   setTempPin: (pin) => dispatch(setTempPin(pin)),
+  startWalletSuccess: () => dispatch(startWalletSuccess()),
+  startWalletLock: () => dispatch(startWalletLock()),
 });
 
 class PinScreen extends React.Component {
@@ -195,9 +199,17 @@ class PinScreen extends React.Component {
 
   goToReset = () => {
     // navigate to reset screen
-    this.props.navigation.navigate('ResetWallet', { onBackPress: () => this.backFromReset() });
+    this.props.navigation.navigate('ResetWallet', {
+      onBackPress: () => {
+        this.props.startWalletLock();
+        this.backFromReset();
+      },
+    });
     // make sure we won't show loadHistory screen
     this.props.setLoadHistoryStatus(false, false);
+    // Start wallet might be set to LOADING, we also need to
+    // set it to READY so the loading screen will hide
+    this.props.startWalletSuccess();
     // unlock so we remove this lock screen
     this.props.unlockScreen();
   }

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -27,6 +27,7 @@ import {
   setTempPin,
   onStartWalletLock,
   startWalletRequested,
+  startWalletNotStarted,
 } from '../actions';
 import { PIN_SIZE } from '../constants';
 
@@ -51,6 +52,7 @@ const mapDispatchToProps = (dispatch) => ({
     words,
     pin
   })),
+  startWalletNotStarted: () => dispatch(startWalletNotStarted()),
 });
 
 class PinScreen extends React.Component {
@@ -223,6 +225,8 @@ class PinScreen extends React.Component {
     this.props.setLoadHistoryStatus(this.props.loadHistoryActive, false);
     // show lock screen again
     this.props.lockScreen();
+    // set the wallet state as NOT_STARTED so the LoadingScreen will hide.
+    this.props.startWalletNotStarted();
     // navigate to dashboard (will be hidden under lock screen)
     this.props.navigation.navigate('Dashboard');
   }

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -25,7 +25,6 @@ import {
   setInitWallet,
   setRecoveringPin,
   setTempPin,
-  startWalletSuccess,
   onStartWalletLock,
 } from '../actions';
 import { PIN_SIZE } from '../constants';
@@ -46,7 +45,6 @@ const mapDispatchToProps = (dispatch) => ({
   setLoadHistoryStatus: (active, error) => dispatch(setLoadHistoryStatus(active, error)),
   setInitWallet: (words, pin) => dispatch(setInitWallet(words, pin)),
   setTempPin: (pin) => dispatch(setTempPin(pin)),
-  startWalletSuccess: () => dispatch(startWalletSuccess()),
   onStartWalletLock: () => dispatch(onStartWalletLock()),
 });
 

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -26,7 +26,7 @@ import {
   setRecoveringPin,
   setTempPin,
   startWalletSuccess,
-  startWalletLock,
+  onStartWalletLock,
 } from '../actions';
 import { PIN_SIZE } from '../constants';
 
@@ -47,7 +47,7 @@ const mapDispatchToProps = (dispatch) => ({
   setInitWallet: (words, pin) => dispatch(setInitWallet(words, pin)),
   setTempPin: (pin) => dispatch(setTempPin(pin)),
   startWalletSuccess: () => dispatch(startWalletSuccess()),
-  startWalletLock: () => dispatch(startWalletLock()),
+  onStartWalletLock: () => dispatch(onStartWalletLock()),
 });
 
 class PinScreen extends React.Component {
@@ -201,7 +201,7 @@ class PinScreen extends React.Component {
     // navigate to reset screen
     this.props.navigation.navigate('ResetWallet', {
       onBackPress: () => {
-        this.props.startWalletLock();
+        this.props.onStartWalletLock();
         this.backFromReset();
       },
     });


### PR DESCRIPTION
### Acceptance Criteria
- We should fix the navigation from `PinScreen` -> `ResetWallet`, it was being stuck on the loading screen
- The wallet was not cleaning the `localStorage` when the reset button is pressed from the `PinScreen`


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
