### PR TITLE
refactor: load from xpriv

### DIFF
--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -79,7 +79,11 @@ export const WALLET_STATUS = {
 };
 
 export function* startWallet(action) {
-  const { words, pin } = action.payload;
+  const {
+    words,
+    pin,
+    fromXpriv,
+  } = action.payload;
 
   NavigationService.navigate('LoadHistoryScreen');
 
@@ -125,12 +129,23 @@ export function* startWallet(action) {
     config.setWalletServiceBaseUrl(WALLET_SERVICE_MAINNET_BASE_URL);
     config.setWalletServiceBaseWsUrl(WALLET_SERVICE_MAINNET_BASE_WS_URL);
 
+    let xpriv;
+    if (fromXpriv) {
+      xpriv = walletUtil.getAcctPathXprivKey(pin);
+    }
+
     wallet = new HathorWalletServiceWallet({
       requestPassword: showPinScreenForResult,
       seed: words,
-      network
+      network,
+      xpriv,
     });
   } else {
+    let xpriv;
+    if (fromXpriv) {
+      xpriv = walletUtil.getXprivKey(pin);
+    }
+
     const connection = new Connection({
       network: networkName, // app currently connects only to mainnet
       servers: ['https://mobile.wallet.hathor.network/v1a/'],

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -153,6 +153,7 @@ export function* startWallet(action) {
 
     const walletConfig = {
       seed: words,
+      xpriv,
       store: STORE,
       connection,
       beforeReloadCallback: () => {

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -206,7 +206,10 @@ export function* startWallet(action) {
   }
 
   walletUtil.storePasswordHash(pin);
-  walletUtil.storeEncryptedWords(words, pin);
+  if (!fromXpriv) {
+    walletUtil.storeEncryptedWords(words, pin);
+  }
+
   setKeychainPin(pin);
 
   yield put(setServerInfo({

--- a/src/screens/LoadWalletErrorScreen.js
+++ b/src/screens/LoadWalletErrorScreen.js
@@ -10,7 +10,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { onStartWalletLock, lockScreen } from '../actions';
 import SimpleButton from '../components/SimpleButton';
 

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -45,10 +45,7 @@ const mapDispatchToProps = (dispatch) => ({
   setLoadHistoryStatus: (active, error) => dispatch(setLoadHistoryStatus(active, error)),
   setTempPin: (pin) => dispatch(setTempPin(pin)),
   onStartWalletLock: () => dispatch(onStartWalletLock()),
-  startWalletRequested: (words, pin) => dispatch(startWalletRequested({
-    words,
-    pin
-  })),
+  startWalletRequested: (payload) => dispatch(startWalletRequested(payload)),
 });
 
 class PinScreen extends React.Component {
@@ -146,10 +143,12 @@ class PinScreen extends React.Component {
       // method an change redux state. No need to execute callback or go back on navigation
       this.handleDataMigration(pin);
       if (!this.props.wallet) {
-        // We are saving HathorWallet object in redux, so if the app has lost redux information
-        // and is in locked screen we must start the HathorWallet object again
-        const words = getWalletWords(pin);
-        this.props.startWalletRequested(words, pin);
+        // If we are here, the wallet has already been initialized in the past, so
+        // we should load from xpriv
+        this.props.startWalletRequested({
+          pin,
+          fromXpriv: true,
+        });
       }
       this.props.unlockScreen();
     } else {

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -143,12 +143,26 @@ class PinScreen extends React.Component {
       // method an change redux state. No need to execute callback or go back on navigation
       this.handleDataMigration(pin);
       if (!this.props.wallet) {
-        // If we are here, the wallet has already been initialized in the past, so
-        // we should load from xpriv
-        this.props.startWalletRequested({
-          pin,
-          fromXpriv: true,
-        });
+        // Here we need to check if the user has the `acctPathMainKey` stored on his accessData
+        // because he won't have it if he's migrating from any version before v0.18.0 directly into
+        // version > v0.21.1. We only use it on the wallet-service facade, but dispatching
+        // `startWalletRequested` once with the words instead of xpriv will update his storage to
+        // contain it so if he ever switches to the wallet-service, it will load properly from it.
+        const xpriv = hathorLib.wallet.getAcctPathXprivKey(pin);
+        if (!xpriv) {
+          const words = getWalletWords(pin);
+          this.props.startWalletRequested({
+            pin,
+            words,
+          });
+        } else {
+          // If we are here, the wallet has already been initialized in the past, so
+          // we should load from xpriv
+          this.props.startWalletRequested({
+            pin,
+            fromXpriv: true,
+          });
+        }
       }
       this.props.unlockScreen();
     } else {


### PR DESCRIPTION
## Summary

This improves the wallet load time by starting the wallet from the stored xpriv instead of generating them again during the loading step

During the investigation of why the wallet was taking up to 11s to load, I ran a benchmark on the methods the lib calls during initialization and found two bottlenecks:

| Method | Time (seconds) |
| --- | --- |
| generateCreateWalletAuthData | 5.401s |
| executeGenerateWallet | 2.453s |

Something interesting to notice is that when the debugger is activated, those methods are up to 40× faster and that's why it was so hard to figure out:

| Method | Time (seconds) |
| --- | --- |
| generateCreateWalletAuthData | 0.357s |
| executeGenerateWallet | 0.145s |

Apparently, when the debugger is activated, it changes the default javascript runtime to v8 (the one from the computer that is running the debugger). `bitcore-lib` is much faster on v8

I tried activating [Hermes](https://reactnative.dev/docs/hermes) on the build, but it didn't improve by a lot.





### Acceptance Criteria
- We should load the from xpriv instead of using the seed
  - The idea here is to avoid calling `executeGenerateWallet` when opening an already started wallet since it's taking a long time to run on mobile devices (because of bitcorelib)
- We should make sure that users migrating from older versions of the wallet won't have problems loading their wallets


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
