### PR TITLE
fix: wallet not reloading data after a reconnect and wallet reset after an error

### DIFF
--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -8,35 +8,6 @@ msgstr ""
 "X-Generator: POEditor.com\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/errorHandler.js:51
-msgid "Unexpected error occurred"
-msgstr "En uventet fejl opstod"
-
-#: src/errorHandler.js:52
-msgid ""
-"Unfortunately an unhandled error happened and you will need to restart your "
-"app.\n"
-"\n"
-"We kindly ask you to report this error to the Hathor team clicking on the "
-"button below.\n"
-"\n"
-"No sensitive data will be shared."
-msgstr ""
-"Desværre opstod der en uventet fejl og du skal genstarte app'en.\n"
-"\n"
-"Vi vil værdsætte det, hvis du rapporterer denne fejl til Hathor teamet, ved "
-"at trykke på knappen herunder.\n"
-"\n"
-"Ingen følsomme data vil blive delt."
-
-#: src/errorHandler.js:55
-msgid "Report error"
-msgstr "Rapporter fejl"
-
-#: src/errorHandler.js:61
-msgid "Close"
-msgstr "Luk"
-
 #.  This should never happen!
 #: src/models.js:24
 msgid "Unknown"
@@ -120,15 +91,15 @@ msgstr ""
 
 #.  Success
 #.  eslint-disable-next-line react/jsx-indent
-#: src/screens/BackupWords.js:146
+#: src/screens/BackupWords.js:148
 msgid "Words saved correctly"
 msgstr "Ord gemt korrekt"
 
-#: src/screens/BackupWords.js:224
+#: src/screens/BackupWords.js:226
 msgid "To make sure you saved,"
 msgstr "For at sikre dig, at du har gemt,"
 
-#: src/screens/BackupWords.js:226
+#: src/screens/BackupWords.js:228
 msgid "Please select the word that corresponds to the number below:"
 msgstr "Vælg det ord, der svarer til nummeret herunder:"
 
@@ -165,27 +136,27 @@ msgstr "Ny PIN gemt"
 msgid "CHANGE PIN"
 msgstr "SKIFT PIN"
 
-#: src/screens/ChoosePinScreen.js:136
+#: src/screens/ChoosePinScreen.js:135
 msgid "Enter your new PIN code"
 msgstr "Indtast din nye PIN-kode"
 
-#: src/screens/ChoosePinScreen.js:148
+#: src/screens/ChoosePinScreen.js:147
 msgid "Enter your new PIN code again"
 msgstr "Indtast din nye PIN-kode igen"
 
-#: src/screens/ChoosePinScreen.js:72
+#: src/screens/ChoosePinScreen.js:71
 msgid "Create a new PIN code,"
 msgstr "Opret en ny PIN-kode,"
 
-#: src/screens/ChoosePinScreen.js:75
+#: src/screens/ChoosePinScreen.js:74
 msgid "To confirm the PIN,"
 msgstr "For at bekræfte pinkoden,"
 
-#: src/screens/ChoosePinScreen.js:162
+#: src/screens/ChoosePinScreen.js:161
 msgid "PIN codes don't match. Try again."
 msgstr "PIN-koder stemmer ikke overens. Prøv igen."
 
-#: src/screens/ChoosePinScreen.js:185
+#: src/screens/ChoosePinScreen.js:184
 msgid "Start the Wallet"
 msgstr "Start Wallet"
 
@@ -454,11 +425,11 @@ msgstr "Du har lige modtaget **${ amount } ${ symbol }**"
 msgid "PAYMENT REQUEST"
 msgstr "BETALINGSANMODNING"
 
-#: src/components/TxDetailsModal.js:52 src/screens/PaymentRequestDetail.js:108
+#: src/components/TxDetailsModal.js:60 src/screens/PaymentRequestDetail.js:108
 msgid "Token"
 msgstr "Token"
 
-#: src/components/TxDetailsModal.js:99 src/screens/PaymentRequestDetail.js:112
+#: src/components/TxDetailsModal.js:107 src/screens/PaymentRequestDetail.js:112
 msgid "Amount"
 msgstr "Antal"
 
@@ -478,24 +449,24 @@ msgstr "Modtaget"
 msgid "Waiting confirmation"
 msgstr "Venter på bekræftelse"
 
-#: src/screens/PinScreen.js:235
+#: src/screens/PinScreen.js:231
 msgid "Incorrect PIN Code. Try again."
 msgstr "Forkert PIN-kode. Prøv igen."
 
-#: src/screens/PinScreen.js:72
+#: src/screens/PinScreen.js:70
 msgid "Enter your PIN Code "
 msgstr "Indtast din pinkode "
 
-#: src/screens/PinScreen.js:73
+#: src/screens/PinScreen.js:71
 msgid "Unlock Hathor Wallet"
 msgstr "Lås Hathor-wallet op"
 
-#: src/screens/PinScreen.js:247
+#: src/screens/PinScreen.js:243
 msgid "Cancel"
 msgstr "Annuller"
 
-#: src/screens/PinScreen.js:250 src/screens/RecoverPin.js:108
-#: src/screens/Settings.js:133
+#: src/screens/PinScreen.js:246 src/screens/RecoverPin.js:108
+#: src/screens/Settings.js:135
 msgid "Reset wallet"
 msgstr "Nulstil wallet"
 
@@ -638,11 +609,11 @@ msgstr "SEND ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Din overførsel behandles"
 
-#: src/sagas/wallet.js:109 src/screens/SendConfirmScreen.js:117
+#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:117
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Indtast din 6-cifrede pin for at godkende overførslen"
 
-#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:118
+#: src/sagas/wallet.js:111 src/screens/SendConfirmScreen.js:118
 msgid "Authorize operation"
 msgstr "Autoriserer overførslen"
 
@@ -676,31 +647,31 @@ msgstr "Du har ikke den anmodede token [${ tokenLabel }]"
 msgid "Scan the QR code"
 msgstr "Scan QR-koden"
 
-#: src/screens/Settings.js:88
+#: src/screens/Settings.js:90
 msgid "You are connected to"
 msgstr "Du er tilsluttet til"
 
-#: src/screens/Settings.js:100
+#: src/screens/Settings.js:102
 msgid "Connected to"
 msgstr "Forbundet til"
 
-#: src/screens/Settings.js:113
+#: src/screens/Settings.js:115
 msgid "Security"
 msgstr "Sikkerhed"
 
-#: src/screens/Settings.js:119
+#: src/screens/Settings.js:121
 msgid "Create a new token"
 msgstr "Opret en ny token"
 
-#: src/screens/Settings.js:127
+#: src/screens/Settings.js:129
 msgid "Register a token"
 msgstr "Registrer en token"
 
-#: src/screens/Settings.js:137
+#: src/screens/Settings.js:139
 msgid "About"
 msgstr "Om"
 
-#: src/screens/Settings.js:144
+#: src/screens/Settings.js:146
 msgid "Unique app identifier"
 msgstr ""
 
@@ -734,11 +705,11 @@ msgstr "Jeg vil afregistrere token **${ tokenLabel }**"
 msgid "Unregister token"
 msgstr "Afregistrer token"
 
-#: src/components/CopyClipboard.js:37
+#: src/components/CopyClipboard.js:47
 msgid "Copied to clipboard!"
 msgstr "Kopieret til udklipsholder!"
 
-#: src/components/ErrorModal.js:27
+#: src/components/GlobalErrorModal.js:49
 msgid ""
 "Thanks for reporting the error to the team. We will investigate it to "
 "prevent from happening again."
@@ -746,13 +717,59 @@ msgstr ""
 "Tak for at rapportere fejlen til teamet. Vi vil undersøge det, for at "
 "forhindre at det sker igen."
 
-#: src/components/ErrorModal.js:39
+#: src/components/GlobalErrorModal.js:79
 msgid "Unexpected error"
 msgstr "Uventet fejl"
 
-#: src/components/ErrorModal.js:43
+#: src/components/GlobalErrorModal.js:83
 msgid "Please restart your app to continue using the wallet."
 msgstr "Genstart venligst app'en for at kunne bruge din wallet igen."
