### PR TITLE
fix: pin screen labels alignment

### DIFF
--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -282,7 +282,12 @@ class PinScreen extends React.Component {
     };
 
     const renderPinDigits = () => (
-      <View>
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+        }}
+      >
         <View
           style={{
             marginVertical: 16,


### PR DESCRIPTION
By navigating back and forth on the PIN Screen while having the Biometry activated, sometimes the PIN Screen would be misaligned.

By duplicating some style restraints into the newly added `renderPinDigits()` helper method this behavior no longer appears.

### Acceptance Criteria
- Pin Screen should be aligned in all cases

### Demostration
Before ( when incorrect alignment is rendered ), After ( fixed behavior )
![Fix Pin](https://github.com/HathorNetwork/hathor-wallet-mobile/assets/1299409/f090e8ed-d040-42d3-becb-ef06f49af36b)

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
