### PR TITLE
fix: Navigator header top padding

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -575,7 +575,10 @@ NavigationService.setTopLevelNavigator(navigationRef);
 const App = () => (
   <SafeAreaProvider>
     <Provider store={store}>
-      <SafeAreaView style={{ flex: 1 }}>
+      <SafeAreaView
+        edges={['top', 'right', 'left']}
+        style={{ flex: 1 }}
+      >
         <NavigationContainer
           ref={navigationRef}
         >

--- a/src/components/HathorHeader.js
+++ b/src/components/HathorHeader.js
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
   wrapper: {
     height: 56,
     flexDirection: 'row',
-    alignItems: 'flex-end',
+    alignItems: 'center',
     borderColor: '#eee',
     paddingHorizontal: 16,
     backgroundColor: baseStyle.title.backgroundColor,

--- a/src/components/TokenSelect.js
+++ b/src/components/TokenSelect.js
@@ -12,7 +12,6 @@ import {
 import { get } from 'lodash';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import chevronRight from '../assets/icons/chevron-right.png';
 import Spinner from './Spinner';
@@ -76,7 +75,7 @@ const TokenSelect = (props) => {
   };
 
   return (
-    <SafeAreaView style={styles.wrapper}>
+    <View style={styles.wrapper}>
       {props.header}
       <View style={styles.listWrapper}>
         <FlatList
@@ -87,7 +86,7 @@ const TokenSelect = (props) => {
           keyExtractor={(item, index) => item.uid}
         />
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/screens/About.js
+++ b/src/screens/About.js
@@ -3,7 +3,6 @@ import {
   Linking,
   ScrollView,
   StyleSheet,
-  SafeAreaView,
   Text,
   TouchableWithoutFeedback,
   View,
@@ -78,7 +77,7 @@ export class About extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: baseStyle.container.backgroundColor }}>
+      <View style={{ flex: 1, backgroundColor: baseStyle.container.backgroundColor }}>
         <HathorHeader
           title={t`ABOUT`}
           onBackPress={() => this.props.navigation.goBack()}
@@ -136,7 +135,7 @@ export class About extends React.Component {
             {' '}WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           </Text>
         </ScrollView>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/BackupWords.js
+++ b/src/screens/BackupWords.js
@@ -10,7 +10,6 @@ import { t } from 'ttag';
 import _ from 'lodash';
 import {
   Image,
-  SafeAreaView,
   StyleSheet,
   Text,
   View,
@@ -216,7 +215,7 @@ class BackupWords extends React.Component {
     };
 
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           onBackPress={() => this.props.navigation.goBack()}
         />
@@ -236,7 +235,7 @@ class BackupWords extends React.Component {
           </View>
           {renderFooter()}
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/ChangePin.js
+++ b/src/screens/ChangePin.js
@@ -9,7 +9,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import {
   Image,
-  SafeAreaView,
   View,
   StyleSheet,
 } from 'react-native';
@@ -232,7 +231,7 @@ class ChangePin extends React.Component {
 
     const step = this.steps[this.state.stepIndex];
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           withBorder
           title={t`CHANGE PIN`}
@@ -242,7 +241,7 @@ class ChangePin extends React.Component {
           {step.render()}
         </View>
         {this.state.done && renderSuccessModal()}
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/ChoosePinScreen.js
+++ b/src/screens/ChoosePinScreen.js
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import {
-  SafeAreaView,
   Text,
   View,
   StyleSheet,
@@ -173,7 +172,7 @@ class ChoosePinScreen extends React.Component {
   render() {
     const step = this.steps[this.state.stepIndex];
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           withLogo
           onBackPress={() => this.props.navigation.goBack()}
@@ -190,7 +189,7 @@ class ChoosePinScreen extends React.Component {
             style={{ marginTop: 16 }}
           />
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/CreateTokenAmount.js
+++ b/src/screens/CreateTokenAmount.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { KeyboardAvoidingView, SafeAreaView, Text, View } from 'react-native';
+import { KeyboardAvoidingView, Text, View } from 'react-native';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
 import { t, jt } from 'ttag';
@@ -110,7 +110,7 @@ class CreateTokenAmount extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
@@ -149,7 +149,7 @@ class CreateTokenAmount extends React.Component {
           </View>
           <OfflineBar style={{ position: 'relative' }} />
         </KeyboardAvoidingView>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/CreateTokenConfirm.js
+++ b/src/screens/CreateTokenConfirm.js
@@ -8,7 +8,6 @@
 import React from 'react';
 import {
   Image,
-  SafeAreaView,
   View,
 } from 'react-native';
 import { connect } from 'react-redux';
@@ -159,7 +158,7 @@ class CreateTokenConfirm extends React.Component {
 
   render() {
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
@@ -227,7 +226,7 @@ class CreateTokenConfirm extends React.Component {
           />
         </View>
         <OfflineBar />
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/CreateTokenDepositNotice.js
+++ b/src/screens/CreateTokenDepositNotice.js
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import {
-  SafeAreaView,
   StyleSheet,
   Text,
   View,
@@ -38,7 +37,7 @@ class CreateTokenDepositNotice extends React.Component {
   render() {
     const depositPercentage = this.props.wallet.storage.getTokenDepositPercentage() * 100;
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.pop()}
@@ -65,7 +64,7 @@ class CreateTokenDepositNotice extends React.Component {
             />
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/CreateTokenDetail.js
+++ b/src/screens/CreateTokenDetail.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { SafeAreaView } from 'react-native';
+import { View } from 'react-native';
 import { connect } from 'react-redux';
 import { t } from 'ttag';
 
@@ -36,7 +36,7 @@ class CreateTokenDetail extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
+      <View style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
         <HathorHeader
           title={t`TOKEN DETAILS`}
           wrapperStyle={{ borderBottomWidth: 0 }}
@@ -46,7 +46,7 @@ class CreateTokenDetail extends React.Component {
           token={this.props.selectedToken}
           contentStyle={{ marginHorizontal: 16, marginTop: 16 }}
         />
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/CreateTokenName.js
+++ b/src/screens/CreateTokenName.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { KeyboardAvoidingView, SafeAreaView, View } from 'react-native';
+import { KeyboardAvoidingView, View } from 'react-native';
 import { t } from 'ttag';
 
 import HathorHeader from '../components/HathorHeader';
@@ -38,7 +38,7 @@ class CreateTokenName extends React.Component {
 
   render() {
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.pop()}
@@ -69,7 +69,7 @@ class CreateTokenName extends React.Component {
           </View>
           <OfflineBar style={{ position: 'relative' }} />
         </KeyboardAvoidingView>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/CreateTokenSymbol.js
+++ b/src/screens/CreateTokenSymbol.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { KeyboardAvoidingView, SafeAreaView, Text, View } from 'react-native';
+import { KeyboardAvoidingView, Text, View } from 'react-native';
 import { t } from 'ttag';
 
 import HathorHeader from '../components/HathorHeader';
@@ -57,7 +57,7 @@ class CreateTokenSymbol extends React.Component {
 
   render() {
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
@@ -89,7 +89,7 @@ class CreateTokenSymbol extends React.Component {
           </View>
           <OfflineBar style={{ position: 'relative' }} />
         </KeyboardAvoidingView>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/InitWallet.js
+++ b/src/screens/InitWallet.js
@@ -15,7 +15,6 @@ import React from 'react';
 import {
   Keyboard,
   KeyboardAvoidingView,
-  SafeAreaView,
   StyleSheet,
   Switch,
   Text,
@@ -55,7 +54,7 @@ class WelcomeScreen extends React.Component {
 
   render() {
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader withLogo />
         <View style={this.style.container}>
           <Text style={this.style.title}>{t`Welcome to Hathor Wallet!`}</Text>
@@ -98,7 +97,7 @@ class WelcomeScreen extends React.Component {
             />
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }
@@ -108,7 +107,7 @@ class InitialScreen extends React.Component {
 
   render() {
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader withLogo />
         <View style={this.style.container}>
           <Text style={this.style.title}>{t`To start,`}</Text>
@@ -134,7 +133,7 @@ class InitialScreen extends React.Component {
             />
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }
@@ -201,7 +200,7 @@ class NewWordsScreen extends React.Component {
     };
 
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           withLogo
           onBackPress={() => this.props.navigation.goBack()}
@@ -221,7 +220,7 @@ class NewWordsScreen extends React.Component {
             />
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }
@@ -300,7 +299,7 @@ class LoadWordsScreen extends React.Component {
   render() {
     return (
       <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }}>
-        <SafeAreaView style={{ flex: 1 }}>
+        <View style={{ flex: 1 }}>
           <HathorHeader
             withLogo
             onBackPress={() => this.props.navigation.goBack()}
@@ -344,7 +343,7 @@ class LoadWordsScreen extends React.Component {
               </View>
             </View>
           </TouchableWithoutFeedback>
-        </SafeAreaView>
+        </View>
       </KeyboardAvoidingView>
     );
   }

--- a/src/screens/LoadHistoryScreen.js
+++ b/src/screens/LoadHistoryScreen.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import {
-  SafeAreaView, StyleSheet, Text, View,
+  StyleSheet, Text, View,
 } from 'react-native';
 import { connect } from 'react-redux';
 import { t } from 'ttag';
@@ -75,9 +75,9 @@ class LoadHistoryScreen extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
         {this.props.loadHistoryStatus.error ? renderError() : renderLoading()}
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -9,7 +9,6 @@ import React from 'react';
 import {
   ActivityIndicator,
   FlatList,
-  SafeAreaView,
   StyleSheet,
   Text,
   View,
@@ -212,7 +211,7 @@ class MainScreen extends React.Component {
     };
 
     return (
-      <SafeAreaView style={{
+      <View style={{
         flex: 1, backgroundColor: '#F7F7F7', justifyContent: 'center', alignItems: 'center',
       }}
       >
@@ -232,7 +231,7 @@ class MainScreen extends React.Component {
           {renderTxHistory()}
         </View>
         <OfflineBar />
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/PaymentRequestDetail.js
+++ b/src/screens/PaymentRequestDetail.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import {
-  SafeAreaView, StyleSheet, Text, View,
+  StyleSheet, Text, View,
 } from 'react-native';
 import { connect } from 'react-redux';
 import { t } from 'ttag';
@@ -83,7 +83,7 @@ class PaymentRequestDetail extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         {renderPaymentConfirm()}
         <HathorHeader
           withBorder
@@ -127,7 +127,7 @@ class PaymentRequestDetail extends React.Component {
           </View>
           <OfflineBar />
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { t } from 'ttag';
 
-import { BackHandler, SafeAreaView, Text, View } from 'react-native';
+import { BackHandler, Text, View } from 'react-native';
 import * as Keychain from 'react-native-keychain';
 import { walletUtils, cryptoUtils } from '@hathor/wallet-lib';
 import SimpleButton from '../components/SimpleButton';
@@ -277,7 +277,7 @@ class PinScreen extends React.Component {
     };
 
     return (
-      <SafeAreaView
+      <View
         style={{
           flex: 1,
           alignItems: 'center',
@@ -304,7 +304,7 @@ class PinScreen extends React.Component {
           error={this.state.error}
         />
         {renderButton()}
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/PushNotification.js
+++ b/src/screens/PushNotification.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   StyleSheet,
-  SafeAreaView,
+  View,
   Switch,
   Image,
 } from 'react-native';
@@ -93,7 +93,7 @@ export default function PushNotification(props) {
   };
 
   return (
-    <SafeAreaView style={styles.view}>
+    <View style={styles.view}>
       <HathorHeader
         title={pageTitleText}
         onBackPress={() => props.navigation.goBack()}
@@ -139,6 +139,6 @@ export default function PushNotification(props) {
           isLast
         />
       </HathorList>
-    </SafeAreaView>
+    </View>
   );
 }

--- a/src/screens/Receive.js
+++ b/src/screens/Receive.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { Dimensions, Keyboard, SafeAreaView } from 'react-native';
+import { Dimensions, Keyboard, View } from 'react-native';
 import { t } from 'ttag';
 
 import { TabBar, TabView } from 'react-native-tab-view';
@@ -100,7 +100,7 @@ class ReceiveScreen extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           title={t`RECEIVE`}
           withBorder
@@ -113,7 +113,7 @@ class ReceiveScreen extends React.Component {
           initialLayout={{ width: Dimensions.get('window').width }}
         />
         <OfflineBar />
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/RegisterToken.js
+++ b/src/screens/RegisterToken.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { SafeAreaView, View } from 'react-native';
+import { View } from 'react-native';
 import { t } from 'ttag';
 
 import HathorHeader from '../components/HathorHeader';
@@ -33,7 +33,7 @@ class RegisterToken extends React.Component {
         flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#f7f7f7', alignSelf: 'stretch',
       }}
       >
-        <SafeAreaView style={{
+        <View style={{
           flex: 1, justifyContent: 'center', alignItems: 'center', alignSelf: 'stretch',
         }}
         >
@@ -52,7 +52,7 @@ class RegisterToken extends React.Component {
               bottomText={t`Scan the token QR code`}
             />
           </View>
-        </SafeAreaView>
+        </View>
       </View>
     );
   }

--- a/src/screens/RegisterTokenManual.js
+++ b/src/screens/RegisterTokenManual.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import {
-  Keyboard, KeyboardAvoidingView, SafeAreaView, Text, View,
+  Keyboard, KeyboardAvoidingView, Text, View,
 } from 'react-native';
 import { t } from 'ttag';
 
@@ -119,7 +119,7 @@ class RegisterTokenManual extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
           <HathorHeader
             withBorder
@@ -150,7 +150,7 @@ class RegisterTokenManual extends React.Component {
             />
           </View>
         </KeyboardAvoidingView>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/ResetWallet.js
+++ b/src/screens/ResetWallet.js
@@ -8,7 +8,6 @@
 import React from 'react';
 import {
   StyleSheet,
-  SafeAreaView,
   Text,
   View,
   Switch,
@@ -100,7 +99,7 @@ class ResetWallet extends React.Component {
 
   render() {
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           title={t`RESET WALLET`}
           onBackPress={this.hideBackButton ? null : () => this.onBackPress()}
@@ -133,7 +132,7 @@ class ResetWallet extends React.Component {
             />
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/Security.js
+++ b/src/screens/Security.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import {
   StyleSheet,
-  SafeAreaView,
+  View,
   Switch,
 } from 'react-native';
 import { connect } from 'react-redux';
@@ -71,7 +71,7 @@ export class Security extends React.Component {
     const switchDisabled = !this.supportedBiometry;
     const biometryText = (switchDisabled ? t`No biometry supported` : t`Use ${this.supportedBiometry}`);
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
+      <View style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
         <HathorHeader
           title={t`SECURITY`}
           onBackPress={() => this.props.navigation.goBack()}
@@ -101,7 +101,7 @@ export class Security extends React.Component {
             isLast
           />
         </HathorList>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/SendAddressInput.js
+++ b/src/screens/SendAddressInput.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { KeyboardAvoidingView, SafeAreaView, View } from 'react-native';
+import { KeyboardAvoidingView, View } from 'react-native';
 import { t } from 'ttag';
 
 import NewHathorButton from '../components/NewHathorButton';
@@ -46,7 +46,7 @@ class SendAddressInput extends React.Component {
 
   render() {
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           withBorder
           title={t`SEND`}
@@ -69,7 +69,7 @@ class SendAddressInput extends React.Component {
           </View>
           <OfflineBar style={{ position: 'relative' }} />
         </KeyboardAvoidingView>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/SendAmountInput.js
+++ b/src/screens/SendAmountInput.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import {
-  KeyboardAvoidingView, SafeAreaView, StyleSheet, Text, View,
+  KeyboardAvoidingView, StyleSheet, Text, View,
 } from 'react-native';
 import { connect } from 'react-redux';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
@@ -145,7 +145,7 @@ class SendAmountInput extends React.Component {
 
     const tokenNameUpperCase = this.state.token.name.toUpperCase();
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           withBorder
           title={t`SEND ${tokenNameUpperCase}`}
@@ -186,7 +186,7 @@ class SendAmountInput extends React.Component {
           </View>
           <OfflineBar style={{ position: 'relative' }} />
         </KeyboardAvoidingView>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/SendConfirmScreen.js
+++ b/src/screens/SendConfirmScreen.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { SafeAreaView, View } from 'react-native';
+import { View } from 'react-native';
 import { connect } from 'react-redux';
 import { t, ngettext, msgid } from 'ttag';
 
@@ -127,7 +127,7 @@ class SendConfirmScreen extends React.Component {
 
     const tokenNameUpperCase = this.token.name.toUpperCase();
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           withBorder
           title={t`SEND ${tokenNameUpperCase}`}
@@ -172,7 +172,7 @@ class SendConfirmScreen extends React.Component {
           />
         </View>
         <OfflineBar />
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { Alert, Platform, SafeAreaView, View } from 'react-native';
+import { Alert, Platform, View } from 'react-native';
 import { request, check, PERMISSIONS, RESULTS } from 'react-native-permissions';
 import { connect } from 'react-redux';
 import { t } from 'ttag';
@@ -115,7 +115,7 @@ class SendScanQRCode extends React.Component {
     );
 
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#f7f7f7' }}>
+      <View style={{ flex: 1, backgroundColor: '#f7f7f7' }}>
         <HathorHeader
           title={t`SEND`}
           rightElement={<ManualInfoButton />}
@@ -131,7 +131,7 @@ class SendScanQRCode extends React.Component {
           )}
         </View>
         <OfflineBar />
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -11,7 +11,6 @@ import { t } from 'ttag';
 import {
   ScrollView,
   StyleSheet,
-  SafeAreaView,
   Text,
   View,
 } from 'react-native';
@@ -79,7 +78,7 @@ export class Settings extends React.Component {
 
   render() {
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: baseStyle.container.backgroundColor }}>
+      <View style={{ flex: 1, backgroundColor: baseStyle.container.backgroundColor }}>
         <ScrollView contentContainerStyle={this.style.scrollView}>
           <View style={this.style.logoView}>
             <Logo
@@ -163,7 +162,7 @@ export class Settings extends React.Component {
           </HathorList>
         </ScrollView>
         <OfflineBar />
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/TokenDetail.js
+++ b/src/screens/TokenDetail.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { SafeAreaView } from 'react-native';
+import { View } from 'react-native';
 import { connect } from 'react-redux';
 import { t } from 'ttag';
 import { get } from 'lodash';
@@ -42,7 +42,7 @@ class TokenDetail extends React.Component {
     const isNFT = isTokenNFT(get(this.props, 'selectedToken.uid'), this.props.tokenMetadata);
 
     return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
+      <View style={{ flex: 1, backgroundColor: '#F7F7F7' }}>
         <HathorHeader
           title={t`TOKEN DETAILS`}
           onBackPress={() => this.props.navigation.goBack()}
@@ -53,7 +53,7 @@ class TokenDetail extends React.Component {
           contentStyle={{ marginHorizontal: 16, marginTop: 16 }}
           isNFT={isNFT}
         />
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/screens/UnregisterToken.js
+++ b/src/screens/UnregisterToken.js
@@ -8,7 +8,6 @@
 import React from 'react';
 import {
   StyleSheet,
-  SafeAreaView,
   Text,
   View,
   Switch,
@@ -108,7 +107,7 @@ class UnregisterToken extends React.Component {
   render() {
     const tokenLabel = getTokenLabel(this.props.selectedToken);
     return (
-      <SafeAreaView style={{ flex: 1 }}>
+      <View style={{ flex: 1 }}>
         <HathorHeader
           title={t`UNREGISTER TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
@@ -141,7 +140,7 @@ class UnregisterToken extends React.Component {
             />
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }


### PR DESCRIPTION
When bumping the Navigation lib to v5 and adding the recommended `react-native-safe-area-context` lib, the previous visual adjustments for the app's top margin became too wide. This PR attempts to fix this with the best solution available.

Further below, two possible solutions are discussed for reference:
- Implementing a negative top margin
- Centralizing the header contents

The implemented solution on this PR's code is the header centralization. The images below explain the tradeoffs between these solutions.

### Acceptance Criteria
- The top padding for the navigators should not be excessively far from the screen top
- The `SafeAreaView` component should only be used on the outer views that interface with the OS directly, not on their children
  - For the current app state, this means the only time this component will be used is on the `RootStack` Stack Navigation instance, on the `App.js` file

## Available Solutions
### Header vertical alignment
This approach only improves the alignment, but leaves the insets sizes to the lib to decide.

The first row displays the Android exhibition, highlighting each of the header's containers:
- A dark yellow for the whole Header
- A blue for the screen title
- A purple for the right button

The second row displays the exhibition on iOS, with a purple color highlighting the "Safe Area" that is added by the OS on the screen top.
![Mobile Padding-V-Align](https://github.com/HathorNetwork/hathor-wallet-mobile/assets/1299409/4f781832-f42b-4e7a-bb6f-9fe45264b9f0)

### Negative top margin
This approach forces the content up against the Safe Area, potentially causing exhibition issues.

The first row shows the exhibition on Android devices. The second row shows the exhibition on iOS, with a purple highlighting the "Safe Area" that is added by the OS on the screen top.
![Mobile Padding-Neg Margin](https://github.com/HathorNetwork/hathor-wallet-mobile/assets/1299409/0fa7f44e-b2bc-48d4-99f3-203e0dce09f4)

### Comparison
![Mobile Padding-Comparison](https://github.com/HathorNetwork/hathor-wallet-mobile/assets/1299409/3ad08b66-e858-49ae-b4a0-689a0fc6fde4)

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.