### PR TITLE
fix: unifies application id name

### DIFF
--- a/android/app/_BUCK
+++ b/android/app/_BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.hathormobile",
+    package = "network.hathor.wallet",
 )
 
 android_resource(
     name = "res",
-    package = "com.hathormobile",
+    package = "network.hathor.wallet",
     res = "src/main/res",
 )
 

--- a/android/app/src/debug/java/com/hathormobile/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/com/hathormobile/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.hathormobile;
+package network.hathor.wallet;
 
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.hathormobile">
+  package="network.hathor.wallet">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/android/app/src/main/java/com/hathormobile/MainActivity.java
+++ b/android/app/src/main/java/com/hathormobile/MainActivity.java
@@ -1,4 +1,4 @@
-package com.hathormobile;
+package network.hathor.wallet;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;

--- a/android/app/src/main/java/com/hathormobile/MainApplication.java
+++ b/android/app/src/main/java/com/hathormobile/MainApplication.java
@@ -1,4 +1,4 @@
-package com.hathormobile;
+package network.hathor.wallet;
 
 import android.app.Application;
 import android.content.Context;
@@ -60,7 +60,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.hathormobile.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("network.hathor.wallet.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);

--- a/android/app/src/main/java/com/hathormobile/ReactInstanceHolder.java
+++ b/android/app/src/main/java/com/hathormobile/ReactInstanceHolder.java
@@ -1,4 +1,4 @@
-package com.hathormobile;
+package network.hathor.wallet;
 
 import com.facebook.react.ReactInstanceManager;
 


### PR DESCRIPTION
There are currently two application ids on the android native files. This causes the application not to open correctly on `npm run android` command.

### Acceptance Criteria
- Application id should be unified across all native files


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