+
+#: src/components/GlobalErrorModal.js:104
+msgid ""
+"Unfortunately an unhandled error happened and you will need to restart your "
+"app.\n"
+"\n"
+"We kindly ask you to report this error to the Hathor team clicking on the "
+"button below.\n"
+"\n"
+"No sensitive data will be shared."
+msgstr ""
+"Desværre opstod der en uventet fejl og du skal genstarte app'en.\n"
+"\n"
+"Vi vil værdsætte det, hvis du rapporterer denne fejl til Hathor teamet, ved "
+"at trykke på knappen herunder.\n"
+"\n"
+"Ingen følsomme data vil blive delt."
+
+#: src/components/GlobalErrorModal.js:107
+#, fuzzy
+msgid ""
+"Unfortunately an unhandled error happened.\n"
+"\n"
+"We kindly ask you to report this error to the Hathor team clicking on the "
+"button below.\n"
+"\n"
+"No sensitive data will be shared."
+msgstr ""
+"Desværre opstod der en uventet fejl og du skal genstarte app'en.\n"
+"\n"
+"Vi vil værdsætte det, hvis du rapporterer denne fejl til Hathor teamet, ved "
+"at trykke på knappen herunder.\n"
+"\n"
+"Ingen følsomme data vil blive delt."
+
+#: src/components/GlobalErrorModal.js:114
+msgid "Unexpected error occurred"
+msgstr "En uventet fejl opstod"
+
+#: src/components/GlobalErrorModal.js:117
+msgid "Report error"
+msgstr "Rapporter fejl"
+
+#: src/components/GlobalErrorModal.js:122
+msgid "Close"
+msgstr "Luk"
 
 #: src/components/NewPaymentRequest.js:180
 msgid "Create payment request"
@@ -766,16 +783,16 @@ msgstr "Ingen internetforbindelse"
 msgid "Opening camera"
 msgstr "Åbner kamera"
 
-#: src/components/ReceiveMyAddress.js:56
-#, javascript-format
-msgid "Here is my address: ${ _this.state.address }"
+#: src/components/ReceiveMyAddress.js:36
+#, fuzzy, javascript-format
+msgid "Here is my address: ${ lastSharedAddress }"
 msgstr "Her er min adresse: ${ _this.state.address }"
 
-#: src/components/ReceiveMyAddress.js:93
+#: src/components/ReceiveMyAddress.js:74
 msgid "New address"
 msgstr "Ny adresse"
 
-#: src/components/ReceiveMyAddress.js:99 src/components/TokenDetails.js:58
+#: src/components/ReceiveMyAddress.js:80 src/components/TokenDetails.js:58
 msgid "Share"
 msgstr "Del"
 
@@ -790,19 +807,19 @@ msgid ""
 msgstr ""
 "Her er konfigurationsstrengen for token ${ tokenLabel }: ${ configString }"
 
-#: src/components/TxDetailsModal.js:53
+#: src/components/TxDetailsModal.js:61
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: src/components/TxDetailsModal.js:54
+#: src/components/TxDetailsModal.js:62
 msgid "Date & Time"
 msgstr "Dato & Tid"
 
-#: src/components/TxDetailsModal.js:55
+#: src/components/TxDetailsModal.js:63
 msgid "ID"
 msgstr "ID"
 
-#: src/components/TxDetailsModal.js:56
+#: src/components/TxDetailsModal.js:64
 msgid "Public Explorer"
 msgstr "Public Explorer"
 

--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -1,14 +1,18 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Hathor\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.2.2\n"
 
-#.  This should never happen!
+#. This should never happen!
 #: src/models.js:24
 msgid "Unknown"
 msgstr "Ukendt"
@@ -27,32 +31,32 @@ msgstr "Sendt ${ symbol }"
 msgid "You sent ${ symbol } to yourself"
 msgstr "Du sendte ${ symbol } til dig selv"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:41
 msgid "[Today •] HH:mm"
 msgstr "[I dag •] HH: mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:42
 msgid "[Tomorrow •] HH:mm"
 msgstr "[I morgen •] HH: mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:43
 msgid "dddd [•] HH:mm"
 msgstr "dddd [•] HH: mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:44
 msgid "[Yesterday •] HH:mm"
 msgstr "[I går •] HH: mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:45
 msgid "[Last] dddd [•] HH:mm"
 msgstr "[Sidste] dddd [•] HH: mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:46
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH: mm"
@@ -89,8 +93,8 @@ msgid ""
 "Privacy Policy|, or our website |link3:https://hathor.network/|."
 msgstr ""
 
-#.  Success
-#.  eslint-disable-next-line react/jsx-indent
+#. Success
+#. eslint-disable-next-line react/jsx-indent
 #: src/screens/BackupWords.js:148
 msgid "Words saved correctly"
 msgstr "Ord gemt korrekt"
@@ -111,7 +115,7 @@ msgstr "Forkert PIN-kode."
 msgid "PIN codes don't match."
 msgstr "PIN-koder stemmer ikke overens."
 
-#.  Should never get here because we've done all the validations before
+#. Should never get here because we've done all the validations before
 #: src/screens/ChangePin.js:174
 msgid "Error while changing PIN"
 msgstr "Fejl under ændring af pinkode"
@@ -187,7 +191,7 @@ msgstr "Du har ${ amountAvailableText } HTR tilgængelig"
 msgid "Next"
 msgstr "Næste"
 
-#.  show loading modal
+#. show loading modal
 #: src/screens/CreateTokenConfirm.js:98
 msgid "Creating token"
 msgstr "Opretter token"
@@ -200,7 +204,7 @@ msgstr "Indtast din 6-cifrede pin for at oprette din token"
 msgid "Authorize token creation"
 msgstr "Autoriser oprettelse af token"
 
-#.  eslint-disable-next-line react/jsx-indent
+#. eslint-disable-next-line react/jsx-indent
 #: src/screens/CreateTokenConfirm.js:180
 #, javascript-format
 msgid "**${ this.name }** created successfully"
@@ -471,10 +475,10 @@ msgid "Reset wallet"
 msgstr "Nulstil wallet"
 
 #. *
-#.      * index {number} Selected index of the tab bar
-#.      
-#.  eslint thinks routes is not used, but TabView uses it
-#.  eslint-disable-next-line react/no-unused-state
+#. * index {number} Selected index of the tab bar
+#.
+#. eslint thinks routes is not used, but TabView uses it
+#. eslint-disable-next-line react/no-unused-state
 #: src/screens/Receive.js:30
 msgid "Payment Request"
 msgstr "Betalingsanmodning"
@@ -495,8 +499,8 @@ msgstr ""
 msgid "Upgrading your wallet, please hang on."
 msgstr ""
 
-#.  translator: Used when the QR Code Scanner is opened, and user will manually
-#.  enter the information.
+#. translator: Used when the QR Code Scanner is opened, and user will manually
+#. enter the information.
 #: src/screens/RegisterToken.js:33 src/screens/SendScanQRCode.js:69
 msgid "Manual info"
 msgstr "Manuel information"
@@ -604,7 +608,7 @@ msgstr[1] "${ amountAndToken } tilgængelig\n"
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "SEND ${ tokenNameUpperCase }"
 
-#.  show loading modal
+#. show loading modal
 #: src/screens/SendConfirmScreen.js:103
 msgid "Your transfer is being processed"
 msgstr "Din overførsel behandles"
@@ -735,7 +739,7 @@ msgid ""
 "\n"
 "No sensitive data will be shared."
 msgstr ""
-"Desværre opstod der en uventet fejl og du skal genstarte app'en.\n"
+"Desværre opstod der en uventet fejl.\n"
 "\n"
 "Vi vil værdsætte det, hvis du rapporterer denne fejl til Hathor teamet, ved "
 "at trykke på knappen herunder.\n"
@@ -743,7 +747,6 @@ msgstr ""
 "Ingen følsomme data vil blive delt."
 
 #: src/components/GlobalErrorModal.js:107
-#, fuzzy
 msgid ""
 "Unfortunately an unhandled error happened.\n"
 "\n"
@@ -752,7 +755,7 @@ msgid ""
 "\n"
 "No sensitive data will be shared."
 msgstr ""
-"Desværre opstod der en uventet fejl og du skal genstarte app'en.\n"
+"Desværre opstod der en uventet fejl.\n"
 "\n"
 "Vi vil værdsætte det, hvis du rapporterer denne fejl til Hathor teamet, ved "
 "at trykke på knappen herunder.\n"
@@ -783,16 +786,16 @@ msgstr "Ingen internetforbindelse"
 msgid "Opening camera"
 msgstr "Åbner kamera"
 
-#: src/components/ReceiveMyAddress.js:36
-#, fuzzy, javascript-format
+#: src/components/ReceiveMyAddress.js:33
+#, javascript-format
 msgid "Here is my address: ${ lastSharedAddress }"
