### PR TITLE
Fix: Issues raised on iOS QA

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -361,7 +361,6 @@ const AppStack = () => {
     >
       <Stack.Navigator
         screenOptions={{
-          presentation: 'modal',
           headerShown: false,
         }}
       >

--- a/src/components/AmountTextInput.js
+++ b/src/components/AmountTextInput.js
@@ -17,7 +17,13 @@ class AmountTextInput extends React.Component {
   }
 
   focus = () => {
-    this.inputRef.current.focus();
+    /* After the focus method is called, the screen is still re-rendered at least once more.
+     * Requesting a delay before the focus command ensures it is executed on the final rendering
+     * of the component.
+     */
+    setTimeout(() => {
+      this.inputRef.current.focus();
+    }, 50);
   }
 
   onChangeText = (text) => {

--- a/src/components/HathorHeader.js
+++ b/src/components/HathorHeader.js
@@ -15,6 +15,7 @@ import Logo from './Logo';
 import chevronLeft from '../assets/icons/chevron-left.png';
 import closeIcon from '../assets/icons/icCloseActive.png';
 import baseStyle from '../styles/init';
+import { HEADER_HEIGHT } from '../constants';
 
 const HathorHeader = (props) => {
   const renderBackButton = () => {
@@ -75,7 +76,7 @@ const HathorHeader = (props) => {
 
 const styles = StyleSheet.create({
   wrapper: {
-    height: 56,
+    height: HEADER_HEIGHT,
     flexDirection: 'row',
     alignItems: 'center',
     borderColor: '#eee',
@@ -95,5 +96,4 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-
 export default HathorHeader;

--- a/src/components/ModalConfirmation.js
+++ b/src/components/ModalConfirmation.js
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 
 import checkLogo from '../assets/images/icCheckBig.png';
+import { getKeyboardAvoidingViewTopDistance } from '../utils';
 
 class ModalConfirmation extends React.Component {
   /**
@@ -43,8 +44,10 @@ class ModalConfirmation extends React.Component {
 
     const { height, width } = Dimensions.get('window');
 
-    // Prevent the bottom message to be covered by some android phones
-    const marginBottom = Platform.OS === 'android' ? 40 : 16;
+    // Prevents the bottom message from being covered
+    const marginBottom = Platform.OS === 'ios'
+      ? getKeyboardAvoidingViewTopDistance() + 30
+      : 40;
 
     const styles = StyleSheet.create({
       modal: {

--- a/src/components/ModalConfirmation.js
+++ b/src/components/ModalConfirmation.js
@@ -7,11 +7,10 @@
 
 import React from 'react';
 import {
-  Dimensions, Image, Platform, StyleSheet, TouchableWithoutFeedback, View,
+  Dimensions, Image, StyleSheet, TouchableWithoutFeedback, View,
 } from 'react-native';
 
 import checkLogo from '../assets/images/icCheckBig.png';
-import { getKeyboardAvoidingViewTopDistance } from '../utils';
 
 class ModalConfirmation extends React.Component {
   /**
@@ -42,13 +41,9 @@ class ModalConfirmation extends React.Component {
       return null;
     }
 
-    const { height, width } = Dimensions.get('window');
+    const { width } = Dimensions.get('window');
 
     // Prevents the bottom message from being covered
-    const marginBottom = Platform.OS === 'ios'
-      ? getKeyboardAvoidingViewTopDistance() + 30
-      : 40;
-
     const styles = StyleSheet.create({
       modal: {
         position: 'absolute',
@@ -58,11 +53,11 @@ class ModalConfirmation extends React.Component {
         justifyContent: 'flex-end',
         alignItems: 'center',
         zIndex: 3,
-        height,
-        width,
+        height: '100%',
+        width: '100%',
       },
       innerModal: {
-        marginBottom,
+        marginBottom: 32,
         height: 270,
         backgroundColor: 'white',
         alignItems: 'center',

--- a/src/components/ReceiveMyAddress.js
+++ b/src/components/ReceiveMyAddress.js
@@ -23,8 +23,7 @@ export default function ReceiveMyAddress() {
   const lastSharedAddress = useSelector((state) => state.lastSharedAddress);
 
   const getNextAddress = async () => {
-    // Fetch the address but do not mark it as used yet.
-    const { address, index } = await wallet.getCurrentAddress();
+    const { address, index } = await wallet.getNextAddress();
 
     dispatch(sharedAddressUpdate(address, index));
   };

--- a/src/components/ReceiveMyAddress.js
+++ b/src/components/ReceiveMyAddress.js
@@ -23,7 +23,8 @@ export default function ReceiveMyAddress() {
   const lastSharedAddress = useSelector((state) => state.lastSharedAddress);
 
   const getNextAddress = async () => {
-    const { address, index } = await wallet.getNextAddress();
+    // Fetch the address but do not mark it as used yet.
+    const { address, index } = await wallet.getCurrentAddress();
 
     dispatch(sharedAddressUpdate(address, index));
   };

--- a/src/constants.js
+++ b/src/constants.js
@@ -101,6 +101,12 @@ export const MIN_JOB_ESTIMATION = 1;
 export const PIN_SIZE = 6;
 
 /**
+ * Default Hathor Header height, used for recalculating layout offsets.
+ * @type {number}
+ */
+export const HEADER_HEIGHT = 56;
+
+/**
  * Unleash constants
  */
 export const UNLEASH_URL = 'https://unleash-proxy.b7e6a7f52ee9fefaf0c53e300cfcb014.hathor.network/proxy';

--- a/src/screens/CreateTokenAmount.js
+++ b/src/screens/CreateTokenAmount.js
@@ -114,7 +114,7 @@ class CreateTokenAmount extends React.Component {
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
-          onCancel={() => this.props.navigation.pop()}
+          onCancel={() => this.props.navigation.getParent()?.goBack()}
         />
         <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
           <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>

--- a/src/screens/CreateTokenAmount.js
+++ b/src/screens/CreateTokenAmount.js
@@ -114,7 +114,7 @@ class CreateTokenAmount extends React.Component {
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
-          onCancel={() => this.props.navigation.getParent()?.goBack()}
+          onCancel={() => this.props.navigation.getParent().goBack()}
         />
         <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
           <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>

--- a/src/screens/CreateTokenConfirm.js
+++ b/src/screens/CreateTokenConfirm.js
@@ -162,7 +162,7 @@ class CreateTokenConfirm extends React.Component {
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
-          onCancel={() => this.props.navigation.getParent()?.goBack()}
+          onCancel={() => this.props.navigation.getParent().goBack()}
         />
 
         { this.state.modal && (

--- a/src/screens/CreateTokenConfirm.js
+++ b/src/screens/CreateTokenConfirm.js
@@ -162,7 +162,7 @@ class CreateTokenConfirm extends React.Component {
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
-          onCancel={() => this.props.navigation.pop()}
+          onCancel={() => this.props.navigation.getParent()?.goBack()}
         />
 
         { this.state.modal && (

--- a/src/screens/CreateTokenName.js
+++ b/src/screens/CreateTokenName.js
@@ -42,7 +42,7 @@ class CreateTokenName extends React.Component {
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.pop()}
-          onCancel={() => this.props.navigation.getParent()?.goBack()}
+          onCancel={() => this.props.navigation.getParent().goBack()}
         />
         <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
           <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>

--- a/src/screens/CreateTokenName.js
+++ b/src/screens/CreateTokenName.js
@@ -42,7 +42,7 @@ class CreateTokenName extends React.Component {
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.pop()}
-          onCancel={() => this.props.navigation.pop()}
+          onCancel={() => this.props.navigation.getParent()?.goBack()}
         />
         <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
           <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>

--- a/src/screens/CreateTokenSymbol.js
+++ b/src/screens/CreateTokenSymbol.js
@@ -61,7 +61,7 @@ class CreateTokenSymbol extends React.Component {
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
-          onCancel={() => this.props.navigation.getParent()?.goBack()}
+          onCancel={() => this.props.navigation.getParent().goBack()}
         />
         <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
           <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>

--- a/src/screens/CreateTokenSymbol.js
+++ b/src/screens/CreateTokenSymbol.js
@@ -61,7 +61,7 @@ class CreateTokenSymbol extends React.Component {
         <HathorHeader
           title={t`CREATE TOKEN`}
           onBackPress={() => this.props.navigation.goBack()}
-          onCancel={() => this.props.navigation.pop()}
+          onCancel={() => this.props.navigation.getParent()?.goBack()}
         />
         <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
           <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>

--- a/src/screens/PaymentRequestDetail.js
+++ b/src/screens/PaymentRequestDetail.js
@@ -46,8 +46,9 @@ class PaymentRequestDetail extends React.Component {
   }
 
   async componentDidMount() {
-    // When we create a new payment request we update the address for a new one
-    await this.props.wallet.getNextAddress();
+    // When we create a new payment request, we don't update the address for a new one
+    // This will only happen when it receives a transaction and becomes a used address
+    await this.props.wallet.getCurrentAddress();
   }
 
   componentDidUpdate(prevProps) {

--- a/src/screens/PaymentRequestDetail.js
+++ b/src/screens/PaymentRequestDetail.js
@@ -43,10 +43,6 @@ class PaymentRequestDetail extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      paymentIsConfirmed: false,
-    };
-
     this.modalConfirmation = React.createRef();
   }
 
@@ -58,7 +54,6 @@ class PaymentRequestDetail extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.payment === null && this.props.payment !== null) {
-      this.setState({ paymentIsConfirmed: true });
       if (this.modalConfirmation.current) {
         this.modalConfirmation.current.show();
       }
@@ -74,7 +69,7 @@ class PaymentRequestDetail extends React.Component {
    * Otherwise, goes directly to the Home screen to see the updated wallet.
    */
   onBackClick() {
-    if (this.state.paymentIsConfirmed) {
+    if (this.props.payment !== null) {
       NavigationService.resetToMain();
     } else {
       this.props.navigation.goBack();

--- a/src/screens/PaymentRequestDetail.js
+++ b/src/screens/PaymentRequestDetail.js
@@ -21,6 +21,7 @@ import OfflineBar from '../components/OfflineBar';
 import TextFmt from '../components/TextFmt';
 import { clearInvoice } from '../actions';
 import { getTokenLabel, renderValue, isTokenNFT } from '../utils';
+import NavigationService from '../NavigationService';
 
 /**
  * address {string} Invoice destination address
@@ -42,6 +43,10 @@ class PaymentRequestDetail extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      paymentIsConfirmed: false,
+    };
+
     this.modalConfirmation = React.createRef();
   }
 
@@ -53,6 +58,7 @@ class PaymentRequestDetail extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.payment === null && this.props.payment !== null) {
+      this.setState({ paymentIsConfirmed: true });
       if (this.modalConfirmation.current) {
         this.modalConfirmation.current.show();
       }
@@ -61,6 +67,18 @@ class PaymentRequestDetail extends React.Component {
 
   componentWillUnmount() {
     this.props.dispatch(clearInvoice());
+  }
+
+  /**
+   * If the payment was not yet received, the user goes back to the "Select Amount" screen.
+   * Otherwise, goes directly to the Home screen to see the updated wallet.
+   */
+  onBackClick() {
+    if (this.state.paymentIsConfirmed) {
+      NavigationService.resetToMain();
+    } else {
+      this.props.navigation.goBack();
+    }
   }
 
   render() {
@@ -89,7 +107,7 @@ class PaymentRequestDetail extends React.Component {
         <HathorHeader
           withBorder
           title={t`PAYMENT REQUEST`}
-          onBackPress={() => this.props.navigation.goBack()}
+          onBackPress={() => this.onBackClick()}
         />
         <View style={{
           flex: 1, justifyContent: 'space-between', alignItems: 'center', width: '100%',

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { t } from 'ttag';
 
-import { BackHandler, Text, View } from 'react-native';
+import { BackHandler, Keyboard, Text, View } from 'react-native';
 import * as Keychain from 'react-native-keychain';
 import { walletUtils, cryptoUtils } from '@hathor/wallet-lib';
 import SimpleButton from '../components/SimpleButton';
@@ -76,6 +76,9 @@ class PinScreen extends React.Component {
   }
 
   componentDidMount() {
+    // If the keyboard is being shown, hide it. This screen's keyboard is built differently
+    Keyboard.dismiss();
+
     const supportedBiometry = getSupportedBiometry();
     const biometryEnabled = isBiometryEnabled();
     if (supportedBiometry && biometryEnabled) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,9 +7,9 @@
 
 import hathorLib from '@hathor/wallet-lib';
 import * as Keychain from 'react-native-keychain';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { t } from 'ttag';
-import { KeyboardAvoidingView, Linking, Platform, Text } from 'react-native';
+import { Linking, Platform, Text } from 'react-native';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 import baseStyle from './styles/init';
 import { PRIMARY_COLOR, HEADER_HEIGHT, KEYCHAIN_USER, networkObj } from './constants';

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,12 +7,12 @@
 
 import hathorLib from '@hathor/wallet-lib';
 import * as Keychain from 'react-native-keychain';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { t } from 'ttag';
-import { Linking, Platform, Text } from 'react-native';
+import { KeyboardAvoidingView, Linking, Platform, Text } from 'react-native';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 import baseStyle from './styles/init';
-import { PRIMARY_COLOR, KEYCHAIN_USER, networkObj } from './constants';
+import { PRIMARY_COLOR, HEADER_HEIGHT, KEYCHAIN_USER, networkObj } from './constants';
 import { STORE } from './store';
 import { TxHistory } from './models';
 
@@ -243,10 +243,12 @@ function extractAddress(plainText) {
  * @return {number} The top distance
  */
 export const getKeyboardAvoidingViewTopDistance = () => {
-  if (Platform.OS === 'android') {
-    return getStatusBarHeight();
-  }
-  return 0;
+  const statusBarHeight = getStatusBarHeight();
+  const calculatedHeight = (Platform.OS === 'ios')
+    ? statusBarHeight + HEADER_HEIGHT
+    : statusBarHeight;
+
+  return calculatedHeight;
 };
 
 /**


### PR DESCRIPTION
Solves items from #318 

### Acceptance Criteria
- Navigating to the "Receive" screen no longer marks an address as used
- "Receive Amount" screen automatically focuses on the Keyboard
- Clicking the "X" on the "Create Token" flow goes back to the dashboard screen
- Clicking "Back" on the "Receive Transaction Details" after receiving a tx, goes back to the dashboard screen
- Correct positioning of the "Receive Transaction Details" confirmation modal
- Correct "Safe Area" insets for modals
- Correct "Safe Area" insets for when the keyboard is being displayed
- Dismisses keyboard whenever the "Pin Screen" is displayed

Tested on simulators for devices:
- iPhone 13 mini
- iPhone 13
- iPhone SE (3rd gen)
- iPhone 14 Pro

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
