### PR TITLE
refactor: remove blank on pin screen

### DIFF
--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -61,7 +61,6 @@ class PinScreen extends React.Component {
       pin: '',
       pinColor: COLORS.textColor,
       error: null,
-      waitingForBiometry: false,
     };
 
     this.canCancel = false;
@@ -112,8 +111,6 @@ class PinScreen extends React.Component {
   handleBackButton = () => true;
 
   askBiometricId = async () => {
-    // Displaying an empty screen while waiting for the OS biometry response
-    this.setState({ waitingForBiometry: true });
     try {
       /* getGenericPassword will return either `false` or UserCredentials:
        *
@@ -125,13 +122,11 @@ class PinScreen extends React.Component {
       const credentials = await Keychain.getGenericPassword({
         authenticationPrompt: { title: this.biometryText },
       });
-      this.setState({ waitingForBiometry: false });
 
       if (credentials !== false) {
         this.dismiss(credentials.password);
       }
     } catch (e) {
-      this.setState({ waitingForBiometry: false });
       // No need to do anything here as the user can type his PIN
     }
   };
@@ -323,16 +318,7 @@ class PinScreen extends React.Component {
           backgroundColor: baseStyle.container.backgroundColor,
         }}
       >
-        { this.state.waitingForBiometry && (
-        <View
-          style={{
-            flex: 1,
-            alignItems: 'center',
-            backgroundColor: baseStyle.container.backgroundColor,
-          }}
-        />
-        )}
-        { !this.state.waitingForBiometry && renderPinDigits()}
+        {renderPinDigits()}
       </View>
     );
   }


### PR DESCRIPTION
## Motivation

Currently we are displaying a blank screen while the faceid is being asked and only displaying the PIN when it's successful or cancelled, the expected behavior is to display the face id indicator on top of the pin screen

### Acceptance Criteria
- Remove the logic that hides the PIN while the faceid is being requested


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
