### PR TITLE
fix: tab bar icons

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -138,6 +138,30 @@ const tabBarIconMap = {
   Settings: 'icSettings',
 };
 
+/**
+ * This workaround is similar to the one in TokenSelect.js
+ *
+ * It should be removed after we upgrade react-navigation to
+ * to use the latest version of SafeAreaView
+ */
+const tabNavigatorMarginWorkaround = () => {
+  const deviceId = DeviceInfo.getDeviceId();
+  const workaroundDeviceIds = [
+    'iPhone13,2', // iPhone 12
+    'iPhone13,3', // iPhone 12 Pro
+    'iPhone13,4', // iPhone 12 Pro Max
+    'iPhone14,5', // iPhone 13
+    'iPhone14,2', // iPhone 13 Pro
+    'iPhone14,3', // iPhone 13 Pro Max
+    'iPhone14,7', // iPhone 14
+    'iPhone14,8', // iPhone 14 Plus
+    'iPhone15,2', // iPhone 14 Pro
+    'iPhone15,3', // iPhone 14 Pro Max
+  ];
+
+  return workaroundDeviceIds.includes(deviceId);
+};
+
 const TabNavigator = createBottomTabNavigator({
   Home: (IS_MULTI_TOKEN ? DashboardStack : MainScreen),
   Send: SendStack,
@@ -151,6 +175,7 @@ const TabNavigator = createBottomTabNavigator({
     style: {
       paddingTop: 12,
       paddingBottom: 12,
+      ...(tabNavigatorMarginWorkaround() ? { marginBottom: 34 } : {})
     },
     tabStyle: {
       justifyContent: 'center',


### PR DESCRIPTION
### Acceptance Criteria
- Tab Navigator should have a larger margin for all affected iPhones

Fixes #221 by manually setting a larger margin for all the 10 iPhone device IDs described in the issue. I decided to use device IDs instead of model names to prevent the need of upgrading `react-native-device-info`.

This problem may appear again when new iPhones are released, but I decided to hardcode the currently known problematic models instead of trying to somehow predict which new models will present the problem. Hopefully we'll soon upgrade `react-navigation`, as described in [this file](https://github.com/HathorNetwork/hathor-wallet-mobile/blob/master/src/components/TokenSelect.js#L25-L36) that implements a similar workaround.

Here's an image of the fixed UI on all 10 problematic iPhone models:

![Screenshot 2023-01-16 at 21 52 03](https://user-images.githubusercontent.com/1757957/212790821-6a3e738b-8c71-4f68-b8fe-09e520f5bd7b.png)

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
