### PR TITLE
fix: Initial screen rendering

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -646,6 +646,10 @@ const RootStack = () => {
 
   const Stack = createStackNavigator();
 
+  /*
+   * XXX: Screens within the Root Stack have no transition animation, as they are processed before
+   * any user interface.
+   */
   return (
     <Stack.Navigator
       initialRouteName='Decide'
@@ -654,9 +658,27 @@ const RootStack = () => {
         gestureEnabled: false,
       }}
     >
-      <Stack.Screen name='Decide' component={BlankScreen} />
-      <Stack.Screen name='App' component={AppStackWrapper} />
-      <Stack.Screen name='Init' component={InitStack} />
+      <Stack.Screen
+        name='Decide'
+        component={BlankScreen}
+        options={{
+          animationEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name='App'
+        component={AppStackWrapper}
+        options={{
+          animationEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name='Init'
+        component={InitStack}
+        options={{
+          animationEnabled: false,
+        }}
+      />
     </Stack.Navigator>
   );
 };

--- a/src/App.js
+++ b/src/App.js
@@ -598,6 +598,9 @@ class _AppStackWrapper extends React.Component {
 const AppStackWrapper = connect(mapStateToProps, mapDispatchToProps)(_AppStackWrapper);
 
 const BlankScreen = () => null;
+const unanimatedScreenOptions = {
+  animationEnabled: false,
+};
 
 /**
  * This is the main Navigator, evaluating if the wallet is already loaded and navigating to the
@@ -661,23 +664,17 @@ const RootStack = () => {
       <Stack.Screen
         name='Decide'
         component={BlankScreen}
-        options={{
-          animationEnabled: false,
-        }}
+        options={unanimatedScreenOptions}
       />
       <Stack.Screen
         name='App'
         component={AppStackWrapper}
-        options={{
-          animationEnabled: false,
-        }}
+        options={unanimatedScreenOptions}
       />
       <Stack.Screen
         name='Init'
         component={InitStack}
-        options={{
-          animationEnabled: false,
-        }}
+        options={unanimatedScreenOptions}
       />
     </Stack.Navigator>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -605,13 +605,13 @@ const BlankScreen = () => null;
  */
 const RootStack = () => {
   const dispatch = useDispatch();
-  const [isLoaded, setIsLoaded] = useState(false);
+  const [appStatus, setAppStatus] = useState('initializing');
 
   useEffect(() => {
     STORE.preStart()
       .then(() => STORE.walletIsLoaded())
       .then((_isLoaded) => {
-        setIsLoaded(_isLoaded);
+        setAppStatus(_isLoaded ? 'isLoaded' : 'notLoaded');
       })
       .catch((e) => {
         // The promise here is swallowing the error,
@@ -629,15 +629,20 @@ const RootStack = () => {
 
   useEffect(() => {
     // If the wallet is loaded, navigate to the main screen with no option to return to init
-    if (isLoaded) {
-      NavigationService.resetToMain();
-    } else {
-      navigationRef.current.reset({
-        index: 0,
-        routes: [{ name: 'Init' }],
-      });
+    switch (appStatus) {
+      case 'isLoaded':
+        NavigationService.resetToMain();
+        break;
+      case 'notLoaded':
+        navigationRef.current.reset({
+          index: 0,
+          routes: [{ name: 'Init' }],
+        });
+        break;
+      default:
+        // Do not navigate anywhere if the storage has not returned the isLoaded data
     }
-  }, [isLoaded]);
+  }, [appStatus]);
 
   const Stack = createStackNavigator();
 


### PR DESCRIPTION
The "Welcome" screen was being rendered while the storage fetched information about the loaded wallet. A blank screen should be shown instead, to avoid content flickering.

### Acceptance Criteria
- Nothing should be rendered until the application decides whether the Wallet is loaded or not


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
