### PR TITLE
chore: Dependabot suggested updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,3 @@
+version: 2
+updates:
+  target-branch: "dev"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (6.1.5)
+    activesupport (6.1.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -54,7 +54,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.0)
     escape (0.0.4)
     ethon (0.15.0)
       ffi (>= 1.15.0)
@@ -63,10 +63,10 @@ GEM
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
-    minitest (5.15.0)
+    minitest (5.17.0)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
@@ -76,7 +76,7 @@ GEM
     ruby-macho (2.5.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     xcodeproj (1.21.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -85,7 +85,7 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       claide (>= 1.0.2, < 2.0)
       cocoapods-core (= 1.11.3)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.4.0, < 2.0)
+      cocoapods-downloader (>= 1.6.3, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.4.0, < 2.0)
@@ -45,7 +45,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.5.1)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ First start the Metro bundler:
 
 Then build the app for Android. Make sure you have a device ready, be it on Android Studio's Emulator or a real device.
 
-`npm run android`
+`npm run android` 
 
 If you need to open the Dev Menu on Android Studio Emulator, use `Ctrl + M` or run `adb shell input keyevent 82` in a terminal.
 


### PR DESCRIPTION
### Acceptance Criteria
- All suggestions from DependaBot should be implemented
- Default branch to be watched by DependaBot changed to `dev`

### Implemented Dependabot suggestions
- #184
- #246

## Changelog summaries of updated dependencies
#### [activesupport](https://github.com/rails/rails/blob/v6.1.7.2/activesupport/CHANGELOG.md):
  - Added protection for dangerous characters in names of tags and attributes
  - Avoids regex backtracking

#### cocoapods-downloader
- [1.4.0 -> 1.5.0](https://my.diffend.io/gems/cocoapods-downloader/1.4.0/1.5.0) - Branch encoding fix ( and patch on [1.5.1](https://my.diffend.io/gems/cocoapods-downloader/1.5.0/1.5.1) )
- [1.5.1 -> 1.6.0](https://my.diffend.io/gems/cocoapods-downloader/1.5.1/1.6.0) - Protection against command injection ( and patches [1.6.1](https://my.diffend.io/gems/cocoapods-downloader/1.6.0/1.6.1), [1.6.2](https://my.diffend.io/gems/cocoapods-downloader/1.6.1/1.6.2) and [1.6.3](https://my.diffend.io/gems/cocoapods-downloader/1.6.2/1.6.3) refactoring and documenting this code )

#### concurrent-ruby
- [1.1.10](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md#release-v1110-22-mar-2022) sets Ruby compatibility at 2.2 and [many other](https://my.diffend.io/gems/concurrent-ruby/1.1.9/1.1.10) minor adjustments
- [1.2.0](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md#release-v120-23-jan-2023) sets Ruby compatibility at 2.3 and [other improvements](https://github.com/ruby-concurrency/concurrent-ruby/releases/tag/v1.2.0)

#### i18n
- [1.11.0](https://github.com/ruby-i18n/i18n/releases/tag/v1.11.0) bugfixes and improvements
- [1.12.0](https://github.com/ruby-i18n/i18n/releases/tag/v1.12.0) fix for a pluralization bug added

#### minitest
- [5.15.0 -> 5.16.0](https://my.diffend.io/gems/minitest/5.15.0/5.16.0#d2h-545339) enhancements and bug fixes ( patches [5.16.1](https://my.diffend.io/gems/minitest/5.16.0/5.16.1#d2h-545339), [5.16.2](https://my.diffend.io/gems/minitest/5.16.1/5.16.2#d2h-545339) and [5.16.3](https://my.diffend.io/gems/minitest/5.16.2/5.16.3#d2h-545339) with more bugfixes

#### tzinfo
- [2.0.5](https://github.com/tzinfo/tzinfo/blob/master/CHANGES.md#version-205---19-jul-2022) improvements and security fixes
- [2.0.6](https://github.com/tzinfo/tzinfo/blob/master/CHANGES.md#version-206---28-jan-2023) fixes deprecation warnings

#### zeitwerk
- [2.6.0](https://github.com/fxn/zeitwerk/blob/main/CHANGELOG.md#260-13-june-2022) many improvements and six patches to fix or further improve the code up to [2.6.6](https://github.com/fxn/zeitwerk/blob/main/CHANGELOG.md#266-8-november-2022)


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