-msgstr "Her er min adresse: ${ _this.state.address }"
+msgstr "Her er min adresse: ${ lastSharedAddress }"
 
-#: src/components/ReceiveMyAddress.js:74
+#: src/components/ReceiveMyAddress.js:71
 msgid "New address"
 msgstr "Ny adresse"
 
-#: src/components/ReceiveMyAddress.js:80 src/components/TokenDetails.js:58
+#: src/components/ReceiveMyAddress.js:77 src/components/TokenDetails.js:58
 msgid "Share"
 msgstr "Del"
 

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -1,9 +1,18 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Generator: Poedit 3.2.2\n"
 
-#.  This should never happen!
+#. This should never happen!
 #: src/models.js:24
 msgid "Unknown"
 msgstr "Desconhecido"
@@ -22,32 +31,32 @@ msgstr "Enviado ${ symbol }"
 msgid "You sent ${ symbol } to yourself"
 msgstr "Você enviou ${ symbol } para você mesmo"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:41
 msgid "[Today •] HH:mm"
 msgstr "[Hoje •] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:42
 msgid "[Tomorrow •] HH:mm"
 msgstr "[Amanhã •] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:43
 msgid "dddd [•] HH:mm"
 msgstr "dddd [•] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:44
 msgid "[Yesterday •] HH:mm"
 msgstr "[Ontem •] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:45
 msgid "[Last] dddd [•] HH:mm"
 msgstr "[Última] dddd [•] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:46
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH:mm"
@@ -87,8 +96,8 @@ msgstr ""
 "Para mais informações, veja os |link1:Termos de Serviço| e |link2:Política "
 "de Privacidade|, ou visite nosso site |link3:https://hathor.network/|."
 
-#.  Success
-#.  eslint-disable-next-line react/jsx-indent
+#. Success
+#. eslint-disable-next-line react/jsx-indent
 #: src/screens/BackupWords.js:148
 msgid "Words saved correctly"
 msgstr "Palavras salvas com sucesso"
@@ -109,7 +118,7 @@ msgstr "PIN incorreto."
 msgid "PIN codes don't match."
 msgstr "Os PINs estão diferentes."
 
-#.  Should never get here because we've done all the validations before
+#. Should never get here because we've done all the validations before
 #: src/screens/ChangePin.js:174
 msgid "Error while changing PIN"
 msgstr "Erro ao mudar o PIN"
@@ -185,7 +194,7 @@ msgstr "Você tem ${ amountAvailableText } HTR disponíveis"
 msgid "Next"
 msgstr "Próximo"
 
-#.  show loading modal
+#. show loading modal
 #: src/screens/CreateTokenConfirm.js:98
 msgid "Creating token"
 msgstr "Criando um token"
@@ -198,7 +207,7 @@ msgstr "Digite seu PIN de 6 dígitos para criar o seu token"
 msgid "Authorize token creation"
 msgstr "Autorizar criação de token"
 
-#.  eslint-disable-next-line react/jsx-indent
+#. eslint-disable-next-line react/jsx-indent
 #: src/screens/CreateTokenConfirm.js:180
 #, javascript-format
 msgid "**${ this.name }** created successfully"
@@ -474,10 +483,10 @@ msgid "Reset wallet"
 msgstr "Resetar a wallet"
 
 #. *
-#.      * index {number} Selected index of the tab bar
-#.      
-#.  eslint thinks routes is not used, but TabView uses it
-#.  eslint-disable-next-line react/no-unused-state
+#. * index {number} Selected index of the tab bar
+#.
+#. eslint thinks routes is not used, but TabView uses it
+#. eslint-disable-next-line react/no-unused-state
 #: src/screens/Receive.js:30
 msgid "Payment Request"
 msgstr "Requisição de Pagamento"
@@ -498,8 +507,8 @@ msgstr "Por favor resete sua wallet e restaure utilizando sua seed."
 msgid "Upgrading your wallet, please hang on."
 msgstr "Atualizando sua wallet, por favor aguarde."
 
-#.  translator: Used when the QR Code Scanner is opened, and user will manually
-#.  enter the information.
+#. translator: Used when the QR Code Scanner is opened, and user will manually
+#. enter the information.
 #: src/screens/RegisterToken.js:33 src/screens/SendScanQRCode.js:69
 msgid "Manual info"
 msgstr "Digitar"
@@ -608,7 +617,7 @@ msgstr[1] "${ amountAndToken } disponíveis"
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "ENVIAR ${ tokenNameUpperCase }"
 
-#.  show loading modal
+#. show loading modal
 #: src/screens/SendConfirmScreen.js:103
 msgid "Your transfer is being processed"
 msgstr "Sua transferência está sendo processada"
@@ -750,7 +759,6 @@ msgstr ""
 "Nenhum dado sensível será compartilhado."
 
 #: src/components/GlobalErrorModal.js:107
-#, fuzzy
 msgid ""
 "Unfortunately an unhandled error happened.\n"
 "\n"
@@ -759,8 +767,7 @@ msgid ""
 "\n"
 "No sensitive data will be shared."
 msgstr ""
-"Infelizmente um erro não tratado ocorreu e você precisa reiniciar o "
-"aplicativo.\n"
+"Infelizmente um erro não tratado ocorreu.\n"
 "\n"
 "Nós pedimos que você envie esse erro para o time da Hathor clicando no botão "
 "abaixo.\n"
@@ -791,16 +798,16 @@ msgstr "Sem conexão com a internet"
 msgid "Opening camera"
 msgstr "Abrindo a câmera"
 
-#: src/components/ReceiveMyAddress.js:36
-#, fuzzy, javascript-format
+#: src/components/ReceiveMyAddress.js:33
+#, javascript-format
 msgid "Here is my address: ${ lastSharedAddress }"
-msgstr "Esse é o meu endereço: ${ _this.state.address }"
+msgstr "Esse é o meu endereço: ${ lastSharedAddress }"
 
-#: src/components/ReceiveMyAddress.js:74
+#: src/components/ReceiveMyAddress.js:71
 msgid "New address"
 msgstr "Novo endereço"
 
-#: src/components/ReceiveMyAddress.js:80 src/components/TokenDetails.js:58
+#: src/components/ReceiveMyAddress.js:77 src/components/TokenDetails.js:58
 msgid "Share"
 msgstr "Compartilhar"
 

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -3,36 +3,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: src/errorHandler.js:51
-msgid "Unexpected error occurred"
-msgstr "Um erro inesperado ocorreu"
-
-#: src/errorHandler.js:52
-msgid ""
-"Unfortunately an unhandled error happened and you will need to restart your "
-"app.\n"
-"\n"
-"We kindly ask you to report this error to the Hathor team clicking on the "
-"button below.\n"
-"\n"
-"No sensitive data will be shared."
-msgstr ""
-"Infelizmente um erro não tratado ocorreu e você precisa reiniciar o "
-"aplicativo.\n"
-"\n"
-"Nós pedimos que você envie esse erro para o time da Hathor clicando no botão "
-"abaixo.\n"
-"\n"
-"Nenhum dado sensível será compartilhado."
-
-#: src/errorHandler.js:55
-msgid "Report error"
-msgstr "Reportar erro"
-
-#: src/errorHandler.js:61
-msgid "Close"
-msgstr "Fechar"
-
 #.  This should never happen!
 #: src/models.js:24
 msgid "Unknown"
@@ -164,27 +134,27 @@ msgstr "Novo PIN salvo"
 msgid "CHANGE PIN"
 msgstr "MUDAR PIN"
 
-#: src/screens/ChoosePinScreen.js:136
+#: src/screens/ChoosePinScreen.js:135
 msgid "Enter your new PIN code"
 msgstr "Digite seu novo PIN"
 
-#: src/screens/ChoosePinScreen.js:148
+#: src/screens/ChoosePinScreen.js:147
 msgid "Enter your new PIN code again"
 msgstr "Digite seu novo PIN novamente"
 
-#: src/screens/ChoosePinScreen.js:72
+#: src/screens/ChoosePinScreen.js:71
 msgid "Create a new PIN code,"
 msgstr "Criar um novo PIN,"
 
-#: src/screens/ChoosePinScreen.js:75
+#: src/screens/ChoosePinScreen.js:74
 msgid "To confirm the PIN,"
 msgstr "Para confirmar o PIN,"
 
-#: src/screens/ChoosePinScreen.js:162
+#: src/screens/ChoosePinScreen.js:161
 msgid "PIN codes don't match. Try again."
 msgstr "Os PINs estão diferentes. Tente novamente."
 
