### PR TITLE
Fix: Navigation background colors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,6 +73,7 @@ import TokenDetail from './screens/TokenDetail';
 import UnregisterToken from './screens/UnregisterToken';
 import ReceiveScreen from './screens/Receive';
 import Settings from './screens/Settings';
+import baseStyle from './styles/init';
 
 /**
  * This Stack Navigator is exhibited when there is no wallet initialized on the local storage.
@@ -301,7 +302,7 @@ class _AppStackWrapper extends React.Component {
 
   style = StyleSheet.create({
     auxView: {
-      backgroundColor: 'white',
+      backgroundColor: baseStyle.container.backgroundColor,
       position: 'absolute',
       top: 0,
       bottom: 0,

--- a/src/components/InfoBox.js
+++ b/src/components/InfoBox.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import PropTypes from 'prop-types';
+import { LIGHT_BG_COLOR } from '../constants';
 
 const InfoBox = (props) => {
   /* eslint-disable react/no-array-index-key */
@@ -36,7 +37,7 @@ const styles = StyleSheet.create({
   wrapper: {
     marginVertical: 16,
     padding: 16,
-    backgroundColor: '#f7f7f7',
+    backgroundColor: LIGHT_BG_COLOR,
     borderRadius: 8,
   },
 });

--- a/src/components/OfflineBar.js
+++ b/src/components/OfflineBar.js
@@ -10,6 +10,7 @@ import { StyleSheet, View, Text } from 'react-native';
 import { connect } from 'react-redux';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 import { t } from 'ttag';
+import { ERROR_BG_COLOR } from '../constants';
 
 /**
  * isOnline {bool} Indicates whether the wallet is connected.
@@ -21,7 +22,7 @@ const mapStateToProps = (state) => ({
 class OfflineBar extends React.Component {
   style = StyleSheet.create({
     view: {
-      backgroundColor: '#DE3535',
+      backgroundColor: ERROR_BG_COLOR,
       position: 'absolute',
       left: 0,
       padding: 5,

--- a/src/components/PinInput.js
+++ b/src/components/PinInput.js
@@ -9,6 +9,7 @@ import React from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 
 import NumPad from './NumPad';
+import { ERROR_BG_COLOR } from '../constants';
 
 class PinInput extends React.Component {
   static defaultProps = {
@@ -65,7 +66,7 @@ const styles = StyleSheet.create({
     margin: 8,
   },
   error: {
-    color: '#DE3535',
+    color: ERROR_BG_COLOR,
     marginTop: 8,
     height: 18,
   },

--- a/src/components/TokenSelect.js
+++ b/src/components/TokenSelect.js
@@ -16,7 +16,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import chevronRight from '../assets/icons/chevron-right.png';
 import Spinner from './Spinner';
-import { PRIMARY_COLOR } from '../constants';
+import { LIGHT_BG_COLOR, PRIMARY_COLOR } from '../constants';
 import { getLightBackground, renderValue, isTokenNFT } from '../utils';
 import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
 
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#f7f7f7',
+    backgroundColor: LIGHT_BG_COLOR,
   },
   listWrapper: {
     alignSelf: 'stretch',
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
   },
   symbolWrapper: {
     padding: 4,
-    backgroundColor: '#f7f7f7',
+    backgroundColor: LIGHT_BG_COLOR,
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 8,

--- a/src/constants.js
+++ b/src/constants.js
@@ -77,6 +77,11 @@ export { IS_MULTI_TOKEN, DEFAULT_TOKEN, PRIMARY_COLOR, SENTRY_DSN };
 export const LIGHT_BG_COLOR = '#f7f7f7';
 
 /**
+ * A background color that indicates an error
+ */
+export const ERROR_BG_COLOR = '#DE3535';
+
+/**
  * Minimum job estimation to show to the user in seconds when mining a tx
  */
 export const MIN_JOB_ESTIMATION = 1;

--- a/src/constants.js
+++ b/src/constants.js
@@ -72,6 +72,11 @@ export const PRIVACY_POLICY_URL = 'https://hathor.network/privacy-policy/';
 export { IS_MULTI_TOKEN, DEFAULT_TOKEN, PRIMARY_COLOR, SENTRY_DSN };
 
 /**
+ * A light background color used to create a discreet color change from a white background
+ */
+export const LIGHT_BG_COLOR = '#f7f7f7';
+
+/**
  * Minimum job estimation to show to the user in seconds when mining a tx
  */
 export const MIN_JOB_ESTIMATION = 1;

--- a/src/screens/ChangePin.js
+++ b/src/screens/ChangePin.js
@@ -21,7 +21,7 @@ import FeedbackModal from '../components/FeedbackModal';
 import TextFmt from '../components/TextFmt';
 import baseStyle from '../styles/init';
 import checkIcon from '../assets/images/icCheckBig.png';
