### PR TITLE
fix: validating if device is registered in the FCM before resetting the push notification

### DIFF
--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -120,9 +120,11 @@ function* createChannelIfNotExists() {
 
 /**
  * Register the device to receive remote messages from FCM.
+ * @param {boolean} showErrorModal if should show error modal in case the device is not registered
+ *
  * @returns {boolean} true if the device is registered on the FCM, false otherwise
  */
-function* confirmDeviceRegistrationOnFirebase() {
+function* confirmDeviceRegistrationOnFirebase(showErrorModal = true) {
   try {
     // Make sure deviceId is registered on the FCM
     if (!messaging().isDeviceRegisteredForRemoteMessages) {
@@ -132,7 +134,9 @@ function* confirmDeviceRegistrationOnFirebase() {
     return true;
   } catch (error) {
     console.error('Error confirming the device is registered on firebase.', error);
-    yield put(onExceptionCaptured(error));
+    if (showErrorModal) {
+      yield put(onExceptionCaptured(error));
+    }
     return false;
   }
 }
@@ -608,6 +612,13 @@ const cleanToken = async () => {
  * This function is responsible for reset the push notification.
  */
 export function* resetPushNotification() {
+  // If we don't have the device registered in the FCM, we shouldn't reset push notification
+  const isDeviceRegistered = yield call(confirmDeviceRegistrationOnFirebase, false);
+  if (!isDeviceRegistered) {
+    console.log('Reset wallet but device is not registered on FCM.');
+    return;
+  }
+
   try {
     // Unregister the device from FCM
     yield call(cleanToken);

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -619,7 +619,7 @@ export function* resetPushNotification() {
       // Unregister the device from FCM
       yield call(cleanToken);
     } catch (error) {
-      console.error('Error clening token from firebase.', error);
+      console.error('Error cleaning token from firebase.', error);
       yield put(onExceptionCaptured(error));
     }
   }

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -614,17 +614,14 @@ const cleanToken = async () => {
 export function* resetPushNotification() {
   // If we don't have the device registered in the FCM, we shouldn't reset push notification
   const isDeviceRegistered = yield call(confirmDeviceRegistrationOnFirebase, false);
-  if (!isDeviceRegistered) {
-    console.log('Reset wallet but device is not registered on FCM.');
-    return;
-  }
-
-  try {
-    // Unregister the device from FCM
-    yield call(cleanToken);
-  } catch (error) {
-    console.error('Error clening token from firebase.', error);
-    yield put(onExceptionCaptured(error));
+  if (isDeviceRegistered) {
+    try {
+      // Unregister the device from FCM
+      yield call(cleanToken);
+    } catch (error) {
+      console.error('Error clening token from firebase.', error);
+      yield put(onExceptionCaptured(error));
+    }
   }
 
   // Clean the store


### PR DESCRIPTION
### Acceptance Criteria
- We should clean the FCM device token only if it's registered.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