-#: src/screens/ChoosePinScreen.js:185
+#: src/screens/ChoosePinScreen.js:184
 msgid "Start the Wallet"
 msgstr "Iniciar a Wallet"
 
@@ -482,24 +452,24 @@ msgstr "Recebido"
 msgid "Waiting confirmation"
 msgstr "Aguardando confirmação"
 
-#: src/screens/PinScreen.js:235
+#: src/screens/PinScreen.js:231
 msgid "Incorrect PIN Code. Try again."
 msgstr "PIN incorreto. Tente novamente."
 
-#: src/screens/PinScreen.js:72
+#: src/screens/PinScreen.js:70
 msgid "Enter your PIN Code "
 msgstr "Digite seu PIN "
 
-#: src/screens/PinScreen.js:73
+#: src/screens/PinScreen.js:71
 msgid "Unlock Hathor Wallet"
 msgstr "Desbloqueie sua Hathor Wallet"
 
-#: src/screens/PinScreen.js:247
+#: src/screens/PinScreen.js:243
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/screens/PinScreen.js:250 src/screens/RecoverPin.js:108
-#: src/screens/Settings.js:133
+#: src/screens/PinScreen.js:246 src/screens/RecoverPin.js:108
+#: src/screens/Settings.js:135
 msgid "Reset wallet"
 msgstr "Resetar a wallet"
 
@@ -643,11 +613,11 @@ msgstr "ENVIAR ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Sua transferência está sendo processada"
 
-#: src/sagas/wallet.js:109 src/screens/SendConfirmScreen.js:117
+#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:117
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Digite seu PIN de 6 dígitos para autorizar a operação"
 
-#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:118
+#: src/sagas/wallet.js:111 src/screens/SendConfirmScreen.js:118
 msgid "Authorize operation"
 msgstr "Autorizar operação"
 
@@ -681,31 +651,31 @@ msgstr "Você não tem o token requisitado [${ tokenLabel }]"
 msgid "Scan the QR code"
 msgstr "Leia o QR code"
 
-#: src/screens/Settings.js:88
+#: src/screens/Settings.js:90
 msgid "You are connected to"
 msgstr "Você está conectado à"
 
-#: src/screens/Settings.js:100
+#: src/screens/Settings.js:102
 msgid "Connected to"
 msgstr "Conectado ao servidor"
 
-#: src/screens/Settings.js:113
+#: src/screens/Settings.js:115
 msgid "Security"
 msgstr "Segurança"
 
-#: src/screens/Settings.js:119
+#: src/screens/Settings.js:121
 msgid "Create a new token"
 msgstr "Criar um novo token"
 
-#: src/screens/Settings.js:127
+#: src/screens/Settings.js:129
 msgid "Register a token"
 msgstr "Registrar um token"
 
-#: src/screens/Settings.js:137
+#: src/screens/Settings.js:139
 msgid "About"
 msgstr "Sobre"
 
-#: src/screens/Settings.js:144
+#: src/screens/Settings.js:146
 msgid "Unique app identifier"
 msgstr "Identificador único do aplicativo"
 
@@ -745,7 +715,7 @@ msgstr "Desregistrar token"
 msgid "Copied to clipboard!"
 msgstr "Copiado!"
 
-#: src/components/ErrorModal.js:27
+#: src/components/GlobalErrorModal.js:49
 msgid ""
 "Thanks for reporting the error to the team. We will investigate it to "
 "prevent from happening again."
@@ -753,13 +723,61 @@ msgstr ""
 "Obrigado por enviar o erro para o time. Nós vamos investigá-lo para que não "
 "aconteça mais."
 
-#: src/components/ErrorModal.js:39
+#: src/components/GlobalErrorModal.js:79
 msgid "Unexpected error"
 msgstr "Erro inesperado"
 
-#: src/components/ErrorModal.js:43
+#: src/components/GlobalErrorModal.js:83
 msgid "Please restart your app to continue using the wallet."
 msgstr "Por favor reinicie seu aplicativo para continuar usando a wallet."
+
+#: src/components/GlobalErrorModal.js:104
+msgid ""
+"Unfortunately an unhandled error happened and you will need to restart your "
+"app.\n"
+"\n"
+"We kindly ask you to report this error to the Hathor team clicking on the "
+"button below.\n"
+"\n"
+"No sensitive data will be shared."
+msgstr ""
+"Infelizmente um erro não tratado ocorreu e você precisa reiniciar o "
+"aplicativo.\n"
+"\n"
+"Nós pedimos que você envie esse erro para o time da Hathor clicando no botão "
+"abaixo.\n"
+"\n"
+"Nenhum dado sensível será compartilhado."
+
+#: src/components/GlobalErrorModal.js:107
+#, fuzzy
+msgid ""
+"Unfortunately an unhandled error happened.\n"
+"\n"
+"We kindly ask you to report this error to the Hathor team clicking on the "
+"button below.\n"
+"\n"
+"No sensitive data will be shared."
+msgstr ""
+"Infelizmente um erro não tratado ocorreu e você precisa reiniciar o "
+"aplicativo.\n"
+"\n"
+"Nós pedimos que você envie esse erro para o time da Hathor clicando no botão "
+"abaixo.\n"
+"\n"
+"Nenhum dado sensível será compartilhado."
+
+#: src/components/GlobalErrorModal.js:114
+msgid "Unexpected error occurred"
+msgstr "Um erro inesperado ocorreu"
+
+#: src/components/GlobalErrorModal.js:117
+msgid "Report error"
+msgstr "Reportar erro"
+
+#: src/components/GlobalErrorModal.js:122
+msgid "Close"
+msgstr "Fechar"
 
 #: src/components/NewPaymentRequest.js:180
 msgid "Create payment request"
@@ -773,16 +791,16 @@ msgstr "Sem conexão com a internet"
 msgid "Opening camera"
 msgstr "Abrindo a câmera"
 
-#: src/components/ReceiveMyAddress.js:56
-#, javascript-format
-msgid "Here is my address: ${ _this.state.address }"
+#: src/components/ReceiveMyAddress.js:36
+#, fuzzy, javascript-format
+msgid "Here is my address: ${ lastSharedAddress }"
 msgstr "Esse é o meu endereço: ${ _this.state.address }"
 
-#: src/components/ReceiveMyAddress.js:93
+#: src/components/ReceiveMyAddress.js:74
 msgid "New address"
 msgstr "Novo endereço"
 
-#: src/components/ReceiveMyAddress.js:99 src/components/TokenDetails.js:58
+#: src/components/ReceiveMyAddress.js:80 src/components/TokenDetails.js:58
 msgid "Share"
 msgstr "Compartilhar"
 

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -11,9 +11,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 3.2.2\n"
 
-#.  This should never happen!
+#. This should never happen!
 #: src/models.js:24
 msgid "Unknown"
 msgstr "Неизвестно"
@@ -32,32 +32,32 @@ msgstr "Отправлено ${ symbol }"
 msgid "You sent ${ symbol } to yourself"
 msgstr "Вы отправили себе ${ symbol }"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:41
 msgid "[Today •] HH:mm"
 msgstr "[Сегодня •] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:42
 msgid "[Tomorrow •] HH:mm"
 msgstr "[Завтра •] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:43
 msgid "dddd [•] HH:mm"
 msgstr "dddd [•] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:44
 msgid "[Yesterday •] HH:mm"
 msgstr "[Вчера •] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:45
 msgid "[Last] dddd [•] HH:mm"
 msgstr "[Последний] dddd [•] HH:mm"
 
-#.  See https://momentjs.com/docs/#/displaying/calendar-time/
+#. See https://momentjs.com/docs/#/displaying/calendar-time/
 #: src/models.js:46
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH:mm"
@@ -93,8 +93,8 @@ msgid ""
 "Privacy Policy|, or our website |link3:https://hathor.network/|."
 msgstr ""
 
-#.  Success
-#.  eslint-disable-next-line react/jsx-indent
+#. Success
+#. eslint-disable-next-line react/jsx-indent
 #: src/screens/BackupWords.js:148
 msgid "Words saved correctly"
 msgstr "Seed-фраза введена верно"
@@ -115,7 +115,7 @@ msgstr "Неверный PIN-код."
 msgid "PIN codes don't match."
 msgstr "PIN-коды не совпадают."
 
-#.  Should never get here because we've done all the validations before
+#. Should never get here because we've done all the validations before
 #: src/screens/ChangePin.js:174
 msgid "Error while changing PIN"
 msgstr "Ошибка при смене PIN-кода"
