### PR TITLE
chore: Bump lib to rc-8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-native-fontawesome": "^0.2.7",
-        "@hathor/wallet-lib": "^1.0.0-rc5",
+        "@hathor/wallet-lib": "^1.0.0-rc8",
         "@notifee/react-native": "^5.7.0",
         "@react-native-async-storage/async-storage": "^1.17.7",
         "@react-native-firebase/app": "^16.5.0",
@@ -2426,19 +2426,43 @@
       }
     },
     "node_modules/@hathor/wallet-lib": {
-      "version": "1.0.0-rc6",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-1.0.0-rc6.tgz",
-      "integrity": "sha512-97UXZB/QYDtsqVLM8K+pltEIhHAzqDkoEmV4lFRv5qG1FzOLw4NcAVs0bDVAb6G4E4v3I/LK6UlUdy4T2KAsnQ==",
+      "version": "1.0.0-rc8",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-1.0.0-rc8.tgz",
+      "integrity": "sha512-Ti65+yYkSf5TMNHjS+iX4UQUfq2wPCGBufR5BRfq+PU7wAcxftEgSlZat/Qdcent9/fEE59V0bLg7uH1JeYvEQ==",
       "dependencies": {
         "axios": "^0.21.4",
         "bitcore-lib": "^8.25.10",
         "bitcore-mnemonic": "^8.25.10",
+        "buffer": "^6.0.3",
         "crypto-js": "^3.1.9-1",
         "isomorphic-ws": "^4.0.1",
         "level": "^8.0.0",
         "lodash": "^4.17.21",
         "long": "^4.0.0",
         "ws": "^7.5.9"
+      }
+    },
+    "node_modules/@hathor/wallet-lib/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@hathor/wallet-lib/node_modules/crypto-js": {
@@ -21731,13 +21755,14 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "1.0.0-rc6",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-1.0.0-rc6.tgz",
-      "integrity": "sha512-97UXZB/QYDtsqVLM8K+pltEIhHAzqDkoEmV4lFRv5qG1FzOLw4NcAVs0bDVAb6G4E4v3I/LK6UlUdy4T2KAsnQ==",
+      "version": "1.0.0-rc8",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-1.0.0-rc8.tgz",
+      "integrity": "sha512-Ti65+yYkSf5TMNHjS+iX4UQUfq2wPCGBufR5BRfq+PU7wAcxftEgSlZat/Qdcent9/fEE59V0bLg7uH1JeYvEQ==",
       "requires": {
         "axios": "^0.21.4",
         "bitcore-lib": "^8.25.10",
         "bitcore-mnemonic": "^8.25.10",
+        "buffer": "^6.0.3",
         "crypto-js": "^3.1.9-1",
         "isomorphic-ws": "^4.0.1",
         "level": "^8.0.0",
@@ -21746,6 +21771,15 @@
         "ws": "^7.5.9"
       },
       "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
         "crypto-js": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-native-fontawesome": "^0.2.7",
-    "@hathor/wallet-lib": "^1.0.0-rc5",
+    "@hathor/wallet-lib": "^1.0.0-rc8",
     "@notifee/react-native": "^5.7.0",
     "@react-native-async-storage/async-storage": "^1.17.7",
     "@react-native-firebase/app": "^16.5.0",


### PR DESCRIPTION
### Acceptance Criteria
- The mobile wallet should use the Wallet Lib version `1.0.0-rc8`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