-import { PIN_SIZE } from '../constants';
+import { ERROR_BG_COLOR, PIN_SIZE } from '../constants';
 import {
   changePin,
 } from '../utils';
@@ -161,7 +161,7 @@ class ChangePin extends React.Component {
     } else {
       const newState = {};
       newState[stateKey] = pin;
-      newState[stateColorKey] = '#DE3535';
+      newState[stateColorKey] = ERROR_BG_COLOR;
       this.setState(newState);
       setTimeout(() => this.removeOneChar(stateKey, stateColorKey, error), 25);
     }

--- a/src/screens/ChoosePinScreen.js
+++ b/src/screens/ChoosePinScreen.js
@@ -19,7 +19,7 @@ import NewHathorButton from '../components/NewHathorButton';
 import HathorHeader from '../components/HathorHeader';
 import PinInput from '../components/PinInput';
 import { startWalletRequested, unlockScreen } from '../actions';
-import { PIN_SIZE } from '../constants';
+import { ERROR_BG_COLOR, PIN_SIZE } from '../constants';
 
 import baseStyle from '../styles/init';
 import { STORE } from '../store';
@@ -165,7 +165,7 @@ class ChoosePinScreen extends React.Component {
     if (pin2.length === 0) {
       this.setState({ pin2: '', error: t`PIN codes don't match. Try again.` });
     } else {
-      this.setState({ pin2, pin2Color: '#DE3535' });
+      this.setState({ pin2, pin2Color: ERROR_BG_COLOR });
       setTimeout(() => this.removeOneChar(), 25);
     }
   }

--- a/src/screens/CreateTokenDetail.js
+++ b/src/screens/CreateTokenDetail.js
@@ -14,6 +14,7 @@ import HathorHeader from '../components/HathorHeader';
 import TokenDetails from '../components/TokenDetails';
 import SimpleButton from '../components/SimpleButton';
 import closeIcon from '../assets/icons/icCloseActive.png';