@@ -191,7 +191,7 @@ msgstr "У вас ${ amountAvailableText } HTR"
 msgid "Next"
 msgstr "Далее"
 
-#.  show loading modal
+#. show loading modal
 #: src/screens/CreateTokenConfirm.js:98
 msgid "Creating token"
 msgstr "Создать токен"
@@ -204,7 +204,7 @@ msgstr "Введите 6-значный PIN-код для создания то�
 msgid "Authorize token creation"
 msgstr "Авторизовать создание токена"
 
-#.  eslint-disable-next-line react/jsx-indent
+#. eslint-disable-next-line react/jsx-indent
 #: src/screens/CreateTokenConfirm.js:180
 #, javascript-format
 msgid "**${ this.name }** created successfully"
@@ -476,10 +476,10 @@ msgid "Reset wallet"
 msgstr "Сбросить кошелек"
 
 #. *
-#.      * index {number} Selected index of the tab bar
-#.      
-#.  eslint thinks routes is not used, but TabView uses it
-#.  eslint-disable-next-line react/no-unused-state
+#. * index {number} Selected index of the tab bar
+#.
+#. eslint thinks routes is not used, but TabView uses it
+#. eslint-disable-next-line react/no-unused-state
 #: src/screens/Receive.js:30
 msgid "Payment Request"
 msgstr "Запрос Средств"
@@ -500,8 +500,8 @@ msgstr ""
 msgid "Upgrading your wallet, please hang on."
 msgstr ""
 
-#.  translator: Used when the QR Code Scanner is opened, and user will manually
-#.  enter the information.
+#. translator: Used when the QR Code Scanner is opened, and user will manually
+#. enter the information.
 #: src/screens/RegisterToken.js:33 src/screens/SendScanQRCode.js:69
 msgid "Manual info"
 msgstr "Ручной ввод"
@@ -609,7 +609,7 @@ msgstr[2] "${ amountAndToken } доступно"
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "ОТПРАВИТЬ ${ tokenNameUpperCase }"
 
-#.  show loading modal
+#. show loading modal
 #: src/screens/SendConfirmScreen.js:103
 msgid "Your transfer is being processed"
 msgstr "Ваш перевод обрабатывается"
@@ -775,16 +775,16 @@ msgstr "Нет соединения с интернетом"
 msgid "Opening camera"
 msgstr "Камера открывается"
 
-#: src/components/ReceiveMyAddress.js:36
-#, fuzzy, javascript-format
+#: src/components/ReceiveMyAddress.js:33
+#, javascript-format
 msgid "Here is my address: ${ lastSharedAddress }"
-msgstr "Это мой адрес: ${ _this.state.address }"
+msgstr "Это мой адрес: ${ lastSharedAddress }"
 
-#: src/components/ReceiveMyAddress.js:74
+#: src/components/ReceiveMyAddress.js:71
 msgid "New address"
 msgstr "Новый адрес"
 
-#: src/components/ReceiveMyAddress.js:80 src/components/TokenDetails.js:58
+#: src/components/ReceiveMyAddress.js:77 src/components/TokenDetails.js:58
 msgid "Share"
 msgstr "Поделиться"
 

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -13,29 +13,6 @@ msgstr ""
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.2.4\n"
 
-#: src/errorHandler.js:51
-msgid "Unexpected error occurred"
-msgstr ""
-
-#: src/errorHandler.js:52
-msgid ""
-"Unfortunately an unhandled error happened and you will need to restart your "
-"app.\n"
-"\n"
-"We kindly ask you to report this error to the Hathor team clicking on the "
-"button below.\n"
-"\n"
-"No sensitive data will be shared."
-msgstr ""
-
-#: src/errorHandler.js:55
-msgid "Report error"
-msgstr ""
-
-#: src/errorHandler.js:61
-msgid "Close"
-msgstr ""
-
 #.  This should never happen!
 #: src/models.js:24
 msgid "Unknown"
@@ -118,15 +95,15 @@ msgstr ""
 
 #.  Success
 #.  eslint-disable-next-line react/jsx-indent
-#: src/screens/BackupWords.js:146
+#: src/screens/BackupWords.js:148
 msgid "Words saved correctly"
 msgstr "Seed-фраза введена верно"
 
-#: src/screens/BackupWords.js:224
+#: src/screens/BackupWords.js:226
 msgid "To make sure you saved,"
 msgstr "Чтобы убедиться в том, что вы сохранили,"
 
-#: src/screens/BackupWords.js:226
+#: src/screens/BackupWords.js:228
 msgid "Please select the word that corresponds to the number below:"
 msgstr "Пожалуйста, выберите слово, которое соответствует номеру ниже:"
 
@@ -163,27 +140,27 @@ msgstr "Новый PIN-код сохранен"
 msgid "CHANGE PIN"
 msgstr "ИЗМЕНИТЬ PIN-код"
 
-#: src/screens/ChoosePinScreen.js:136
+#: src/screens/ChoosePinScreen.js:135
 msgid "Enter your new PIN code"
 msgstr "Введите новый PIN-код"
 
-#: src/screens/ChoosePinScreen.js:148
+#: src/screens/ChoosePinScreen.js:147
 msgid "Enter your new PIN code again"
 msgstr "Введите новый PIN-код еще раз"
 
-#: src/screens/ChoosePinScreen.js:72
+#: src/screens/ChoosePinScreen.js:71
 msgid "Create a new PIN code,"
 msgstr "Создать новый PIN-код,"
 
-#: src/screens/ChoosePinScreen.js:75
+#: src/screens/ChoosePinScreen.js:74
 msgid "To confirm the PIN,"
 msgstr "Для подтверждения PIN-кода,"
 
-#: src/screens/ChoosePinScreen.js:162
+#: src/screens/ChoosePinScreen.js:161
 msgid "PIN codes don't match. Try again."
 msgstr "PIN-коды не совпадают. Попробуйте еще раз."
 
-#: src/screens/ChoosePinScreen.js:185
+#: src/screens/ChoosePinScreen.js:184
 msgid "Start the Wallet"
 msgstr "Запустить кошелек"
 
@@ -453,11 +430,11 @@ msgstr "Вы только что получили **${ amount } ${ symbol }**"
 msgid "PAYMENT REQUEST"
 msgstr "ЗАПРОС СРЕДСТВ"
 
-#: src/components/TxDetailsModal.js:52 src/screens/PaymentRequestDetail.js:108
+#: src/components/TxDetailsModal.js:60 src/screens/PaymentRequestDetail.js:108
 msgid "Token"
 msgstr "Токен"
 
-#: src/components/TxDetailsModal.js:99 src/screens/PaymentRequestDetail.js:112
+#: src/components/TxDetailsModal.js:107 src/screens/PaymentRequestDetail.js:112
 msgid "Amount"
 msgstr "Количество"
 
@@ -477,24 +454,24 @@ msgstr "Получено"
 msgid "Waiting confirmation"
 msgstr "Ожидание подтверждения"
 
-#: src/screens/PinScreen.js:235
+#: src/screens/PinScreen.js:231
 msgid "Incorrect PIN Code. Try again."
 msgstr "Неверный PIN-код. Попробуйте еще раз."
 
-#: src/screens/PinScreen.js:72
+#: src/screens/PinScreen.js:70
 msgid "Enter your PIN Code "
 msgstr "Введите свой PIN-код "
 
-#: src/screens/PinScreen.js:73
+#: src/screens/PinScreen.js:71
 msgid "Unlock Hathor Wallet"
 msgstr "Разблокировать Hathor Wallet"
 
-#: src/screens/PinScreen.js:247
+#: src/screens/PinScreen.js:243
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/screens/PinScreen.js:250 src/screens/RecoverPin.js:108
-#: src/screens/Settings.js:133
+#: src/screens/PinScreen.js:246 src/screens/RecoverPin.js:108
+#: src/screens/Settings.js:135
 msgid "Reset wallet"
 msgstr "Сбросить кошелек"
 
@@ -637,11 +614,11 @@ msgstr "ОТПРАВИТЬ ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Ваш перевод обрабатывается"
 
-#: src/sagas/wallet.js:109 src/screens/SendConfirmScreen.js:117
+#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:117
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Введите 6-значный PIN-код для авторизации операции"
 
-#: src/sagas/wallet.js:110 src/screens/SendConfirmScreen.js:118
+#: src/sagas/wallet.js:111 src/screens/SendConfirmScreen.js:118
 msgid "Authorize operation"
 msgstr "Авторизовать операцию"
 
