### PR TITLE
refactor: new feature flag schema

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -88,3 +88,8 @@ export const METADATA_CONCURRENT_DOWNLOAD = 5;
 // Wallet service URLs
 export const WALLET_SERVICE_MAINNET_BASE_URL = 'https://wallet-service.hathor.network/';
 export const WALLET_SERVICE_MAINNET_BASE_WS_URL = 'wss://ws.wallet-service.hathor.network/';
+
+/**
+ * This is the environment stage that will be used to load the unleash feature flags.
+ */
+export const STAGE = 'mainnet';

--- a/src/constants.js
+++ b/src/constants.js
@@ -93,3 +93,8 @@ export const WALLET_SERVICE_MAINNET_BASE_WS_URL = 'wss://ws.wallet-service.hatho
  * This is the environment stage that will be used to load the unleash feature flags.
  */
 export const STAGE = 'mainnet';
+
+/**
+ * The feature toggle configured in Unleash
+ */
+export const WALLET_SERVICE_FEATURE_TOGGLE = 'wallet-service-mobile.rollout';

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -6,6 +6,7 @@ import {
   UNLEASH_URL,
   UNLEASH_CLIENT_KEY,
   UNLEASH_POLLING_INTERVAL,
+  STAGE,
 } from './constants';
 
 export const Events = {
@@ -18,13 +19,13 @@ export class FeatureFlags extends events.EventEmitter {
 
     this.userId = userId;
     this.network = network;
-    this.walletServiceFlag = `wallet-service-mobile-${Platform.OS}-${this.network}.rollout`;
+    this.walletServiceFlag = 'wallet-service-mobile.rollout';
     this.walletServiceEnabled = null;
     this.client = new UnleashClient({
       url: UNLEASH_URL,
       clientKey: UNLEASH_CLIENT_KEY,
       refreshInterval: UNLEASH_POLLING_INTERVAL,
-      appName: `wallet-service-mobile-${Platform.OS}`,
+      appName: `wallet-service-mobile`,
     });
 
     this.client.on('update', () => {
@@ -57,7 +58,14 @@ export class FeatureFlags extends events.EventEmitter {
       if (shouldIgnore) {
         return false;
       }
-      this.client.updateContext({ userId: this.userId });
+      const options = {
+        userId: this.userId,
+        properties: {
+          platform: Platform.OS,
+          stage: STAGE,
+        },
+      };
+      this.client.updateContext(options);
 
       // Start polling for feature flag updates
       await this.client.start();

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -6,6 +6,7 @@ import {
   UNLEASH_URL,
   UNLEASH_CLIENT_KEY,
   UNLEASH_POLLING_INTERVAL,
+  WALLET_SERVICE_FEATURE_TOGGLE,
   STAGE,
 } from './constants';
 
@@ -18,13 +19,13 @@ export class FeatureFlags extends events.EventEmitter {
     super();
 
     this.userId = userId;
-    this.walletServiceFlag = 'wallet-service-mobile.rollout';
+    this.walletServiceFlag = WALLET_SERVICE_FEATURE_TOGGLE;
     this.walletServiceEnabled = null;
     this.client = new UnleashClient({
       url: UNLEASH_URL,
       clientKey: UNLEASH_CLIENT_KEY,
       refreshInterval: UNLEASH_POLLING_INTERVAL,
-      appName: `wallet-service-mobile`,
+      appName: 'wallet-service-mobile',
     });
 
     this.client.on('update', () => {

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -62,6 +62,7 @@ export class FeatureFlags extends events.EventEmitter {
         userId: this.userId,
         properties: {
           platform: Platform.OS,
+          network: this.network,
           stage: STAGE,
         },
       };

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -14,11 +14,10 @@ export const Events = {
 };
 
 export class FeatureFlags extends events.EventEmitter {
-  constructor(userId, network) {
+  constructor(userId) {
     super();
 
     this.userId = userId;
-    this.network = network;
     this.walletServiceFlag = 'wallet-service-mobile.rollout';
     this.walletServiceEnabled = null;
     this.client = new UnleashClient({
@@ -47,9 +46,6 @@ export class FeatureFlags extends events.EventEmitter {
   * Uses the Hathor Unleash Server and Proxy to determine if the
   * wallet should use the WalletService facade or the old facade
   *
-  * @params {string} userId An user identifier (e.g. the firstAddress)
-  * @params {string} network The network name ('mainnet' or 'testnet')
-  *
   * @return {boolean} The result from the unleash feature flag
   */
   async shouldUseWalletService() {
@@ -62,7 +58,6 @@ export class FeatureFlags extends events.EventEmitter {
         userId: this.userId,
         properties: {
           platform: Platform.OS,
-          network: this.network,
           stage: STAGE,
         },
       };

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -85,7 +85,7 @@ export function* startWallet(action) {
 
   const networkName = 'mainnet';
   const uniqueDeviceId = getUniqueId();
-  const featureFlags = new FeatureFlags(uniqueDeviceId, networkName);
+  const featureFlags = new FeatureFlags(uniqueDeviceId);
   const useWalletService = yield call(() => featureFlags.shouldUseWalletService());
 
   yield put(setUseWalletService(useWalletService));


### PR DESCRIPTION
## Motivation

Today we have multiple feature flags for the wallet-service mobile wallets:

* `wallet-service-mobile-ios-testnet.rollout`
* `wallet-service-mobile-ios-mainnet.rollout`
* `wallet-service-mobile-android-mainnet.rollout`
* `wallet-service-mobile-android-testnet.rollout`

The idea is to refactor this, to have a single feature flag `wallet-service-mobile.rollout` for both mobile wallets and use the new `constraints` mechanism from unleash to set the rollout percentages

Here is an example of a configured feature flag with this new mechanism:

![Screenshot 2023-02-06 at 16 15 21](https://user-images.githubusercontent.com/3586068/217064029-30bf8795-6ee2-4aa9-b3d7-99c075a25852.png)


### Acceptance Criteria
- We should use unleash's `properties` attribute while setting context for the unleash client to be able to fine control our unleash feature strategies


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
