### PR TITLE
(3) refactor: hardcoded explorer link to networkSettings explorerUrl

### DIFF
--- a/src/components/PublicExplorerListButton.js
+++ b/src/components/PublicExplorerListButton.js
@@ -5,13 +5,15 @@ import icShareActive from '../assets/icons/icShareActive.png';
 import { ListButton } from './HathorList';
 import { COLORS } from '../styles/themes';
 import { useSelector } from 'react-redux';
+import { combineURLs } from '../utils';
 
 export function PublicExplorerListButton(props) {
   const { txId } = props;
   const explorerIcon = <Image source={icShareActive} width={24} height={24} />;
-  const explorerUrl = useSelector((state) => state.networkSettings.explorerUrl);
+  const baseExplorerUrl = useSelector((state) => state.networkSettings.explorerUrl);
+  const txUrl = `transaction/${txId}`;
   // XXX: maybe we should have this on the constants or utils to check the network
-  const explorerLink = `${explorerUrl}transaction/${txId}`;
+  const explorerLink = combineURLs(baseExplorerUrl, txUrl);
 
   return (
     <ListButton title={t`Public Explorer`} button={explorerIcon} onPress={() => { Linking.openURL(explorerLink); }} titleStyle={{ color: COLORS.textColorShadow }} isLast />

--- a/src/components/PublicExplorerListButton.js
+++ b/src/components/PublicExplorerListButton.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { t } from 'ttag';
 import { Image, Linking } from 'react-native';
+import { useSelector } from 'react-redux';
 import icShareActive from '../assets/icons/icShareActive.png';
 import { ListButton } from './HathorList';
 import { COLORS } from '../styles/themes';
-import { useSelector } from 'react-redux';
 import { combineURLs } from '../utils';
 
 export function PublicExplorerListButton(props) {

--- a/src/components/PublicExplorerListButton.js
+++ b/src/components/PublicExplorerListButton.js
@@ -4,12 +4,14 @@ import { Image, Linking } from 'react-native';
 import icShareActive from '../assets/icons/icShareActive.png';
 import { ListButton } from './HathorList';
 import { COLORS } from '../styles/themes';
+import { useSelector } from 'react-redux';
 
 export function PublicExplorerListButton(props) {
   const { txId } = props;
   const explorerIcon = <Image source={icShareActive} width={24} height={24} />;
+  const explorerUrl = useSelector((state) => state.networkSettings.explorerUrl);
   // XXX: maybe we should have this on the constants or utils to check the network
-  const explorerLink = `https://explorer.hathor.network/transaction/${txId}`;
+  const explorerLink = `${explorerUrl}transaction/${txId}`;
 
   return (
     <ListButton title={t`Public Explorer`} button={explorerIcon} onPress={() => { Linking.openURL(explorerLink); }} titleStyle={{ color: COLORS.textColorShadow }} isLast />

--- a/src/utils.js
+++ b/src/utils.js
@@ -370,6 +370,6 @@ export const getPushNotificationSettings = (pushNotification) => {
  */
 export function combineURLs(baseURL, relativeURL) {
   return relativeURL
-    ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
+    ? `${baseURL.replace(/\/+$/, '')}/${relativeURL.replace(/^\/+/, '')}`
     : baseURL;
-};
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -360,3 +360,16 @@ export const getPushNotificationSettings = (pushNotification) => {
     showAmountEnabled
   };
 };
+
+/**
+ * Creates a new URL by combining the specified URLs
+ *
+ * @param {string} baseURL The base URL
+ * @param {string} relativeURL The relative URL
+ * @returns {string} The combined URL
+ */
+export function combineURLs(baseURL, relativeURL) {
+  return relativeURL
+    ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
+    : baseURL;
+};


### PR DESCRIPTION
### Acceptance Criteria
- Use the networkSettings.explorerUrl as the link to the explorer button.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