@@ -675,31 +652,31 @@ msgstr "У вас нет запрошенного токена [${ tokenLabel }]
 msgid "Scan the QR code"
 msgstr "Сканировать QR-код"
 
-#: src/screens/Settings.js:88
+#: src/screens/Settings.js:90
 msgid "You are connected to"
 msgstr "Вы подключены к"
 
-#: src/screens/Settings.js:100
+#: src/screens/Settings.js:102
 msgid "Connected to"
 msgstr "Подключены к"
 
-#: src/screens/Settings.js:113
+#: src/screens/Settings.js:115
 msgid "Security"
 msgstr "Безопасность"
 
-#: src/screens/Settings.js:119
+#: src/screens/Settings.js:121
 msgid "Create a new token"
 msgstr "Создать новый токен"
 
-#: src/screens/Settings.js:127
+#: src/screens/Settings.js:129
 msgid "Register a token"
 msgstr "Зарегистрировать токен"
 
-#: src/screens/Settings.js:137
+#: src/screens/Settings.js:139
 msgid "About"
 msgstr "О нас"
 
-#: src/screens/Settings.js:144
+#: src/screens/Settings.js:146
 msgid "Unique app identifier"
 msgstr ""
 
@@ -735,22 +712,55 @@ msgstr "Я хочу отменить регистрацию токена **${ to
 msgid "Unregister token"
 msgstr "Отменить регистрацию токена"
 
-#: src/components/CopyClipboard.js:37
+#: src/components/CopyClipboard.js:47
 msgid "Copied to clipboard!"
 msgstr "Скопировано в буфер обмена!"
 
-#: src/components/ErrorModal.js:27
+#: src/components/GlobalErrorModal.js:49
 msgid ""
 "Thanks for reporting the error to the team. We will investigate it to "
 "prevent from happening again."
 msgstr ""
 
-#: src/components/ErrorModal.js:39
+#: src/components/GlobalErrorModal.js:79
 msgid "Unexpected error"
 msgstr ""
 
-#: src/components/ErrorModal.js:43
+#: src/components/GlobalErrorModal.js:83
 msgid "Please restart your app to continue using the wallet."
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:104
+msgid ""
+"Unfortunately an unhandled error happened and you will need to restart your "
+"app.\n"
+"\n"
+"We kindly ask you to report this error to the Hathor team clicking on the "
+"button below.\n"
+"\n"
+"No sensitive data will be shared."
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:107
+msgid ""
+"Unfortunately an unhandled error happened.\n"
+"\n"
+"We kindly ask you to report this error to the Hathor team clicking on the "
+"button below.\n"
+"\n"
+"No sensitive data will be shared."
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:114
+msgid "Unexpected error occurred"
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:117
+msgid "Report error"
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:122
+msgid "Close"
 msgstr ""
 
 #: src/components/NewPaymentRequest.js:180
@@ -765,16 +775,16 @@ msgstr "Нет соединения с интернетом"
 msgid "Opening camera"
 msgstr "Камера открывается"
 
-#: src/components/ReceiveMyAddress.js:56
-#, javascript-format
-msgid "Here is my address: ${ _this.state.address }"
+#: src/components/ReceiveMyAddress.js:36
+#, fuzzy, javascript-format
+msgid "Here is my address: ${ lastSharedAddress }"
 msgstr "Это мой адрес: ${ _this.state.address }"
 
-#: src/components/ReceiveMyAddress.js:93
+#: src/components/ReceiveMyAddress.js:74
 msgid "New address"
 msgstr "Новый адрес"
 
-#: src/components/ReceiveMyAddress.js:99 src/components/TokenDetails.js:58
+#: src/components/ReceiveMyAddress.js:80 src/components/TokenDetails.js:58
 msgid "Share"
 msgstr "Поделиться"
 
@@ -788,19 +798,19 @@ msgid ""
 "Here is the configuration string of token ${ tokenLabel }: ${ configString }"
 msgstr "Это конфигурация вашего токена ${ tokenLabel }: ${ configString }"
 
-#: src/components/TxDetailsModal.js:53
+#: src/components/TxDetailsModal.js:61
 msgid "Description"
 msgstr "Описание"
 
-#: src/components/TxDetailsModal.js:54
+#: src/components/TxDetailsModal.js:62
 msgid "Date & Time"
 msgstr "Дата и Время"
 
-#: src/components/TxDetailsModal.js:55
+#: src/components/TxDetailsModal.js:63
 msgid "ID"
 msgstr "ID"
 
-#: src/components/TxDetailsModal.js:56
+#: src/components/TxDetailsModal.js:64
 msgid "Public Explorer"
 msgstr "Public Explorer"
 

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -3,29 +3,6 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: src/errorHandler.js:51
-msgid "Unexpected error occurred"
-msgstr ""
-
-#: src/errorHandler.js:52
-msgid ""
-"Unfortunately an unhandled error happened and you will need to restart your "
-"app.\n"
-"\n"
-"We kindly ask you to report this error to the Hathor team clicking on the "
-"button below.\n"
-"\n"
-"No sensitive data will be shared."
-msgstr ""
-
-#: src/errorHandler.js:55
-msgid "Report error"
-msgstr ""
-
-#: src/errorHandler.js:61
-msgid "Close"
-msgstr ""
-
 #: src/models.js:24
 #.  This should never happen!
 msgid "Unknown"
@@ -153,27 +130,27 @@ msgstr ""
 msgid "CHANGE PIN"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:136
+#: src/screens/ChoosePinScreen.js:135
 msgid "Enter your new PIN code"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:148
+#: src/screens/ChoosePinScreen.js:147
 msgid "Enter your new PIN code again"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:72
+#: src/screens/ChoosePinScreen.js:71
 msgid "Create a new PIN code,"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:75
+#: src/screens/ChoosePinScreen.js:74
 msgid "To confirm the PIN,"
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:162
+#: src/screens/ChoosePinScreen.js:161
 msgid "PIN codes don't match. Try again."
 msgstr ""
 
-#: src/screens/ChoosePinScreen.js:185
+#: src/screens/ChoosePinScreen.js:184
 msgid "Start the Wallet"
 msgstr ""
 
@@ -467,25 +444,25 @@ msgstr ""
 msgid "Waiting confirmation"
 msgstr ""
 
-#: src/screens/PinScreen.js:235
+#: src/screens/PinScreen.js:231
 msgid "Incorrect PIN Code. Try again."
 msgstr ""
 
-#: src/screens/PinScreen.js:72
+#: src/screens/PinScreen.js:70
 msgid "Enter your PIN Code "
 msgstr ""
 
-#: src/screens/PinScreen.js:73
+#: src/screens/PinScreen.js:71
 msgid "Unlock Hathor Wallet"
 msgstr ""
 
-#: src/screens/PinScreen.js:247
+#: src/screens/PinScreen.js:243
 msgid "Cancel"
 msgstr ""
 
-#: src/screens/PinScreen.js:250
+#: src/screens/PinScreen.js:246
 #: src/screens/RecoverPin.js:108
-#: src/screens/Settings.js:133
+#: src/screens/Settings.js:135
 msgid "Reset wallet"
 msgstr ""
 
@@ -628,12 +605,12 @@ msgstr ""
 msgid "Your transfer is being processed"
 msgstr ""
 
-#: src/sagas/wallet.js:109
+#: src/sagas/wallet.js:110
 #: src/screens/SendConfirmScreen.js:117
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr ""
 
-#: src/sagas/wallet.js:110
+#: src/sagas/wallet.js:111
 #: src/screens/SendConfirmScreen.js:118
 msgid "Authorize operation"
 msgstr ""
@@ -668,31 +645,31 @@ msgstr ""
 msgid "Scan the QR code"
 msgstr ""
 
-#: src/screens/Settings.js:88
+#: src/screens/Settings.js:90
 msgid "You are connected to"
 msgstr ""
 
-#: src/screens/Settings.js:100
+#: src/screens/Settings.js:102
 msgid "Connected to"
 msgstr ""
 
-#: src/screens/Settings.js:113
+#: src/screens/Settings.js:115
 msgid "Security"
 msgstr ""
 
-#: src/screens/Settings.js:119
+#: src/screens/Settings.js:121
 msgid "Create a new token"
 msgstr ""
 
-#: src/screens/Settings.js:127
+#: src/screens/Settings.js:129
 msgid "Register a token"
 msgstr ""
 
-#: src/screens/Settings.js:137
+#: src/screens/Settings.js:139
 msgid "About"
 msgstr ""
 
