### PR TITLE
chore: update api level to 33

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         buildToolsVersion = "31.0.0"
         kotlin_version = "1.7.20"
         minSdkVersion = 23
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64


### PR DESCRIPTION
### Acceptance Criteria
- update the manifest to targed the api level 33

The only behavior affected by this API level is the [granular media-permission](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions), however the default behavior provided by the platform is good enough.

Closes: #315 

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
