### PR TITLE
refactor: Remove callback from screen nav params

### DIFF
--- a/src/components/NewPaymentRequest.js
+++ b/src/components/NewPaymentRequest.js
@@ -69,6 +69,13 @@ class NewPaymentRequest extends React.Component {
     this.focusEvent();
   }
 
+  componentDidUpdate(prevProps) {
+    // Sync local state with the updated selected token, if it has changed
+    if (prevProps.selectedToken !== this.props.selectedToken) {
+      this.setState({ token: this.props.selectedToken });
+    }
+  }
+
   focus = () => {
     this.setState({ amount: '', token: this.props.selectedToken });
     this.focusInput();
@@ -78,10 +85,6 @@ class NewPaymentRequest extends React.Component {
     if (this.inputRef.current) {
       this.inputRef.current.focus();
     }
-  }
-
-  onTokenChange = (token) => {
-    this.setState({ token });
   }
 
   getTokenUID = () => (
@@ -115,15 +118,8 @@ class NewPaymentRequest extends React.Component {
 
   onTokenBoxPress = () => {
     this.modalOpened = true;
-    this.props.navigation.navigate(
-      'ChangeToken',
-      {
-        token: this.state.token,
-        onItemPress: (item) => {
-          this.onTokenChange(item);
-        },
-      },
-    );
+    // We will be informed of any token change by the redux `selectedToken` state
+    this.props.navigation.navigate('ChangeToken', { token: this.state.token });
   }
 
   render() {

--- a/src/components/TokenSelect.js
+++ b/src/components/TokenSelect.js
@@ -19,6 +19,22 @@ import { LIGHT_BG_COLOR, PRIMARY_COLOR } from '../constants';
 import { getLightBackground, renderValue, isTokenNFT } from '../utils';
 import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
 
+/**
+ * @typedef TokenBalance
+ * @property {number} data.available
+ * @property {string} status
+ */
+
+/**
+ * @param {Object} props
+ * @param {Record<string,TokenBalance>} props.tokensBalance
+ * @param {{ uid: string }} props.selectedToken
+ * @param {unknown} props.tokenMetadata
+ * @param {unknown} props.tokens
+ * @param {unknown} props.header
+ * @param {boolean} props.renderArrow
+ * @param {function} props.onItemPress
+ */
 const TokenSelect = (props) => {
   const renderItem = ({ item, index }) => {
     const symbolWrapperStyle = [styles.symbolWrapper];

--- a/src/screens/ChangeToken.js
+++ b/src/screens/ChangeToken.js
@@ -10,6 +10,11 @@ import { connect } from 'react-redux';
 
 import HathorHeader from '../components/HathorHeader';
 import TokenSelect from '../components/TokenSelect';
+import { updateSelectedToken } from '../actions';
+
+const mapDispatchToProps = (dispatch) => ({
+  updateSelectedToken: (token) => dispatch(updateSelectedToken(token)),
+});
 
 /**
  * tokens {Array} Array of token configs registered on this wallet
@@ -32,16 +37,11 @@ class ChangeToken extends React.Component {
 
     // Selected token
     this.token = props.route.params.token ?? null;
-
-    // Callback on token press
-    this.onPressCallback = props.route.params.onItemPress ?? null;
   }
 
   onItemPress = (item) => {
-    if (this.onPressCallback) {
-      this.onPressCallback(item);
-    }
-
+    // Update the global selected token and navigate back to the caller screen
+    this.props.updateSelectedToken(item);
     this.props.navigation.goBack();
   }
 
@@ -55,7 +55,7 @@ class ChangeToken extends React.Component {
 
     return (
       <TokenSelect
-        header=<Header />
+        header={<Header />}
         onItemPress={this.onItemPress}
         selectedToken={this.token}
         tokens={this.props.tokens}
@@ -66,4 +66,4 @@ class ChangeToken extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(ChangeToken);
+export default connect(mapStateToProps, mapDispatchToProps)(ChangeToken);

--- a/src/screens/SendAmountInput.js
+++ b/src/screens/SendAmountInput.js
@@ -63,6 +63,13 @@ class SendAmountInput extends React.Component {
     this.focusEvent();
   }
 
+  componentDidUpdate(prevProps) {
+    // Sync local state with the updated selected token, if it has changed
+    if (prevProps.selectedToken !== this.props.selectedToken) {
+      this.setState({ token: this.props.selectedToken });
+    }
+  }
+
   focusInput = () => {
     if (this.inputRef.current) {
       this.inputRef.current.focus();
@@ -73,20 +80,9 @@ class SendAmountInput extends React.Component {
     this.setState({ amount: text, error: null });
   }
 
-  onTokenChange = (token) => {
-    this.setState({ token });
-  }
-
   onTokenBoxPress = () => {
-    this.props.navigation.navigate(
-      'ChangeToken',
-      {
-        token: this.state.token,
-        onItemPress: (item) => {
-          this.onTokenChange(item);
-        },
-      },
-    );
+    // We will be informed of any token change by the redux `selectedToken` state
+    this.props.navigation.navigate('ChangeToken', { token: this.state.token });
   }
 
   onButtonPress = () => {


### PR DESCRIPTION
Since the upgrade to navigation v5, some screen navigations trigger a [`Non-serializable values were found in the navigation state`](https://reactnavigation.org/docs/troubleshooting/#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state) alert.

The solution for this was to remove callbacks from the `ChooseToken` screen and replace it with existing saga flows:
- The `onItemPressed` callback function passed as `prop` was removed
- The `ChooseToken` screen updates directly the `selectedToken` redux state
- The screens that call it listen to that update directly from the state

### Acceptance Criteria
- All navigation parameters on the app should be serializable


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