+import { LIGHT_BG_COLOR } from '../constants';
 
 /**
  * selectedToken {Object} Select token config {name, symbol, uid}
@@ -36,7 +37,7 @@ class CreateTokenDetail extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: LIGHT_BG_COLOR }}>
         <HathorHeader
           title={t`TOKEN DETAILS`}
           wrapperStyle={{ borderBottomWidth: 0 }}

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -33,7 +33,7 @@ import { Strong, str2jsx, getLightBackground, renderValue, isTokenNFT } from '..
 import chevronUp from '../assets/icons/chevron-up.png';
 import chevronDown from '../assets/icons/chevron-down.png';
 import infoIcon from '../assets/icons/info-circle.png';
-import { IS_MULTI_TOKEN, PRIMARY_COLOR } from '../constants';
+import { IS_MULTI_TOKEN, LIGHT_BG_COLOR, PRIMARY_COLOR } from '../constants';
 import { fetchMoreHistory, updateTokenHistory } from '../actions';
 import Spinner from '../components/Spinner';
 import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
@@ -213,7 +213,7 @@ class MainScreen extends React.Component {
 
     return (
       <SafeAreaView style={{
-        flex: 1, backgroundColor: '#F7F7F7', justifyContent: 'center', alignItems: 'center',
+        flex: 1, backgroundColor: LIGHT_BG_COLOR, justifyContent: 'center', alignItems: 'center',
       }}
       >
         {this.state.modal}

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -25,7 +25,7 @@ import {
   startWalletRequested,
   resetOnLockScreen,
 } from '../actions';
-import { PIN_SIZE } from '../constants';
+import { ERROR_BG_COLOR, PIN_SIZE } from '../constants';
 import { STORE } from '../store';
 import baseStyle from '../styles/init';
 
@@ -245,7 +245,7 @@ class PinScreen extends React.Component {
     if (pin.length === 0) {
       this.setState({ pin: '', error: t`Incorrect PIN Code. Try again.` });
     } else {
-      this.setState({ pin, pinColor: '#DE3535' });
+      this.setState({ pin, pinColor: ERROR_BG_COLOR });
       setTimeout(() => this.removeOneChar(), 25);
     }
   };

--- a/src/screens/PushNotification.js
+++ b/src/screens/PushNotification.js
@@ -13,7 +13,7 @@ import FeedbackModal from '../components/FeedbackModal';
 import errorIcon from '../assets/images/icErrorBig.png';
 import { pushApiReady, pushRegistrationRequested } from '../actions';
 import Spinner from '../components/Spinner';
-import { PUSH_API_STATUS } from '../constants';
+import { LIGHT_BG_COLOR, PUSH_API_STATUS } from '../constants';
 
 /**
  * Check if the api status is loading and if the pin screen is not showing.
@@ -39,7 +39,7 @@ const hasApiStatusFailed = (pushNotification) => {
 const styles = StyleSheet.create({
   view: {
     flex: 1,
-    backgroundColor: '#F7F7F7',
+    backgroundColor: LIGHT_BG_COLOR,
   },
   feedbackModalIcon: {
     height: 105,

--- a/src/screens/RegisterToken.js
+++ b/src/screens/RegisterToken.js
@@ -12,6 +12,7 @@ import { t } from 'ttag';
 import HathorHeader from '../components/HathorHeader';
 import QRCodeReader from '../components/QRCodeReader';
 import SimpleButton from '../components/SimpleButton';
+import { LIGHT_BG_COLOR } from '../constants';
 
 class RegisterToken extends React.Component {
   onSuccess = (e) => {
@@ -30,7 +31,7 @@ class RegisterToken extends React.Component {
 
     return (
       <View style={{
-        flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#f7f7f7', alignSelf: 'stretch',
+        flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: LIGHT_BG_COLOR, alignSelf: 'stretch',
       }}
       >
         <SafeAreaView style={{

--- a/src/screens/Security.js
+++ b/src/screens/Security.js
@@ -21,6 +21,7 @@ import {
 } from '../utils';
 import { HathorList, ListItem, ListMenu } from '../components/HathorList';
 import { lockScreen } from '../actions';
+import { LIGHT_BG_COLOR } from '../constants';
 
 const mapDispatchToProps = (dispatch) => ({
   lockScreen: () => dispatch(lockScreen()),
@@ -71,7 +72,7 @@ export class Security extends React.Component {
     const switchDisabled = !this.supportedBiometry;
     const biometryText = (switchDisabled ? t`No biometry supported` : t`Use ${this.supportedBiometry}`);
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: LIGHT_BG_COLOR }}>
         <HathorHeader
           title={t`SECURITY`}
           onBackPress={() => this.props.navigation.goBack()}

--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -16,6 +16,7 @@ import OfflineBar from '../components/OfflineBar';
 import HathorHeader from '../components/HathorHeader';
 import SimpleButton from '../components/SimpleButton';
 import { getTokenLabel, parseQRCode } from '../utils';
+import { LIGHT_BG_COLOR } from '../constants';
 
 const mapStateToProps = (state) => ({
   wallet: state.wallet,
@@ -115,7 +116,7 @@ class SendScanQRCode extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#f7f7f7' }}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: LIGHT_BG_COLOR }}>
         <HathorHeader
           title={t`SEND`}
           rightElement={<ManualInfoButton />}

--- a/src/screens/TokenDetail.js
+++ b/src/screens/TokenDetail.js
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import { t } from 'ttag';
 import { get } from 'lodash';
 
-import { IS_MULTI_TOKEN } from '../constants';
+import { IS_MULTI_TOKEN, LIGHT_BG_COLOR } from '../constants';
 import { isTokenNFT } from '../utils';
 import HathorHeader from '../components/HathorHeader';
 import SimpleButton from '../components/SimpleButton';
@@ -42,7 +42,7 @@ class TokenDetail extends React.Component {
     const isNFT = isTokenNFT(get(this.props, 'selectedToken.uid'), this.props.tokenMetadata);
 
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: LIGHT_BG_COLOR }}>
         <HathorHeader
           title={t`TOKEN DETAILS`}
           onBackPress={() => this.props.navigation.goBack()}

--- a/src/screens/UnregisterToken.js
+++ b/src/screens/UnregisterToken.js
@@ -23,7 +23,7 @@ import NewHathorButton from '../components/NewHathorButton';
 import TextFmt from '../components/TextFmt';
 import baseStyle from '../styles/init';
 import { getTokenLabel } from '../utils';
-import { PRIMARY_COLOR } from '../constants';
+import { ERROR_BG_COLOR, PRIMARY_COLOR } from '../constants';
 import NavigationService from '../NavigationService';
 
 /**
@@ -50,7 +50,7 @@ class UnregisterToken extends React.Component {
       textError: {
         marginTop: 32,
         marginBottom: 32,
-        color: '#dc3545',
+        color: ERROR_BG_COLOR,
       },
     }) });
 

--- a/src/styles/init.js
+++ b/src/styles/init.js
@@ -5,10 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import { PRIMARY_COLOR } from '../constants';
 
-const defaultBackgroundColor = '#fafafa';
+/**
+ * TODO: Obtain color from the OS scheme
+ * @see: https://reactnavigation.org/docs/5.x/themes/#using-the-operating-system-preferences
+ * @type {string}
+ */
+const defaultBackgroundColor = (Platform.OS === 'ios') ? '#fff' : '#fafafa';
 
 const baseStyle = StyleSheet.create({
   container: {


### PR DESCRIPTION
### Acceptance Criteria
- The navigators from React Navigator 5 should have a background the same color as the light theme on the native OS

### Additional refactors
Centralized two other colors that were being used throughout many files. These will help with an eventual adaptation of the whole application to allow dark mode later.
- A light background, but noticeably darker than white for giving a sense of container border
- A red color used in error messages and the offline panel background

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