-#: src/screens/Settings.js:144
+#: src/screens/Settings.js:146
 msgid "Unique app identifier"
 msgstr ""
 
@@ -729,18 +706,51 @@ msgstr ""
 msgid "Copied to clipboard!"
 msgstr ""
 
-#: src/components/ErrorModal.js:27
+#: src/components/GlobalErrorModal.js:49
 msgid ""
 "Thanks for reporting the error to the team. We will investigate it to "
 "prevent from happening again."
 msgstr ""
 
-#: src/components/ErrorModal.js:39
+#: src/components/GlobalErrorModal.js:79
 msgid "Unexpected error"
 msgstr ""
 
-#: src/components/ErrorModal.js:43
+#: src/components/GlobalErrorModal.js:83
 msgid "Please restart your app to continue using the wallet."
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:104
+msgid ""
+"Unfortunately an unhandled error happened and you will need to restart your "
+"app.\n"
+"\n"
+"We kindly ask you to report this error to the Hathor team clicking on the "
+"button below.\n"
+"\n"
+"No sensitive data will be shared."
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:107
+msgid ""
+"Unfortunately an unhandled error happened.\n"
+"\n"
+"We kindly ask you to report this error to the Hathor team clicking on the "
+"button below.\n"
+"\n"
+"No sensitive data will be shared."
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:114
+msgid "Unexpected error occurred"
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:117
+msgid "Report error"
+msgstr ""
+
+#: src/components/GlobalErrorModal.js:122
+msgid "Close"
 msgstr ""
 
 #: src/components/NewPaymentRequest.js:180
@@ -755,16 +765,16 @@ msgstr ""
 msgid "Opening camera"
 msgstr ""
 
-#: src/components/ReceiveMyAddress.js:56
+#: src/components/ReceiveMyAddress.js:36
 #, javascript-format
-msgid "Here is my address: ${ _this.state.address }"
+msgid "Here is my address: ${ lastSharedAddress }"
 msgstr ""
 
-#: src/components/ReceiveMyAddress.js:93
+#: src/components/ReceiveMyAddress.js:74
 msgid "New address"
 msgstr ""
 
-#: src/components/ReceiveMyAddress.js:99
+#: src/components/ReceiveMyAddress.js:80
 #: src/components/TokenDetails.js:58
 msgid "Share"
 msgstr ""

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -765,16 +765,16 @@ msgstr ""
 msgid "Opening camera"
 msgstr ""
 
-#: src/components/ReceiveMyAddress.js:36
+#: src/components/ReceiveMyAddress.js:33
 #, javascript-format
 msgid "Here is my address: ${ lastSharedAddress }"
 msgstr ""
 
-#: src/components/ReceiveMyAddress.js:74
+#: src/components/ReceiveMyAddress.js:71
 msgid "New address"
 msgstr ""
 
-#: src/components/ReceiveMyAddress.js:80
+#: src/components/ReceiveMyAddress.js:77
 #: src/components/TokenDetails.js:58
 msgid "Share"
 msgstr ""

--- a/src/actions.js
+++ b/src/actions.js
@@ -510,11 +510,17 @@ export const walletRefreshSharedAddress = () => ({
 });
 
 /**
- * Update address that must be shared with user
+ * Update address that will be shared with user
+ *
+ * lastSharedAddress {string} The address to use
+ * lastSharedIndex {int} The address index to use
  */
-export const sharedAddressUpdate = (data) => ({
+export const sharedAddressUpdate = (lastSharedAddress, lastSharedIndex) => ({
   type: types.SHARED_ADDRESS_UPDATE,
-  payload: data,
+  payload: {
+    lastSharedAddress,
+    lastSharedIndex,
+  },
 });
 
 /**

--- a/src/actions.js
+++ b/src/actions.js
@@ -73,6 +73,8 @@ export const types = {
   WALLET_STATE_READY: 'WALLET_STATE_READY',
   WALLET_STATE_ERROR: 'WALLET_STATE_ERROR',
   WALLET_RELOADING: 'WALLET_RELOADING',
+  WALLET_REFRESH_SHARED_ADDRESS: 'WALLET_REFRESH_SHARED_ADDRESS',
+  SHARED_ADDRESS_UPDATE: 'SHARED_ADDRESS_UPDATE',
   EXCEPTION_CAPTURED: 'EXCEPTION_CAPTURED',
 };
 
@@ -501,6 +503,18 @@ export const walletStateReady = () => ({
 
 export const onWalletReload = () => ({
   type: types.WALLET_RELOADING,
+});
+
+export const walletRefreshSharedAddress = () => ({
+  type: types.WALLET_REFRESH_SHARED_ADDRESS,
+});
+
+/**
+ * Update address that must be shared with user
+ */
+export const sharedAddressUpdate = (data) => ({
+  type: types.SHARED_ADDRESS_UPDATE,
+  payload: data,
 });
 
 /**

--- a/src/components/ReceiveMyAddress.js
+++ b/src/components/ReceiveMyAddress.js
@@ -25,10 +25,7 @@ export default function ReceiveMyAddress() {
   const getNextAddress = async () => {
     const { address, index } = await wallet.getNextAddress();
 
-    dispatch(sharedAddressUpdate({
-      lastSharedAddress: address,
-      lastSharedIndex: index,
-    }));
+    dispatch(sharedAddressUpdate(address, index));
   };
 
   const shareAddress = () => {

--- a/src/components/ReceiveMyAddress.js
+++ b/src/components/ReceiveMyAddress.js
@@ -10,100 +10,80 @@ import {
   Dimensions, Share, StyleSheet, View,
 } from 'react-native';
 import { t } from 'ttag';
-
 import QRCode from 'react-native-qrcode-svg';
-
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import SimpleButton from './SimpleButton';
 import CopyClipboard from './CopyClipboard';
+import { sharedAddressUpdate } from '../actions';
 
-const mapStateToProps = (state) => ({
-  wallet: state.wallet,
-});
+export default function ReceiveMyAddress() {
+  const dispatch = useDispatch();
+  const wallet = useSelector((state) => state.wallet);
+  const lastSharedAddress = useSelector((state) => state.lastSharedAddress);
 
-class ReceiveMyAddress extends React.Component {
-  constructor(props) {
-    super(props);
+  const getNextAddress = async () => {
+    const { address, index } = await wallet.getNextAddress();
 
-    /**
-     * address {string} Wallet address
-     */
-    this.state = {
-      address: '',
-    };
+    dispatch(sharedAddressUpdate({
+      lastSharedAddress: address,
+      lastSharedIndex: index,
+    }));
+  };
 
-    this.willFocusEvent = null;
-  }
-
-  componentDidMount() {
-    const { navigation } = this.props;
-    this.willFocusEvent = navigation.addListener('willFocus', () => {
-      this.setState({ address: this.props.wallet.getCurrentAddress().address });
-    });
-  }
-
-  componentWillUnmount() {
-    this.willFocusEvent.remove();
-  }
-
-  getNextAddress = () => {
-    this.setState({ address: this.props.wallet.getNextAddress().address });
-  }
-
-  shareAddress = () => {
+  const shareAddress = () => {
     Share.share({
-      message: t`Here is my address: ${this.state.address}`,
+      message: t`Here is my address: ${lastSharedAddress}`,
     });
+  };
+
+  if (!lastSharedAddress) {
+    return null;
   }
 
-  render() {
-    if (!this.state.address) return null;
+  // This is used to set the width of the address wrapper view
+  // For some reason I was not being able to set as 100%, so I had to use this
+  const { height, width } = Dimensions.get('window');
 
-    // This is used to set the width of the address wrapper view
-    // For some reason I was not being able to set as 100%, so I had to use this
-    const { height, width } = Dimensions.get('window');
+  const addressWrapperStyle = StyleSheet.create({
+    style: {
+      padding: 16,
+      borderBottomWidth: 1.5,
+      borderTopWidth: 1.5,
+      borderColor: '#e5e5ea',
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: width - 32,
+    },
+  });
 
-    const addressWrapperStyle = StyleSheet.create({
-      style: {
-        padding: 16,
-        borderBottomWidth: 1.5,
-        borderTopWidth: 1.5,
-        borderColor: '#e5e5ea',
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: width - 32,
-      },
-    });
-
-    return (
-      <View style={styles.wrapper}>
-        <View style={styles.qrcodeWrapper}>
-          <QRCode value={`hathor:${this.state.address}`} size={height < 650 ? 160 : 250} />
-        </View>
-        <View style={addressWrapperStyle.style}>
-          <CopyClipboard
-            text={this.state.address}
-            textStyle={{ fontSize: height < 650 ? 11 : 13 }}
-          />
-        </View>
-        <View style={{ flexDirection: 'row' }}>
-          <SimpleButton
-            title={t`New address`}
-            onPress={this.getNextAddress}
-            containerStyle={[styles.buttonContainer, styles.leftButtonBorder]}
-          />
-          <SimpleButton
-            onPress={this.shareAddress}
-            title={t`Share`}
-            color='#000'
-            containerStyle={styles.buttonContainer}
-          />
-        </View>
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.qrcodeWrapper}>
+        <QRCode value={`hathor:${lastSharedAddress}`} size={height < 650 ? 160 : 250} />
       </View>
-    );
-  }
+      <View style={addressWrapperStyle.style}>
+        <CopyClipboard
+          text={lastSharedAddress}
+          textStyle={{ fontSize: height < 650 ? 11 : 13 }}
+        />
+      </View>
+      <View style={{ flexDirection: 'row' }}>
+        <SimpleButton
+          title={t`New address`}
+          onPress={getNextAddress}
+          containerStyle={[styles.buttonContainer, styles.leftButtonBorder]}
+        />
+        <SimpleButton
+          onPress={shareAddress}
+          title={t`Share`}
+          color='#000'
+          containerStyle={styles.buttonContainer}
+        />
+      </View>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -132,5 +112,3 @@ const styles = StyleSheet.create({
     borderColor: '#eee',
   },
 });
