### PR TITLE
fix: tx details modal over lock screen

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -234,6 +234,18 @@ It's a second custom NFT token to test.
         1. The `HTR - HATHOR` name should be in the primary color (purple)
     1. Click on the `HTR - HATHOR` item
         1. The **Balance** page should open
+1. **View the details of the transaction while in foreground starting from lock screen**
+    1. Send a token after turn on `Enable Push Notification` option
+    1. **Keep the application open**
+    1. Go to the Settings screen.
+    1. Go to Security
+    1. Click on Lock Wallet.
+    1. Click on the notification
+    1. Unlock the screen
+    1. Wait until the modal with tx details open
+        1. The `HTR - HATHOR` name should be in the primary color (purple)
+    1. Click on the `HTR - HATHOR` item
+        1. The **Balance** page should open
 1. **Reset wallet and send a token**
     1. Reset the wallet
     1. Send HTR to this wallet

--- a/src/App.js
+++ b/src/App.js
@@ -237,6 +237,7 @@ const AppStack = createStackNavigator({
 const mapStateToProps = (state) => ({
   loadHistory: state.loadHistoryStatus.active,
   isScreenLocked: state.lockScreen,
+  isResetOnScreenLocked: state.resetOnLockScreen,
   isRecoveringPin: state.recoveringPin,
   walletStartState: state.walletStartState,
 });
@@ -400,7 +401,24 @@ class _AppStackWrapper extends React.Component {
 
       if (!this.props.isRecoveringPin) {
         if (this.props.isScreenLocked) {
-          screen = <PinScreen isLockScreen navigation={this.props.navigation} />;
+          /**
+           * NOTE:
+           * This approach shows the ResetWallet screen as an auxiliar view,
+           * replacing the PinScreen and setting the back button to drop the view,
+           * letting the PinScreen be re-rendered.
+           *
+           * This approach also keeps the navigation stack unchanged,
+           * therefore increasing the convinience for the user.
+           *
+           * The previous approach unlocks the wallet and navigates to ResetWallet
+           * screen with a back button pointing to StartWalletLockScreen,
+           * this interfering in the stack navigation.
+           */
+          if (this.props.isResetOnScreenLocked) {
+            screen = <ResetWallet navigation={this.props.navigation} />;
+          } else {
+            screen = <PinScreen isLockScreen navigation={this.props.navigation} />;
+          }
         } else {
           screen = <LoadHistoryScreen />;
         }

--- a/src/App.js
+++ b/src/App.js
@@ -409,10 +409,6 @@ class _AppStackWrapper extends React.Component {
            *
            * This approach also keeps the navigation stack unchanged,
            * therefore increasing the convinience for the user.
-           *
-           * The previous approach unlocks the wallet and navigates to ResetWallet
-           * screen with a back button pointing to StartWalletLockScreen,
-           * this interfering in the stack navigation.
            */
           if (this.props.isResetOnScreenLocked) {
             screen = <ResetWallet navigation={this.props.navigation} />;

--- a/src/actions.js
+++ b/src/actions.js
@@ -190,8 +190,23 @@ export const setUniqueDeviceId = (uniqueId) => ({
   payload: uniqueId,
 });
 
+/**
+ * Action to set the screen unlocked.
+ * @returns action
+ */
 export const unlockScreen = () => ({ type: types.SET_LOCK_SCREEN, payload: false });
 
+/**
+ * Check if the action is about to set screen to unlocked state.
+ * @param {{ type: string, payload: boolean }} action
+ * @returns {boolean} true if unlocked and false otherwise.
+ */
+export const isUnlockScreen = (action) => action.type === types.SET_LOCK_SCREEN && action.payload === false;
+
+/**
+ * Action to set the screen locked.
+ * @returns action
+ */
 export const lockScreen = () => ({ type: types.SET_LOCK_SCREEN, payload: true });
 
 /**

--- a/src/actions.js
+++ b/src/actions.js
@@ -198,13 +198,6 @@ export const setUniqueDeviceId = (uniqueId) => ({
 export const unlockScreen = () => ({ type: types.SET_LOCK_SCREEN, payload: false });
 
 /**
- * Check if the action is about to set screen to unlocked state.
- * @param {{ type: string, payload: boolean }} action
- * @returns {boolean} true if unlocked and false otherwise.
- */
-export const isUnlockScreen = (action) => action.type === types.SET_LOCK_SCREEN && action.payload === false;
-
-/**
  * Action to set the screen locked.
  * @returns action
  */

--- a/src/actions.js
+++ b/src/actions.js
@@ -40,6 +40,7 @@ export const types = {
   SET_SERVER_INFO: 'SET_SERVER_INFO',
   ACTIVATE_FETCH_HISTORY: 'ACTIVATE_FETCH_HISTORY',
   SET_LOCK_SCREEN: 'SET_LOCK_SCREEN',
+  SET_RESET_ON_LOCK_SCREEN: 'SET_RESET_ON_LOCK_SCREEN',
   SET_INIT_WALLET: 'SET_INIT_WALLET',
   UPDATE_HEIGHT: 'UPDATE_HEIGHT',
   SHOW_ERROR_MODAL: 'SHOW_ERROR_MODAL',
@@ -208,6 +209,18 @@ export const isUnlockScreen = (action) => action.type === types.SET_LOCK_SCREEN 
  * @returns action
  */
 export const lockScreen = () => ({ type: types.SET_LOCK_SCREEN, payload: true });
+
+/**
+ * Action to set the reset on screen locked.
+ * @returns action
+ */
+export const resetOnLockScreen = () => ({ type: types.SET_RESET_ON_LOCK_SCREEN, payload: true });
+
+/**
+ * Action to drop the reset on screen locked.
+ * @returns action
+ */
+export const dropResetOnLockScreen = () => ({ type: types.SET_RESET_ON_LOCK_SCREEN, payload: false });
 
 /**
  * height {number} new height of the network

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -89,6 +89,7 @@ const initialState = {
   isOnline: false,
   serverInfo: { version: '', network: '' },
   lockScreen: true,
+  resetOnLockScreen: false,
   height: 0,
   errorHandler: {
     showAlert: false,
@@ -225,6 +226,8 @@ const reducer = (state = initialState, action) => {
       return onSetServerInfo(state, action);
     case types.SET_LOCK_SCREEN:
       return onSetLockScreen(state, action);
+    case types.SET_RESET_ON_LOCK_SCREEN:
+      return onSetResetOnLockScreen(state, action);
     case types.SHOW_ERROR_MODAL:
       return onShowErrorModal(state, action);
     case types.HIDE_ERROR_MODAL:
@@ -461,6 +464,11 @@ const onSetLoadHistoryStatus = (state, action) => ({
 const onSetLockScreen = (state, action) => ({
   ...state,
   lockScreen: action.payload,
+});
+
+const onSetResetOnLockScreen = (state, action) => ({
+  ...state,
+  resetOnLockScreen: action.payload,
 });
 
 const onSetRecoveringPin = (state, action) => ({

--- a/src/sagas/helpers.js
+++ b/src/sagas/helpers.js
@@ -10,7 +10,7 @@ import { put, race, take, call } from 'redux-saga/effects';
 import { t } from 'ttag';
 import NavigationService from '../NavigationService';
 import {
-  setIsShowingPinScreen,
+  setIsShowingPinScreen, types,
 } from '../actions';
 
 /**
@@ -102,3 +102,13 @@ export const showPinScreenForResult = async (dispatch) => new Promise((resolve) 
   // We should set the global isShowingPinScreen
   dispatch(setIsShowingPinScreen(true));
 });
+
+/**
+ * Check if the action is about to set screen to unlocked state.
+ * @param {{ type: string, payload: boolean }} action
+ * @returns {boolean} true if unlocked and false otherwise.
+ */
+export function isUnlockScreen(action) {
+  return action.type === types.SET_LOCK_SCREEN
+    && action.payload === false;
+}

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -512,7 +512,7 @@ export const getTxDetails = async (wallet, txId) => {
  */
 export function* loadTxDetails(action) {
   const { txId } = action.payload;
-  const isLocked = select((state) => state.lockScreen);
+  const isLocked = yield select((state) => state.lockScreen);
   if (isLocked) {
     const { resetWallet } = yield race({
       unlockWallet: take(isUnlockScreen),

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -514,7 +514,14 @@ export function* loadTxDetails(action) {
   const { txId } = action.payload;
   const isLocked = select((state) => state.lockScreen);
   if (isLocked) {
-    yield take(isUnlockScreen);
+    const { resetWallet } = yield race({
+      unlockWallet: take(isUnlockScreen),
+      resetWallet: take(types.RESET_WALLET)
+    });
+    if (resetWallet) {
+      console.debug('Halting loadTxDetails');
+      return;
+    }
   }
 
   try {

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -40,7 +40,6 @@ import {
   pushTxDetailsRequested,
   pushTxDetailsSuccess,
   pushAskRegistrationRefreshQuestion,
-  isUnlockScreen,
 } from '../actions';
 import {
   pushNotificationKey,
@@ -51,7 +50,7 @@ import {
   PUSH_CHANNEL_TRANSACTION,
 } from '../constants';
 import { getPushNotificationSettings } from '../utils';
-import { showPinScreenForResult } from './helpers';
+import { isUnlockScreen, showPinScreenForResult } from './helpers';
 import { messageHandler } from '../workers/pushNotificationHandler';
 import { WALLET_STATUS } from './wallet';
 

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -40,6 +40,7 @@ import {
   pushTxDetailsRequested,
   pushTxDetailsSuccess,
   pushAskRegistrationRefreshQuestion,
+  isUnlockScreen,
 } from '../actions';
 import {
   pushNotificationKey,
@@ -511,6 +512,11 @@ export const getTxDetails = async (wallet, txId) => {
  */
 export function* loadTxDetails(action) {
   const { txId } = action.payload;
+  const isLocked = select((state) => state.lockScreen);
+  if (isLocked) {
+    yield take(isUnlockScreen);
+  }
+
   try {
     const wallet = yield select((state) => state.wallet);
     const txDetails = yield call(getTxDetails, wallet, txId);

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -26,6 +26,7 @@ import {
   setTempPin,
   onStartWalletLock,
   startWalletRequested,
+  resetOnLockScreen,
 } from '../actions';
 import { PIN_SIZE } from '../constants';
 
@@ -42,6 +43,7 @@ const mapDispatchToProps = (dispatch) => ({
   setRecoveringPin: (state) => dispatch(setRecoveringPin(state)),
   unlockScreen: () => dispatch(unlockScreen()),
   lockScreen: () => dispatch(lockScreen()),
+  resetOnLockScreen: () => dispatch(resetOnLockScreen()),
   setLoadHistoryStatus: (active, error) => dispatch(setLoadHistoryStatus(active, error)),
   setTempPin: (pin) => dispatch(setTempPin(pin)),
   onStartWalletLock: () => dispatch(onStartWalletLock()),
@@ -212,18 +214,7 @@ class PinScreen extends React.Component {
   }
 
   goToReset = () => {
-    // navigate to reset screen
-    this.props.navigation.navigate('ResetWallet', {
-      onBackPress: () => {
-        this.props.onStartWalletLock();
-        this.backFromReset();
-      },
-    });
-    // make sure we won't show loadHistory screen
-    this.props.setLoadHistoryStatus(false, false);
-
-    // unlock so we remove this lock screen
-    this.props.unlockScreen();
+    this.props.resetOnLockScreen();
   }
 
   /*

--- a/src/screens/ResetWallet.js
+++ b/src/screens/ResetWallet.js
@@ -23,10 +23,18 @@ import NewHathorButton from '../components/NewHathorButton';
 import TextFmt from '../components/TextFmt';
 import baseStyle from '../styles/init';
 import { PRIMARY_COLOR } from '../constants';
-import { resetWallet } from '../actions';
+import { dropResetOnLockScreen, resetWallet } from '../actions';
+
+/**
+ * isScreenLocked {bool} check if is in lock screen state
+ */
+const mapStateToProps = (state) => ({
+  isScreenLocked: state.lockScreen,
+});
 
 const mapDispatchToProps = (dispatch) => ({
   resetWallet: () => dispatch(resetWallet()),
+  dropResetOnLockScreen: () => dispatch(dropResetOnLockScreen()),
 });
 
 
@@ -53,8 +61,16 @@ class ResetWallet extends React.Component {
 
   constructor(props) {
     super(props);
-    this.onBackPress = this.props.navigation.getParam('onBackPress', this.props.navigation.goBack);
-    this.hideBackButton = this.props.navigation.getParam('hideBackButton', false);
+    if (this.props.isScreenLocked) {
+      this.onBackPress = this.props.dropResetOnLockScreen;
+    } else {
+      this.onBackPress = this.props.navigation.getParam('onBackPress', this.props.navigation.goBack);
+    }
+
+    this.hideBackButton = false;
+    if (this.props.navigation) {
+      this.hideBackButton = this.props.navigation.getParam('hideBackButton', false);
+    }
   }
 
   toggleSwitch = (value) => {
@@ -107,4 +123,4 @@ class ResetWallet extends React.Component {
   }
 }
 
-export default connect(null, mapDispatchToProps)(ResetWallet);
+export default connect(mapStateToProps, mapDispatchToProps)(ResetWallet);


### PR DESCRIPTION
### Acceptance Criteria
- Avoid transaction details modal (balance modal) to appear over lock screen. With this fix the modal will only appear after unlock the screen.

Regarding the previous approach to render the reset page from the pin screen:

> The previous approach unlocks the wallet and navigates to ResetWallet
> screen with a back button pointing to StartWalletLockScreen,
> this interfering with the stack navigation.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
