### PR TITLE
fix: wallet reset cleanup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -313,7 +313,7 @@ class _AppStackWrapper extends React.Component {
     const version = DeviceInfo.getVersion();
     // We use this string to parse the version from user agent
     // in some of our services, so changing this might break another service
-    if (this.props.wallet && this.props.wallet.storage) {
+    if (this.props.wallet?.storage) {
       this.props.wallet.storage.config.setUserAgent(`Hathor Wallet Mobile / ${version}`);
     }
     // set notification foreground listener

--- a/src/App.js
+++ b/src/App.js
@@ -355,7 +355,7 @@ class _AppStackWrapper extends React.Component {
    * These tokens are known as 'registered' tokens
    */
   updateReduxTokens = async () => {
-    if ((!this.props.wallet) || (!this.props.wallet.storage)) {
+    if (!this.props.wallet?.storage) {
       return;
     }
     const tokens = [...INITIAL_TOKENS];

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -232,8 +232,6 @@ const reducer = (state = initialState, action) => {
       return onHideErrorModal(state);
     case types.SET_WALLET:
       return onSetWallet(state, action);
-    case types.RESET_WALLET:
-      return onResetWallet(state, action);
     case types.RESET_WALLET_SUCCESS:
       return onResetWalletSuccess(state);
     case types.RESET_LOADED_DATA:
@@ -516,16 +514,15 @@ const onSetUseWalletService = (state, action) => ({
   useWalletService: action.payload,
 });
 
-const onResetWallet = (state) => ({
-  ...state,
-  wallet: null,
-});
-
 const onResetWalletSuccess = (state) => {
   const oldUnleashClient = state.unleashClient;
+  const oldFeatureTogglesInitialized = state.featureTogglesInitialized;
+  const oldFeatureToggles = state.featureToggles;
   return {
     ...initialState,
     unleashClient: oldUnleashClient,
+    featureTogglesInitialized: oldFeatureTogglesInitialized,
+    featureToggles: oldFeatureToggles,
   };
 };
 

--- a/src/sagas/featureToggle.js
+++ b/src/sagas/featureToggle.js
@@ -144,25 +144,19 @@ export function* monitorFeatureFlags(currentRetry = 0) {
 
 export function* setupUnleashListeners(unleashClient) {
   const channel = eventChannel((emitter) => {
-    const listener = (state) => emitter(state);
+    const l1 = () => emitter({ type: 'FEATURE_TOGGLE_UPDATE' });
+    const l2 = () => emitter({ type: 'FEATURE_TOGGLE_READY' });
+    const l3 = (err) => emitter({ type: 'FEATURE_TOGGLE_ERROR', data: err });
 
-    unleashClient.on(UnleashEvents.UPDATE, () => emitter({
-      type: 'FEATURE_TOGGLE_UPDATE',
-    }));
-
-    unleashClient.on(UnleashEvents.READY, () => emitter({
-      type: 'FEATURE_TOGGLE_READY',
-    }));
-
-    unleashClient.on(UnleashEvents.ERROR, (err) => emitter({
-      type: 'FEATURE_TOGGLE_ERROR',
-      data: err,
-    }));
+    unleashClient.on(UnleashEvents.UPDATE, l1);
+    unleashClient.on(UnleashEvents.READY, l2);
+    unleashClient.on(UnleashEvents.ERROR, l3);
 
     return () => {
-      unleashClient.removeListener(UnleashEvents.UPDATE, listener);
-      unleashClient.removeListener(UnleashEvents.READY, listener);
-      unleashClient.removeListener(UnleashEvents.ERROR, listener);
+      // XXX: This should be a cleanup but removeListener does not exist
+      // This will throw an error and it will interfere with other sagas
+      // Since it works without the cleanup i will leave this method empty
+      // until have determined the best cleanup approach
     };
   });
 

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -645,12 +645,12 @@ export function* onResetWallet() {
 
   if (wallet) {
     yield call(() => wallet.stop({ cleanStorage: true, cleanAddresses: true }));
+    yield setWallet(null);
+    yield call(() => STORE.resetWallet());
     return;
   }
 
-  // Wallet was not initialized yet, this might happen if resetWallet
-  // is called from the PinScreen. There is no event listeners to cleanup
-  yield call(() => STORE.clearItems(true));
+  yield call(() => STORE.resetWallet());
 
   yield put(resetWalletSuccess());
 }

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -39,7 +39,7 @@ import {
   WALLET_SERVICE_FEATURE_TOGGLE,
   PUSH_NOTIFICATION_FEATURE_TOGGLE,
 } from '../constants';
-import { STORE, generateStorage } from '../store';
+import { STORE } from '../store';
 import {
   tokenFetchBalanceRequested,
   tokenFetchHistoryRequested,
@@ -129,7 +129,7 @@ export function* startWallet(action) {
   // clean storage and metadata before starting the wallet
   // this should be cleaned when stopping the wallet,
   // but the wallet may be closed unexpectedly
-  const storage = generateStorage()
+  const storage = STORE.getStorage();
   yield storage.store.cleanMetadata();
   yield storage.cleanStorage(true);
 

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -39,7 +39,7 @@ import {
   WALLET_SERVICE_FEATURE_TOGGLE,
   PUSH_NOTIFICATION_FEATURE_TOGGLE,
 } from '../constants';
-import { STORE } from '../store';
+import { STORE, generateStorage } from '../store';
 import {
   tokenFetchBalanceRequested,
   tokenFetchHistoryRequested,
@@ -129,7 +129,7 @@ export function* startWallet(action) {
   // clean storage and metadata before starting the wallet
   // this should be cleaned when stopping the wallet,
   // but the wallet may be closed unexpectedly
-  const storage = STORE.getStorage();
+  const storage = generateStorage()
   yield storage.store.cleanMetadata();
   yield storage.cleanStorage(true);
 

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -646,8 +646,6 @@ export function* onResetWallet() {
   if (wallet) {
     yield call(() => wallet.stop({ cleanStorage: true, cleanAddresses: true }));
     yield setWallet(null);
-    yield call(() => STORE.resetWallet());
-    return;
   }
 
   yield call(() => STORE.resetWallet());

--- a/src/screens/ChoosePinScreen.js
+++ b/src/screens/ChoosePinScreen.js
@@ -22,6 +22,7 @@ import { startWalletRequested, unlockScreen } from '../actions';
 import { PIN_SIZE } from '../constants';
 
 import baseStyle from '../styles/init';
+import { STORE } from '../store';
 
 const mapDispatchToProps = (dispatch) => ({
   unlockScreen: () => dispatch(unlockScreen()),
@@ -78,10 +79,12 @@ class ChoosePinScreen extends React.Component {
   }
 
   goToNextScreen = () => {
-    // we are just initializing the wallet, so make sure it's not locked when going to AppStack
-    this.props.unlockScreen();
-    this.props.startWalletRequested(this.words, this.state.pin1);
-    this.props.navigation.navigate('Home');
+    STORE.initStorage(this.words, this.state.pin1).then(() => {
+      // we are just initializing the wallet, so make sure it's not locked when going to AppStack
+      this.props.unlockScreen();
+      this.props.startWalletRequested(this.words, this.state.pin1);
+      this.props.navigation.navigate('Home');
+    });
   }
 
   startPinAgain = () => {

--- a/src/store.js
+++ b/src/store.js
@@ -195,6 +195,7 @@ class AsyncStorageStore {
     await storage.saveAccessData(accessData);
   }
 
+  /* eslint-disable class-methods-use-this */
   /**
    * Get a Storage instance for the loaded wallet.
    * @returns {Storage} Storage instance if the wallet is loaded.
@@ -203,6 +204,7 @@ class AsyncStorageStore {
     const store = new HybridStore();
     return new Storage(store);
   }
+  /* eslint-enable class-methods-use-this */
 
   /**
    * Get access data of loaded wallet from async storage.

--- a/src/store.js
+++ b/src/store.js
@@ -107,6 +107,11 @@ class HybridStore extends MemoryStore {
 }
 /* eslint-enable class-methods-use-this */
 
+export function generateStorage() {
+  const store = new HybridStore();
+  return new Storage(store);
+}
+
 /**
  * We use AsyncStorage to persist access data when our app is closed since the
  * wallet-lib does not have a way to choose the persisted wallet as a loaded
@@ -182,7 +187,6 @@ class AsyncStorageStore {
    * @param {string} pin - Will be used as pin and password
    */
   async initStorage(seed, pin) {
-    // Remove old storage if it exists
     const accessData = walletUtils.generateAccessDataFromSeed(
       seed,
       {
@@ -191,20 +195,9 @@ class AsyncStorageStore {
         networkName: NETWORK,
       },
     );
-    const storage = this.getStorage();
+    const storage = generateStorage();
     await storage.saveAccessData(accessData);
   }
-
-  /* eslint-disable class-methods-use-this */
-  /**
-   * Get a Storage instance for the loaded wallet.
-   * @returns {Storage} Storage instance if the wallet is loaded.
-   */
-  getStorage() {
-    const store = new HybridStore();
-    return new Storage(store);
-  }
-  /* eslint-enable class-methods-use-this */
 
   /**
    * Get access data of loaded wallet from async storage.
@@ -212,7 +205,7 @@ class AsyncStorageStore {
    * @returns {IWalletAccessData|null}
    */
   async _getAccessData() {
-    const storage = this.getStorage();
+    const storage = generateStorage();
     return storage.getAccessData();
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -107,11 +107,6 @@ class HybridStore extends MemoryStore {
 }
 /* eslint-enable class-methods-use-this */
 
-export function generateStorage() {
-  const store = new HybridStore();
-  return new Storage(store);
-}
-
 /**
  * We use AsyncStorage to persist access data when our app is closed since the
  * wallet-lib does not have a way to choose the persisted wallet as a loaded
@@ -195,7 +190,7 @@ class AsyncStorageStore {
         networkName: NETWORK,
       },
     );
-    const storage = generateStorage();
+    const storage = this.getStorage();
     await storage.saveAccessData(accessData);
   }
 
@@ -205,9 +200,20 @@ class AsyncStorageStore {
    * @returns {IWalletAccessData|null}
    */
   async _getAccessData() {
-    const storage = generateStorage();
+    const storage = this.getStorage();
     return storage.getAccessData();
   }
+
+  /* eslint-disable class-methods-use-this */
+  /**
+   * Build a new storage instance using the HybridStore
+   * @returns {Storage}
+   */
+  getStorage() {
+    const store = new HybridStore();
+    return new Storage(store);
+  }
+  /* eslint-enable class-methods-use-this */
 
   /**
    * Will attempt to load the access data from either the old or new storage.

--- a/src/store.js
+++ b/src/store.js
@@ -15,6 +15,11 @@ export const ACCESS_DATA_KEY = 'asyncstorage:access';
 export const REGISTERED_TOKENS_KEY = 'asyncstorage:registeredTokens';
 export const STORE_VERSION_KEY = 'asyncstorage:version';
 
+export const walletKeys = [
+  ACCESS_DATA_KEY,
+  REGISTERED_TOKENS_KEY,
+];
+
 /* eslint-disable class-methods-use-this */
 /**
  * The hybrid store will use the mobile native AsyncStorage to persist data and
@@ -113,8 +118,6 @@ class HybridStore extends MemoryStore {
  * was stored in the AsyncStorage.
  */
 class AsyncStorageStore {
-  _storage = null;
-
   version = 1;
 
   constructor() {
@@ -153,6 +156,16 @@ class AsyncStorageStore {
   }
 
   /**
+   * Reset the persisted wallet data
+   */
+  async resetWallet() {
+    // This should delete the access data and registered tokens, the only persisted data
+    await AsyncStorage.multiRemove(walletKeys);
+    // This will delete any wallet data of the legacy storage
+    await this.clearItems(true);
+  }
+
+  /**
    * Check if the wallet is loaded.
    * Only works after preload is called and hathorMemoryStorage is populated.
    *
@@ -170,7 +183,6 @@ class AsyncStorageStore {
    */
   async initStorage(seed, pin) {
     // Remove old storage if it exists
-    this._storage = null;
     const accessData = walletUtils.generateAccessDataFromSeed(
       seed,
       {
@@ -183,16 +195,18 @@ class AsyncStorageStore {
     await storage.saveAccessData(accessData);
   }
 
+  getNewStorage() {
+    const store = new HybridStore();
+    return new Storage(store);
+  }
+
   /**
    * Get a Storage instance for the loaded wallet.
    * @returns {Storage} Storage instance if the wallet is loaded.
    */
   getStorage() {
-    if (!this._storage) {
-      const store = new HybridStore();
-      this._storage = new Storage(store);
-    }
-    return this._storage;
+    const store = new HybridStore();
+    return new Storage(store);
   }
 
   /**

--- a/src/store.js
+++ b/src/store.js
@@ -195,11 +195,6 @@ class AsyncStorageStore {
     await storage.saveAccessData(accessData);
   }
 
-  getNewStorage() {
-    const store = new HybridStore();
-    return new Storage(store);
-  }
-
   /**
    * Get a Storage instance for the loaded wallet.
    * @returns {Storage} Storage instance if the wallet is loaded.


### PR DESCRIPTION
### Acceptance Criteria
- When restarting the wallet we should fully clean any persisted data
- The feature toggle cleanup was interfering with the wallet reset
- Loading the tokens into redux should not use "for await" 
- Remove unnecessary copy of the storage instance.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