-
-export default connect(mapStateToProps)(ReceiveMyAddress);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -64,6 +64,9 @@ import { WALLET_STATUS } from './sagas/wallet';
  *   isFatal {boolean} Indicates if the error is fatal
  *   error {Error} Error object with the stacktrace, to be sent to Sentry
  * }
+ *
+ * lastSharedAddress {string} The current address to use
+ * lastSharedIndex {int} The current address index to use
  */
 const initialState = {
   tokensHistory: {},
@@ -99,6 +102,8 @@ const initialState = {
   tempPin: null,
   isShowingPinScreen: false,
   walletStartState: WALLET_STATUS.NOT_STARTED,
+  lastSharedAddress: null,
+  lastSharedIndex: null,
 };
 
 const reducer = (state = initialState, action) => {
@@ -189,6 +194,8 @@ const reducer = (state = initialState, action) => {
       return onExceptionCaptured(state, action);
     case types.WALLET_RELOADING:
       return onWalletReloading(state);
+    case types.SHARED_ADDRESS_UPDATE:
+      return onSharedAddressUpdate(state, action);
     default:
       return state;
   }
@@ -666,6 +673,16 @@ export const onExceptionCaptured = (state, { payload }) => {
 const onWalletReloading = (state) => ({
   ...state,
   walletStartState: WALLET_STATUS.LOADING,
+});
+
+/**
+ * @param {string} action.payload.lastSharedAddress The current address to use
+ * @param {int} action.payload.lastSharedIndex The current address index to use
+ */
+const onSharedAddressUpdate = (state, action) => ({
+  ...state,
+  lastSharedAddress: action.payload.lastSharedAddress,
+  lastSharedIndex: action.payload.lastSharedIndex,
 });
 
 const saga = createSagaMiddleware();

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -354,17 +354,10 @@ const onSetTempPin = (state, action) => ({
   tempPin: action.payload,
 });
 
-const onSetWallet = (state, action) => {
-  if (state.wallet && state.wallet.state !== hathorLib.HathorWallet.CLOSED) {
-    // Wallet was not closed
-    state.wallet.stop();
-  }
-
-  return {
-    ...state,
-    wallet: action.payload
-  };
-};
+const onSetWallet = (state, action) => ({
+  ...state,
+  wallet: action.payload,
+});
 
 const onSetUniqueDeviceId = (state, action) => ({
   ...state,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -187,6 +187,8 @@ const reducer = (state = initialState, action) => {
       return onWalletBestBlockUpdate(state, action);
     case types.EXCEPTION_CAPTURED:
       return onExceptionCaptured(state, action);
+    case types.WALLET_RELOADING:
+      return onWalletReloading(state);
     default:
       return state;
   }
@@ -660,6 +662,11 @@ export const onExceptionCaptured = (state, { payload }) => {
     },
   };
 };
+
+const onWalletReloading = (state) => ({
+  ...state,
+  walletStartState: WALLET_STATUS.LOADING,
+});
 
 const saga = createSagaMiddleware();
 const middlewares = [

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -609,6 +609,9 @@ export function* onWalletReloadData() {
     // We also need to refresh the addresses since we are not starting the wallet again
     yield call(wallet.getNewAddresses.bind(wallet));
 
+    // Then dispatch the refreshSharedAddress so our redux store is updated
+    yield put(walletRefreshSharedAddress());
+
     // Finally, set the wallet to READY by dispatching startWalletSuccess
     yield put(startWalletSuccess());
   } catch (e) {

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -486,6 +486,9 @@ export function* handleTx(action) {
   if (action.type === 'WALLET_NEW_TX') {
     yield put(newTx(tx));
   }
+
+  // We should sync the last shared address on our redux store with the facade's internal state
+  yield put(walletRefreshSharedAddress());
 }
 
 export function* setupWalletListeners(wallet) {

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -659,10 +659,7 @@ export function* refreshSharedAddress() {
 
   const { address, index } = wallet.getCurrentAddress();
 
-  yield put(sharedAddressUpdate({
-    lastSharedAddress: address,
-    lastSharedIndex: index,
-  }));
+  yield put(sharedAddressUpdate(address, index));
 }
 
 export function* saga() {

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -606,11 +606,17 @@ export function* onWalletReloadData() {
       yield put(tokenInvalidateHistory(tokenUid));
     }
 
-    // We also need to refresh the addresses since we are not starting the wallet again
-    yield call(wallet.getNewAddresses.bind(wallet));
+    // If we are on the wallet-service, we also need to refresh the
+    // facade instance internal addresses
+    if (useWalletService) {
+      yield call(wallet.getNewAddresses.bind(wallet));
+    }
 
-    // Then dispatch the refreshSharedAddress so our redux store is updated
+    // dispatch the refreshSharedAddress so our redux store is potentially
+    // updated with the new addresses that we missed during the disconnection
+    // time
     yield put(walletRefreshSharedAddress());
+
 
     // Finally, set the wallet to READY by dispatching startWalletSuccess
     yield put(startWalletSuccess());

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -26,10 +26,13 @@ import CopyClipboard from '../components/CopyClipboard';
 
 /**
  * selectedToken {Object} Select token config {name, symbol, uid}
- * server {str} URL of the full node this wallet is connected to
+ * server {str} URL of server this wallet is connected to
  */
 const mapStateToProps = (state) => {
-  const server = hathorLib.storage.getItem('wallet:server');
+  const server = state.useWalletService
+    ? hathorLib.config.getWalletServiceBaseUrl()
+    : hathorLib.config.getServerUrl();
+
   return {
     selectedToken: state.selectedToken,
     isOnline: state.isOnline,

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -23,7 +23,6 @@ import { IS_MULTI_TOKEN, PRIMARY_COLOR } from '../constants';
 import { getLightBackground } from '../utils';
 import CopyClipboard from '../components/CopyClipboard';
 
-
 /**
  * selectedToken {Object} Select token config {name, symbol, uid}
  * server {str} URL of server this wallet is connected to


### PR DESCRIPTION
## Summary

After the refactor done in https://github.com/HathorNetwork/hathor-wallet-mobile/pull/232, the wallet stopped reloading after a websocket reconnection.

The initial problem was that we were not setting the `walletStartedState` to `LOADING`, which made it reload the wallet but never display the loading screen.

But not only that, since we refactored the loading flow, the reload was still not happening. Upon investigation, I found out that the old mechanism for reloading the wallet was only working because the `LoadHistoryScreen` was dispatching the `startWalletRequested` action on the `componentDidUpdate`, as we can see [here](https://github.com/HathorNetwork/hathor-wallet-mobile/pull/232/files#diff-6b628a954cc3611565a6b19e839717bb5431913b6d02c38206de52df4b355fbbL55).

### Acceptance Criteria
- We should reload the wallet data after a reconnection
- We should refresh the wallet addresses after a reconnection
- We should stop resetting the wallet if an error occurs
- We should display the correct wallet-service connected server while on the wallet-service facade


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
