### PR TITLE
(15) refactor: network settings actions

### DIFF
--- a/__tests__/sagas/networkSettings.test.ts
+++ b/__tests__/sagas/networkSettings.test.ts
@@ -4,7 +4,7 @@ import { all, effectTypes, fork } from 'redux-saga/effects';
 import createSagaMiddleware, { END, runSaga } from 'redux-saga';
 import { applyMiddleware, createStore } from 'redux';
 import { reducer } from '../../src/reducers/reducer';
-import { networkSettingsUpdate, networkSettingsUpdateSuccess, reloadWalletRequested, types } from '../../src/actions';
+import { networkSettingsUpdateRequest, networkSettingsUpdateSuccess, reloadWalletRequested, types } from '../../src/actions';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { networkSettingsKeyMap } from '../../src/constants';
 import { STORE } from '../../src/store';
@@ -46,47 +46,47 @@ describe('updateNetworkSettings', () => {
         const task = middleware.run(defaultSaga);
 
         Promise.resolve()
-            .then(() => store.dispatch(networkSettingsUpdate(null)))
-            .then(() => store.dispatch(networkSettingsUpdate(undefined)))
-            .then(() => store.dispatch(networkSettingsUpdate({})))
-            .then(() => store.dispatch(networkSettingsUpdate({ explorerUrl: undefined })))
-            .then(() => store.dispatch(networkSettingsUpdate({ explorerUrl: null })))
-            .then(() => store.dispatch(networkSettingsUpdate({ explorerUrl: '' })))
-            .then(() => store.dispatch(networkSettingsUpdate({ explorerUrl: 1 })))
-            .then(() => store.dispatch(networkSettingsUpdate({ explorerUrl: 'invalid.url.com' })))
+            .then(() => store.dispatch(networkSettingsUpdateRequest(null)))
+            .then(() => store.dispatch(networkSettingsUpdateRequest(undefined)))
+            .then(() => store.dispatch(networkSettingsUpdateRequest({})))
+            .then(() => store.dispatch(networkSettingsUpdateRequest({ explorerUrl: undefined })))
+            .then(() => store.dispatch(networkSettingsUpdateRequest({ explorerUrl: null })))
+            .then(() => store.dispatch(networkSettingsUpdateRequest({ explorerUrl: '' })))
+            .then(() => store.dispatch(networkSettingsUpdateRequest({ explorerUrl: 1 })))
+            .then(() => store.dispatch(networkSettingsUpdateRequest({ explorerUrl: 'invalid.url.com' })))
             // explorerUrl is valid, however it must have at least nodeUrl
-            .then(() => store.dispatch(networkSettingsUpdate({ explorerUrl: 'http://localhost:8081/' })))
+            .then(() => store.dispatch(networkSettingsUpdateRequest({ explorerUrl: 'http://localhost:8081/' })))
             // explorerUrl is valid, but explorerServiceUrl is empty
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: '',
             })))
             // explorerUrl is valid, but explorerServiceUrl is invalid 
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'invalid.url.com',
             })))
             // explorer urls are valid, but nodeUrl is empty
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: '',
             })))
             // explorer urls are valid, but nodeUrl is invalid 
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'invalid.url.com'
             })))
             // explorer and node urls are valid, but waletServiceUrl is invalid
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'http://localhost:3000/',
                 walletServiceUrl: 'invalid.url.com'
             })))
             // explorer, node, and wallet service urls are valid, but walletServiceWsUrl is empty
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'http://localhost:3000/',
@@ -94,7 +94,7 @@ describe('updateNetworkSettings', () => {
                 walletServiceWsUrl: ''
             })))
             // explorer, node, and wallet service urls are valid, but walletServiceWsUrl is invalid 
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'http://localhost:3000/',
@@ -102,7 +102,7 @@ describe('updateNetworkSettings', () => {
                 walletServiceWsUrl: 'invalid.url.com'
             })))
             // all urls are valid, except nodeUrl
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'invalid.url.com',
@@ -171,21 +171,21 @@ describe('updateNetworkSettings', () => {
 
         Promise.resolve()
             // calls getFullnodeNetwork 
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'http://localhost:3000/',
             })))
             // calls getWalletServiceNetwork 
             // it will fail because is lacking the walletServiceWsUrl
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'http://localhost:3000/',
                 walletServiceUrl: 'http://localhost:8080/'
             })))
             // calls getWalletServiceNetwork 
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'http://localhost:3000/',
@@ -193,14 +193,14 @@ describe('updateNetworkSettings', () => {
                 walletServiceWsUrl: 'ws://ws.localhost:4040/'
             })))
             // calls getFullnodeNetwork 
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'http://localhost:3000/',
             })))
             // calls getFullnodeNetwork 
             // here the getFullnodeNetwork rejects throwing an error
-            .then(() => store.dispatch(networkSettingsUpdate({
+            .then(() => store.dispatch(networkSettingsUpdateRequest({
                 explorerUrl: 'http://localhost:8081/',
                 explorerServiceUrl: 'http://localhost:8082/',
                 nodeUrl: 'http://localhost:3000/',

--- a/src/actions.js
+++ b/src/actions.js
@@ -128,6 +128,7 @@ export const types = {
   NETWORKSETTINGS_PERSIST_STORE: 'NETWORKSETTINGS_PERSIST_STORE',
   /* It indicates the persistence is complete and the wallet will be reloaded. */
   NETWORKSETTINGS_UPDATE_WAITING: 'NETWORKSETTINGS_UPDATE_WAITING',
+  /* It indicates the update is complete after wallet reloads. */
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORK_SETTINGS_UPDATE_SUCCESS',
   NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
   NETWORKSETTINGS_UPDATE_FAILURE: 'NETWORK_SETTINGS_UPDATE_FAILURE',
@@ -917,20 +918,11 @@ export const networkSettingsUpdateWaiting = () => ({
 });
 
 /**
- * Emits the custom network settings to be stored and persisted.
- * @param {{
- *   stage: string,
- *   network: string,
- *   nodeUrl: string,
- *   explorerUrl: string,
- *   explorerServiceUrl: string,
- *   walletServiceUrl?: string
- *   walletServiceWsUrl?: string
- * }} customNetwork Settings to persist
+ * Emits the success signal after wallet reloads.
+ * It servers as hook for the frontend to provide feedback for the user.
  */
-export const networkSettingsUpdateSuccess = (customNetwork) => ({
+export const networkSettingsUpdateSuccess = () => ({
   type: types.NETWORKSETTINGS_UPDATE_SUCCESS,
-  payload: customNetwork,
 });
 
 /**

--- a/src/actions.js
+++ b/src/actions.js
@@ -130,9 +130,10 @@ export const types = {
   NETWORKSETTINGS_UPDATE_WAITING: 'NETWORKSETTINGS_UPDATE_WAITING',
   /* It indicates the update is complete after wallet reloads. */
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORK_SETTINGS_UPDATE_SUCCESS',
+  /* It indicates the update request has invalid inputs. */
+  NETWORKSETTINGS_UPDATE_INVALID: 'NETWORKSETTINGS_UPDATE_INVALID',
   NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
   NETWORKSETTINGS_UPDATE_FAILURE: 'NETWORK_SETTINGS_UPDATE_FAILURE',
-  NETWORKSETTINGS_UPDATE_ERRORS: 'NETWORK_SETTINGS_UPDATE_ERRORS',
 };
 
 export const featureToggleInitialized = () => ({
@@ -934,8 +935,8 @@ export const networkSettingsUpdateFailure = () => ({
 });
 
 /**
- * Emits errors signal for custom network settings form representing
- * invalid inputs.
+ * Emits invalid signal for custom network settings request inputs.
+ * It means the form should present the invalid message on the corresponding inputs.
  * @param {{
  *   message: string,
  *   nodeUrl: string,
@@ -945,8 +946,8 @@ export const networkSettingsUpdateFailure = () => ({
  *   walletServiceWsUrl?: string
  * }} errors The validation errors from custom network settings form
  */
-export const networkSettingsUpdateErrors = (errors) => ({
-  type: types.NETWORKSETTINGS_UPDATE_ERRORS,
+export const networkSettingsUpdateInvalid = (errors) => ({
+  type: types.NETWORKSETTINGS_UPDATE_INVALID,
   payload: errors,
 });
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -911,7 +911,6 @@ export const networkSettingsPersistStore = (customNetwork) => ({
   payload: customNetwork,
 });
 
-
 /**
  * Emits the waiting signal after persist the custom network.
  * It means the wallet will reload.

--- a/src/actions.js
+++ b/src/actions.js
@@ -930,7 +930,7 @@ export const networkSettingsUpdateSuccess = () => ({
 /**
  * Emits the failure signal for custom network settings request.
  * It means the request couldn't be processed due to internal error.
- * It servers as hook for the frontend to provide feedback for the user.
+ * It serves as hook for the frontend to provide feedback for the user.
  */
 export const networkSettingsUpdateFailure = () => ({
   type: types.NETWORKSETTINGS_UPDATE_FAILURE,

--- a/src/actions.js
+++ b/src/actions.js
@@ -120,7 +120,7 @@ export const types = {
   // NOTE: These actions follows a taxonomy that should be applied
   // to all other actions.
   // See: https://github.com/HathorNetwork/hathor-wallet-mobile/issues/334
-  /* It delivers the user's network settings input from the form. */
+  /* It initiates an update of the network settings based on user input from a form. */
   NETWORKSETTINGS_UPDATE_REQUEST: 'NETWORK_SETTINGS_UPDATE_REQUEST',
   /* It updates the redux state */
   NETWORKSETTINGS_UPDATE_STATE: 'NETWORKSETTINGS_UPDATE_STATE',
@@ -128,7 +128,7 @@ export const types = {
   NETWORKSETTINGS_PERSIST_STORE: 'NETWORKSETTINGS_PERSIST_STORE',
   /* It indicates the persistence is complete and the wallet will be reloaded. */
   NETWORKSETTINGS_UPDATE_WAITING: 'NETWORKSETTINGS_UPDATE_WAITING',
-  /* It indicates the update is complete after wallet reloads. */
+  /* It indicates the update is complete after the wallet reloads. */
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORK_SETTINGS_UPDATE_SUCCESS',
   /* It indicates the update request has invalid inputs. */
   NETWORKSETTINGS_UPDATE_INVALID: 'NETWORKSETTINGS_UPDATE_INVALID',
@@ -912,32 +912,34 @@ export const networkSettingsPersistStore = (customNetwork) => ({
 });
 
 /**
- * Emits the waiting signal after persist the custom network.
- * It means the wallet will reload.
+ * Action indicating that the network settings update process
+ * is in a waiting state.
+ * This is used after persisting custom network configurations,
+ * resulting in a wallet reload.
  */
 export const networkSettingsUpdateWaiting = () => ({
   type: types.NETWORKSETTINGS_UPDATE_WAITING,
 });
 
 /**
- * Emits the success signal after wallet reloads.
- * It servers as hook for the frontend to provide feedback for the user.
+ * Action indicating that the network settings update was successful.
+ * This serves as a hook for the frontend to provide feedback to the user.
  */
 export const networkSettingsUpdateSuccess = () => ({
   type: types.NETWORKSETTINGS_UPDATE_SUCCESS,
 });
 
 /**
- * Emits the failure signal for custom network settings request.
+ * Action indicating a failure state for the custom network settings request.
  * It means the request couldn't be processed due to internal error.
- * It serves as hook for the frontend to provide feedback for the user.
+ * This serves as a hook for the frontend to provide feedback to the user.
  */
 export const networkSettingsUpdateFailure = () => ({
   type: types.NETWORKSETTINGS_UPDATE_FAILURE,
 });
 
 /**
- * Emits invalid signal for custom network settings request inputs.
+ * Action indicating an invalid state for the custom network settings request inputs.
  * It means the form should present the invalid message on the corresponding inputs.
  * @param {{
  *   message: string,

--- a/src/actions.js
+++ b/src/actions.js
@@ -132,8 +132,9 @@ export const types = {
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORK_SETTINGS_UPDATE_SUCCESS',
   /* It indicates the update request has invalid inputs. */
   NETWORKSETTINGS_UPDATE_INVALID: 'NETWORKSETTINGS_UPDATE_INVALID',
-  NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
+  /* It indicates the update request has failed. */
   NETWORKSETTINGS_UPDATE_FAILURE: 'NETWORK_SETTINGS_UPDATE_FAILURE',
+  NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
 };
 
 export const featureToggleInitialized = () => ({
@@ -929,6 +930,7 @@ export const networkSettingsUpdateSuccess = () => ({
 /**
  * Emits the failure signal for custom network settings request.
  * It means the request couldn't be processed due to internal error.
+ * It servers as hook for the frontend to provide feedback for the user.
  */
 export const networkSettingsUpdateFailure = () => ({
   type: types.NETWORKSETTINGS_UPDATE_FAILURE,

--- a/src/actions.js
+++ b/src/actions.js
@@ -122,6 +122,8 @@ export const types = {
   // See: https://github.com/HathorNetwork/hathor-wallet-mobile/issues/334
   /* It delivers the user's network settings input from the form. */
   NETWORKSETTINGS_UPDATE_REQUEST: 'NETWORK_SETTINGS_UPDATE_REQUEST',
+  /* It updates the redux state */
+  NETWORKSETTINGS_UPDATE_STATE: 'NETWORKSETTINGS_UPDATE_STATE',
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORK_SETTINGS_UPDATE_SUCCESS',
   NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
   NETWORKSETTINGS_UPDATE_FAILURE: 'NETWORK_SETTINGS_UPDATE_FAILURE',
@@ -865,6 +867,23 @@ export const setWCConnectionFailed = (failed) => ({
 export const networkSettingsUpdateRequest = (customNetworkRequest) => ({
   type: types.NETWORKSETTINGS_UPDATE_REQUEST,
   payload: customNetworkRequest,
+});
+
+/**
+ * Emits the custom network settings to update the redux store.
+ * @param {{
+ *   stage: string,
+ *   network: string,
+ *   nodeUrl: string,
+ *   explorerUrl: string,
+ *   explorerServiceUrl: string,
+ *   walletServiceUrl?: string
+ *   walletServiceWsUrl?: string
+ * }} customNetwork Settings to persist
+ */
+export const networkSettingsUpdateState = (customNetwork) => ({
+  type: types.NETWORKSETTINGS_UPDATE_STATE,
+  payload: customNetwork,
 });
 
 /**

--- a/src/actions.js
+++ b/src/actions.js
@@ -134,6 +134,7 @@ export const types = {
   NETWORKSETTINGS_UPDATE_INVALID: 'NETWORKSETTINGS_UPDATE_INVALID',
   /* It indicates the update request has failed. */
   NETWORKSETTINGS_UPDATE_FAILURE: 'NETWORK_SETTINGS_UPDATE_FAILURE',
+  /* It updates the redux state of network settings status */
   NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
 };
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -120,7 +120,8 @@ export const types = {
   // NOTE: These actions follows a taxonomy that should be applied
   // to all other actions.
   // See: https://github.com/HathorNetwork/hathor-wallet-mobile/issues/334
-  NETWORKSETTINGS_UPDATE: 'NETWORK_SETTINGS_UPDATE',
+  /* It delivers the user's network settings input from the form. */
+  NETWORKSETTINGS_UPDATE_REQUEST: 'NETWORK_SETTINGS_UPDATE_REQUEST',
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORK_SETTINGS_UPDATE_SUCCESS',
   NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
   NETWORKSETTINGS_UPDATE_FAILURE: 'NETWORK_SETTINGS_UPDATE_FAILURE',
@@ -861,8 +862,8 @@ export const setWCConnectionFailed = (failed) => ({
  *   walletServiceWsUrl?: string
  * }} customNetworkRequest Request input
  */
-export const networkSettingsUpdate = (customNetworkRequest) => ({
-  type: types.NETWORKSETTINGS_UPDATE,
+export const networkSettingsUpdateRequest = (customNetworkRequest) => ({
+  type: types.NETWORKSETTINGS_UPDATE_REQUEST,
   payload: customNetworkRequest,
 });
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -124,6 +124,8 @@ export const types = {
   NETWORKSETTINGS_UPDATE_REQUEST: 'NETWORK_SETTINGS_UPDATE_REQUEST',
   /* It updates the redux state */
   NETWORKSETTINGS_UPDATE_STATE: 'NETWORKSETTINGS_UPDATE_STATE',
+  /* It persists the complete structure of network settings in the app storage and updates the redux store. */
+  NETWORKSETTINGS_PERSIST_STORE: 'NETWORKSETTINGS_PERSIST_STORE',
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORK_SETTINGS_UPDATE_SUCCESS',
   NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
   NETWORKSETTINGS_UPDATE_FAILURE: 'NETWORK_SETTINGS_UPDATE_FAILURE',
@@ -883,6 +885,23 @@ export const networkSettingsUpdateRequest = (customNetworkRequest) => ({
  */
 export const networkSettingsUpdateState = (customNetwork) => ({
   type: types.NETWORKSETTINGS_UPDATE_STATE,
+  payload: customNetwork,
+});
+
+/**
+ * Emits the custom network settings to persist in the app storage and update the redux store.
+ * @param {{
+ *   stage: string,
+ *   network: string,
+ *   nodeUrl: string,
+ *   explorerUrl: string,
+ *   explorerServiceUrl: string,
+ *   walletServiceUrl?: string
+ *   walletServiceWsUrl?: string
+ * }} customNetwork Settings to persist
+ */
+export const networkSettingsPersistStore = (customNetwork) => ({
+  type: types.NETWORKSETTINGS_PERSIST_STORE,
   payload: customNetwork,
 });
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -126,6 +126,8 @@ export const types = {
   NETWORKSETTINGS_UPDATE_STATE: 'NETWORKSETTINGS_UPDATE_STATE',
   /* It persists the complete structure of network settings in the app storage and updates the redux store. */
   NETWORKSETTINGS_PERSIST_STORE: 'NETWORKSETTINGS_PERSIST_STORE',
+  /* It indicates the persistence is complete and the wallet will be reloaded. */
+  NETWORKSETTINGS_UPDATE_WAITING: 'NETWORKSETTINGS_UPDATE_WAITING',
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORK_SETTINGS_UPDATE_SUCCESS',
   NETWORKSETTINGS_UPDATE_READY: 'NETWORK_SETTINGS_UPDATE_READY',
   NETWORKSETTINGS_UPDATE_FAILURE: 'NETWORK_SETTINGS_UPDATE_FAILURE',
@@ -903,6 +905,15 @@ export const networkSettingsUpdateState = (customNetwork) => ({
 export const networkSettingsPersistStore = (customNetwork) => ({
   type: types.NETWORKSETTINGS_PERSIST_STORE,
   payload: customNetwork,
+});
+
+
+/**
+ * Emits the waiting signal after persist the custom network.
+ * It means the wallet will reload.
+ */
+export const networkSettingsUpdateWaiting = () => ({
+  type: types.NETWORKSETTINGS_UPDATE_WAITING,
 });
 
 /**

--- a/src/components/NetworkSettings/NetworkStatusBar.js
+++ b/src/components/NetworkSettings/NetworkStatusBar.js
@@ -14,6 +14,10 @@ import { PRE_SETTINGS_MAINNET } from '../../constants';
 const customNetworkText = t`Custom network`;
 
 function notMainnet(networkSettings) {
+  if (networkSettings.walletServiceUrl) {
+    return !isEqual(networkSettings, PRE_SETTINGS_MAINNET);
+  }
+
   const currNetwork = {
     stage: networkSettings.stage,
     network: networkSettings.network,

--- a/src/components/NetworkSettings/NetworkStatusBar.js
+++ b/src/components/NetworkSettings/NetworkStatusBar.js
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { useSelector } from 'react-redux';
-import { eq } from 'lodash';
+import { useSelector } from "react-redux";
+import { isEqual } from "lodash";
 import { t } from 'ttag';
 import { AlertUI } from '../../styles/themes';
 import { ToplineBar } from '../ToplineBar';
@@ -13,18 +13,18 @@ import { PRE_SETTINGS_MAINNET } from '../../constants';
 
 const customNetworkText = t`Custom network`;
 
-export const NetworkStatusBar = () => {
-  const networkSettings = useSelector((state) => state.networkSettings);
-  if (eq(networkSettings, PRE_SETTINGS_MAINNET)) {
-    return null;
-  }
+function notMainnet(networkSettings) {
+  return !isEqual(networkSettings , PRE_SETTINGS_MAINNET);
+}
 
-  const style = {
-    backgroundColor: AlertUI.primaryColor,
-    color: AlertUI.dark40Color,
-  };
-  const text = `${customNetworkText}: ${networkSettings.network}`;
-  return (
-    <ToplineBar style={style} text={text} />
-  );
+const style = {
+  backgroundColor: AlertUI.primaryColor,
+  color: AlertUI.dark40Color,
+};
+
+export const NetworkStatusBar = () => {
+  const getStatusText = (networkSettings) => customNetworkText+': '+networkSettings.network;
+  const networkSettings = useSelector((state) => state.networkSettings);
+
+  return notMainnet(networkSettings) && (<ToplineBar style={style} text={getStatusText(networkSettings)} />);
 };

--- a/src/components/NetworkSettings/NetworkStatusBar.js
+++ b/src/components/NetworkSettings/NetworkStatusBar.js
@@ -14,7 +14,21 @@ import { PRE_SETTINGS_MAINNET } from '../../constants';
 const customNetworkText = t`Custom network`;
 
 function notMainnet(networkSettings) {
-  return !isEqual(networkSettings, PRE_SETTINGS_MAINNET);
+  const currNetwork = {
+    stage: networkSettings.stage,
+    network: networkSettings.network,
+    nodeUrl: networkSettings.nodeUrl,
+    explorerUrl: networkSettings.explorerUrl,
+    explorerServiceUrl: networkSettings.explorerServiceUrl,
+  };
+  const mainnet = {
+    stage: PRE_SETTINGS_MAINNET.stage,
+    network: PRE_SETTINGS_MAINNET.network,
+    nodeUrl: PRE_SETTINGS_MAINNET.nodeUrl,
+    explorerUrl: PRE_SETTINGS_MAINNET.explorerUrl,
+    explorerServiceUrl: PRE_SETTINGS_MAINNET.explorerServiceUrl,
+  };
+  return !isEqual(currNetwork, mainnet);
 }
 
 const style = {

--- a/src/components/NetworkSettings/NetworkStatusBar.js
+++ b/src/components/NetworkSettings/NetworkStatusBar.js
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { useSelector } from "react-redux";
-import { isEqual } from "lodash";
+import { useSelector } from 'react-redux';
+import { isEqual } from 'lodash';
 import { t } from 'ttag';
 import { AlertUI } from '../../styles/themes';
 import { ToplineBar } from '../ToplineBar';
@@ -14,7 +14,7 @@ import { PRE_SETTINGS_MAINNET } from '../../constants';
 const customNetworkText = t`Custom network`;
 
 function notMainnet(networkSettings) {
-  return !isEqual(networkSettings , PRE_SETTINGS_MAINNET);
+  return !isEqual(networkSettings, PRE_SETTINGS_MAINNET);
 }
 
 const style = {
@@ -23,8 +23,10 @@ const style = {
 };
 
 export const NetworkStatusBar = () => {
-  const getStatusText = (networkSettings) => customNetworkText+': '+networkSettings.network;
+  const getStatusText = (networkSettings) => `${customNetworkText}: ${networkSettings.network}`;
   const networkSettings = useSelector((state) => state.networkSettings);
 
-  return notMainnet(networkSettings) && (<ToplineBar style={style} text={getStatusText(networkSettings)} />);
+  return notMainnet(networkSettings) && (
+    <ToplineBar style={style} text={getStatusText(networkSettings)} />
+  );
 };

--- a/src/components/NetworkSettings/NetworkStatusBar.js
+++ b/src/components/NetworkSettings/NetworkStatusBar.js
@@ -14,10 +14,17 @@ import { PRE_SETTINGS_MAINNET } from '../../constants';
 const customNetworkText = t`Custom network`;
 
 function notMainnet(networkSettings) {
+  // If the networkSettings has a walletServiceUrl, then
+  // we should run a full check against the mainnet presettings.
+  // This is important because the wallet service has precedence
+  // over fullnode.
   if (networkSettings.walletServiceUrl) {
     return !isEqual(networkSettings, PRE_SETTINGS_MAINNET);
   }
 
+  // In the absence of walletServiceUrl we can remove wallet
+  // service URLs from the equality check against the mainnet
+  // presettings.
   const currNetwork = {
     stage: networkSettings.stage,
     network: networkSettings.network,

--- a/src/constants.js
+++ b/src/constants.js
@@ -209,6 +209,7 @@ export const NETWORKSETTINGS_STATUS = {
   READY: 'ready',
   FAILED: 'failed',
   LOADING: 'loading',
+  WAITING: 'waiting',
 };
 
 /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -210,6 +210,7 @@ export const NETWORKSETTINGS_STATUS = {
   FAILED: 'failed',
   LOADING: 'loading',
   WAITING: 'waiting',
+  SUCCESSFUL: 'successful',
 };
 
 /**

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -327,6 +327,8 @@ export const reducer = (state = initialState, action) => {
       return onPushReset(state);
     case types.EXCEPTION_CAPTURED:
       return onExceptionCaptured(state, action);
+    case types.RELOAD_WALLET_REQUESTED:
+      return onReloadWalletRequested(state);
     case types.WALLET_RELOADING:
       return onWalletReloading(state);
     case types.SHARED_ADDRESS_UPDATE:
@@ -1031,6 +1033,16 @@ export const onExceptionCaptured = (state, { payload }) => {
     },
   };
 };
+
+/**
+ * On wallet reload, tokens data will be reloaded as well.
+ */
+export const onReloadWalletRequested = (state) => ({
+  ...state,
+  tokensHistory: initialState.tokensHistory,
+  tokensBalance: initialState.tokensBalance,
+  loadHistoryStatus: initialState.loadHistoryStatus,
+});
 
 const onWalletReloading = (state) => ({
   ...state,

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -347,6 +347,8 @@ export const reducer = (state = initialState, action) => {
       return onSetWCConnectionFailed(state, action);
     case types.NETWORKSETTINGS_UPDATE_REQUEST:
       return onNetworkSettingsUpdateRequest(state);
+    case types.NETWORKSETTINGS_UPDATE_STATE:
+      return onNetworkSettingsUpdateState(state, action);
     case types.NETWORKSETTINGS_UPDATE_SUCCESS:
       return onNetworkSettingsUpdateSucess(state, action);
     case types.NETWORKSETTINGS_UPDATE_READY:
@@ -1089,6 +1091,15 @@ export const onSetWCConnectionFailed = (state, { payload }) => ({
 export const onNetworkSettingsUpdateRequest = (state) => ({
   ...state,
   networkSettingsStatus: NETWORKSETTINGS_STATUS.LOADING,
+});
+
+/**
+ * @param {Object} action.payload The network settings emitted in saga
+ * @see networkSettingsUpdateState customNetwork
+ */
+export const onNetworkSettingsUpdateState = (state, { payload }) => ({
+  ...state,
+  networkSettings: payload,
 });
 
 /**

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -354,7 +354,7 @@ export const reducer = (state = initialState, action) => {
     case types.NETWORKSETTINGS_UPDATE_WAITING:
       return onNetworkSettingsUpdateWaiting(state);
     case types.NETWORKSETTINGS_UPDATE_SUCCESS:
-      return onNetworkSettingsUpdateSucess(state, action);
+      return onNetworkSettingsUpdateSuccess(state);
     case types.NETWORKSETTINGS_UPDATE_READY:
       return onNetworkSettingsUpdateReady(state);
     case types.NETWORKSETTINGS_UPDATE_FAILURE:
@@ -1125,13 +1125,11 @@ export const onNetworkSettingsUpdateWaiting = (state) => ({
 });
 
 /**
- * @param {Object} action.payload The network settings emitted in saga
- * @see updateNetworkSettings
+ * Set `SUCCESSFUL` state on network settings status.
  */
-export const onNetworkSettingsUpdateSucess = (state, { payload }) => ({
+export const onNetworkSettingsUpdateSuccess = (state) => ({
   ...state,
-  networkSettings: payload,
-  networkSettingsStatus: NETWORKSETTINGS_STATUS.LOADING,
+  networkSettingsStatus: NETWORKSETTINGS_STATUS.SUCCESSFUL,
 });
 
 /**

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -207,7 +207,7 @@ const initialState = {
     ...FEATURE_TOGGLE_DEFAULTS,
   },
   networkSettings: PRE_SETTINGS_MAINNET,
-  networkSettingsErrors: {},
+  networkSettingsInvalid: {},
   networkSettingsStatus: NETWORKSETTINGS_STATUS.READY,
 };
 
@@ -359,8 +359,8 @@ export const reducer = (state = initialState, action) => {
       return onNetworkSettingsUpdateReady(state);
     case types.NETWORKSETTINGS_UPDATE_FAILURE:
       return onNetworkSettingsUpdateFailure(state);
-    case types.NETWORKSETTINGS_UPDATE_ERRORS:
-      return onNetworkSettingsUpdateErrors(state, action);
+    case types.NETWORKSETTINGS_UPDATE_INVALID:
+      return onNetworkSettingsUpdateInvalid(state, action);
     default:
       return state;
   }
@@ -1150,8 +1150,12 @@ export const onNetworkSettingsUpdateFailure = (state) => ({
   networkSettingsStatus: NETWORKSETTINGS_STATUS.FAILED
 });
 
-export const onNetworkSettingsUpdateErrors = (state, { payload }) => ({
+/**
+ * @param {Object} action.payload The errors from network settings input validation
+ * @see networkSettingsUpdateInvalid errors
+ */
+export const onNetworkSettingsUpdateInvalid = (state, { payload }) => ({
   ...state,
-  networkSettingsErrors: payload,
+  networkSettingsInvalid: payload,
   networkSettingsStatus: NETWORKSETTINGS_STATUS.READY,
 });

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -351,6 +351,8 @@ export const reducer = (state = initialState, action) => {
       return onNetworkSettingsUpdateState(state, action);
     case types.NETWORKSETTINGS_PERSIST_STORE:
       return onNetworkSettingsPersistStore(state, action);
+    case types.NETWORKSETTINGS_UPDATE_WAITING:
+      return onNetworkSettingsUpdateWaiting(state);
     case types.NETWORKSETTINGS_UPDATE_SUCCESS:
       return onNetworkSettingsUpdateSucess(state, action);
     case types.NETWORKSETTINGS_UPDATE_READY:
@@ -1114,6 +1116,13 @@ export const onNetworkSettingsPersistStore = (state, { payload }) => ({
   networkSettingsStatus: NETWORKSETTINGS_STATUS.LOADING,
 });
 
+/**
+ * Set `WAITING` state on network settings status.
+ */
+export const onNetworkSettingsUpdateWaiting = (state) => ({
+  ...state,
+  networkSettingsStatus: NETWORKSETTINGS_STATUS.WAITING,
+});
 
 /**
  * @param {Object} action.payload The network settings emitted in saga

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -345,8 +345,8 @@ export const reducer = (state = initialState, action) => {
       return onSetWalletConnectSessions(state, action);
     case types.WC_SET_CONNECTION_FAILED:
       return onSetWCConnectionFailed(state, action);
-    case types.NETWORKSETTINGS_UPDATE:
-      return onNetworkSettingsUpdate(state);
+    case types.NETWORKSETTINGS_UPDATE_REQUEST:
+      return onNetworkSettingsUpdateRequest(state);
     case types.NETWORKSETTINGS_UPDATE_SUCCESS:
       return onNetworkSettingsUpdateSucess(state, action);
     case types.NETWORKSETTINGS_UPDATE_READY:
@@ -1086,7 +1086,7 @@ export const onSetWCConnectionFailed = (state, { payload }) => ({
  * @param {Object} action.payload The network settings emitted in saga
  * @see updateNetworkSettings
  */
-export const onNetworkSettingsUpdate = (state) => ({
+export const onNetworkSettingsUpdateRequest = (state) => ({
   ...state,
   networkSettingsStatus: NETWORKSETTINGS_STATUS.LOADING,
 });

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -349,6 +349,8 @@ export const reducer = (state = initialState, action) => {
       return onNetworkSettingsUpdateRequest(state);
     case types.NETWORKSETTINGS_UPDATE_STATE:
       return onNetworkSettingsUpdateState(state, action);
+    case types.NETWORKSETTINGS_PERSIST_STORE:
+      return onNetworkSettingsPersistStore(state, action);
     case types.NETWORKSETTINGS_UPDATE_SUCCESS:
       return onNetworkSettingsUpdateSucess(state, action);
     case types.NETWORKSETTINGS_UPDATE_READY:
@@ -1101,6 +1103,17 @@ export const onNetworkSettingsUpdateState = (state, { payload }) => ({
   ...state,
   networkSettings: payload,
 });
+
+/**
+ * @param {Object} action.payload The network settings emitted in saga
+ * @see networkSettingsPersistStore customNetwork
+ */
+export const onNetworkSettingsPersistStore = (state, { payload }) => ({
+  ...state,
+  networkSettings: payload,
+  networkSettingsStatus: NETWORKSETTINGS_STATUS.LOADING,
+});
+
 
 /**
  * @param {Object} action.payload The network settings emitted in saga

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1142,8 +1142,7 @@ export const onNetworkSettingsUpdateReady = (state) => ({
 });
 
 /**
- * @param {Object} action.payload The errors from network settings input validation
- * @see updateNetworkSettings
+ * Set `FAILED` state on network settings status.
  */
 export const onNetworkSettingsUpdateFailure = (state) => ({
   ...state,

--- a/src/sagas/helpers.js
+++ b/src/sagas/helpers.js
@@ -251,5 +251,9 @@ export function disableFeaturesIfNeeded(customNetworkSettings, currentFeatureTog
 export function getNetworkSettings(state) {
   // The state is always present, but the stored network settings
   // has precedence, once it indicates a custom network.
-  return STORE.getItem(networkSettingsKeyMap.networkSettings) ?? state.networkSettings;
+  let networkSettings = STORE.getItem(networkSettingsKeyMap.networkSettings);
+  if (!networkSettings) {
+    networkSettings = state.networkSettings;
+  }
+  return networkSettings;
 }

--- a/src/sagas/helpers.js
+++ b/src/sagas/helpers.js
@@ -251,9 +251,5 @@ export function disableFeaturesIfNeeded(customNetworkSettings, currentFeatureTog
 export function getNetworkSettings(state) {
   // The state is always present, but the stored network settings
   // has precedence, once it indicates a custom network.
-  let networkSettings = STORE.getItem(networkSettingsKeyMap.networkSettings);
-  if (!networkSettings) {
-    networkSettings = state.networkSettings;
-  }
-  return networkSettings;
+  return STORE.getItem(networkSettingsKeyMap.networkSettings) ?? state.networkSettings;
 }

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -11,7 +11,8 @@ import {
   networkSettingsUpdateWaiting,
   types,
   reloadWalletRequested,
-  onExceptionCaptured
+  onExceptionCaptured,
+  networkSettingsUpdateReady
 } from '../actions';
 import {
   NETWORK,
@@ -41,6 +42,8 @@ export function* initNetworkSettings() {
   const status = yield select((state) => state.networkSettingsStatus);
   if (status === NETWORKSETTINGS_STATUS.WAITING) {
     yield put(networkSettingsUpdateSuccess());
+  } else {
+    yield put(networkSettingsUpdateReady());
   }
 }
 

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -8,7 +8,6 @@ import {
   networkSettingsPersistStore,
   networkSettingsUpdateInvalid,
   networkSettingsUpdateFailure,
-  networkSettingsUpdateReady,
   networkSettingsUpdateState,
   networkSettingsUpdateSuccess,
   networkSettingsUpdateWaiting,

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -8,6 +8,7 @@ import {
   networkSettingsUpdateErrors,
   networkSettingsUpdateFailure,
   networkSettingsUpdateReady,
+  networkSettingsUpdateState,
   networkSettingsUpdateSuccess,
   reloadWalletRequested,
   types
@@ -24,7 +25,7 @@ import { STORE } from '../store';
 export function* initNetworkSettings() {
   const customNetwork = STORE.getItem(networkSettingsKeyMap.networkSettings);
   if (customNetwork) {
-    yield put(networkSettingsUpdateSuccess(customNetwork));
+    yield put(networkSettingsUpdateState(customNetwork));
   }
 }
 

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -138,7 +138,6 @@ export function* updateNetworkSettings(action) {
     try {
       network = yield call(getFullnodeNetwork);
     } catch (err) {
-      // NOTE: Keep the console?
       console.error('Error calling the fullnode while trying to get network details in updateNetworkSettings effect..', err);
       rollbackConfigUrls(backupUrl);
       yield put(networkSettingsUpdateFailure());

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -41,8 +41,12 @@ export function* initNetworkSettings() {
 
   const status = yield select((state) => state.networkSettingsStatus);
   if (status === NETWORKSETTINGS_STATUS.WAITING) {
+    // This branch completes the network update by delivering
+    // a success feedback to the user.
     yield put(networkSettingsUpdateSuccess());
   } else {
+    // This branch is a fallback to set network status to READY
+    // after wallet initialization.
     yield put(networkSettingsUpdateReady());
   }
 }

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -3,7 +3,15 @@ import { config } from '@hathor/wallet-lib';
 import { isEmpty } from 'lodash';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { t } from 'ttag';
-import { featureToggleUpdate, networkSettingsUpdateErrors, networkSettingsUpdateFailure, networkSettingsUpdateReady, networkSettingsUpdateSuccess, reloadWalletRequested, types } from '../actions';
+import {
+  featureToggleUpdate,
+  networkSettingsUpdateErrors,
+  networkSettingsUpdateFailure,
+  networkSettingsUpdateReady,
+  networkSettingsUpdateSuccess,
+  reloadWalletRequested,
+  types
+} from '../actions';
 import { HTTP_REQUEST_TIMEOUT, NETWORK, networkSettingsKeyMap, NETWORK_TESTNET, STAGE, STAGE_DEV_PRIVNET, STAGE_TESTNET, WALLET_SERVICE_REQUEST_TIMEOUT } from '../constants';
 import { getFullnodeNetwork, getWalletServiceNetwork } from './helpers';
 import { STORE } from '../store';
@@ -250,7 +258,7 @@ export function* cleanNetworkSettings() {
 export function* saga() {
   yield all([
     takeEvery(types.START_WALLET_SUCCESS, initNetworkSettings),
-    takeEvery(types.NETWORKSETTINGS_UPDATE, updateNetworkSettings),
+    takeEvery(types.NETWORKSETTINGS_UPDATE_REQUEST, updateNetworkSettings),
     takeEvery(types.NETWORKSETTINGS_UPDATE_SUCCESS, persistNetworkSettings),
     takeEvery(types.RESET_WALLET, cleanNetworkSettings),
   ]);

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -158,6 +158,7 @@ export function* updateNetworkSettings(action) {
 
   // Fail after try get network from fullnode
   if (!network) {
+    console.warn('The network could not be found.');
     yield put(networkSettingsUpdateFailure());
     return;
   }
@@ -256,7 +257,13 @@ export function* persistNetworkSettings(action) {
  * Deletes the network settings from the application storage.
  */
 export function* cleanNetworkSettings() {
-  STORE.removeItem(networkSettingsKeyMap.networkSettings);
+  try {
+    STORE.removeItem(networkSettingsKeyMap.networkSettings);
+  }
+  catch (err) {
+    console.error('Error while deleting the custom network settings from app storage.', err);
+    yield 1;
+  }
   yield 0;
 }
 

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -15,19 +15,22 @@ import {
   reloadWalletRequested,
   types
 } from '../actions';
-import { HTTP_REQUEST_TIMEOUT, NETWORK, networkSettingsKeyMap, NETWORK_TESTNET, STAGE, STAGE_DEV_PRIVNET, STAGE_TESTNET, WALLET_SERVICE_REQUEST_TIMEOUT } from '../constants';
+import { HTTP_REQUEST_TIMEOUT, NETWORK, networkSettingsKeyMap, NETWORKSETTINGS_STATUS, NETWORK_TESTNET, STAGE, STAGE_DEV_PRIVNET, STAGE_TESTNET, WALLET_SERVICE_REQUEST_TIMEOUT } from '../constants';
 import { getFullnodeNetwork, getWalletServiceNetwork } from './helpers';
 import { STORE } from '../store';
 
 /**
- * Initialize network settings saga.
- *
- * It looks up a stored network settings to update the redux state.
+ * Initialize the network settings saga when the wallet starts successfully.
  */
 export function* initNetworkSettings() {
   const customNetwork = STORE.getItem(networkSettingsKeyMap.networkSettings);
   if (customNetwork) {
     yield put(networkSettingsUpdateState(customNetwork));
+  }
+
+  const status = yield select((state) => state.networkSettingsStatus);
+  if (status === NETWORKSETTINGS_STATUS.WAITING) {
+    yield put(networkSettingsUpdateSuccess());
   }
 }
 

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -254,7 +254,7 @@ export function* persistNetworkSettings(action) {
   if (!wallet) {
     // If we fall into this situation, the app should be killed
     // for the custom new network settings take effect.
-    const errMsg = 'Wallet not found while trying to persist the custom network settings.';
+    const errMsg = t`Wallet not found while trying to persist the custom network settings.`;
     console.warn(errMsg);
     yield put(onExceptionCaptured(errMsg, /* isFatal */ true));
     return;

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -11,6 +11,7 @@ import {
   networkSettingsUpdateReady,
   networkSettingsUpdateState,
   networkSettingsUpdateSuccess,
+  networkSettingsUpdateWaiting,
   reloadWalletRequested,
   types
 } from '../actions';
@@ -248,7 +249,7 @@ export function* persistNetworkSettings(action) {
     yield put(reloadWalletRequested());
   }
 
-  yield put(networkSettingsUpdateReady());
+  yield put(networkSettingsUpdateWaiting());
 }
 
 /**

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -6,7 +6,7 @@ import { t } from 'ttag';
 import {
   featureToggleUpdate,
   networkSettingsPersistStore,
-  networkSettingsUpdateErrors,
+  networkSettingsUpdateInvalid,
   networkSettingsUpdateFailure,
   networkSettingsUpdateReady,
   networkSettingsUpdateState,
@@ -61,53 +61,50 @@ export function* updateNetworkSettings(action) {
     walletServiceWsUrl,
   } = action.payload || {};
 
-  const errors = {};
+  const invalidPayload = {};
 
   // validates input emptyness
   if (isEmpty(action.payload)) {
-    errors.message = t`Custom Network Settings cannot be empty.`;
+    invalidPayload.message = t`Custom Network Settings cannot be empty.`;
   }
 
   // validates explorerUrl
   // - required
   // - should have a valid URL
   if (isEmpty(explorerUrl) || invalidUrl(explorerUrl)) {
-    errors.explorerUrl = t`explorerUrl should be a valid URL.`;
+    invalidPayload.explorerUrl = t`explorerUrl should be a valid URL.`;
   }
 
   // validates explorerServiceUrl
   // - required
   // - should have a valid URL
   if (isEmpty(explorerServiceUrl) || invalidUrl(explorerServiceUrl)) {
-    errors.explorerServiceUrl = t`explorerServiceUrl should be a valid URL.`;
+    invalidPayload.explorerServiceUrl = t`explorerServiceUrl should be a valid URL.`;
   }
 
   // validates nodeUrl
   // - required
   // - should have a valid URl
   if (isEmpty(nodeUrl) || invalidUrl(nodeUrl)) {
-    errors.nodeUrl = t`nodeUrl should be a valid URL.`;
+    invalidPayload.nodeUrl = t`nodeUrl should be a valid URL.`;
   }
 
   // validates walletServiceUrl
   // - optional
   // - should have a valid URL, if given
   if (walletServiceUrl && invalidUrl(walletServiceUrl)) {
-    errors.walletServiceUrl = t`walletServiceUrl should be a valid URL.`;
+    invalidPayload.walletServiceUrl = t`walletServiceUrl should be a valid URL.`;
   }
 
   // validates walletServiceWsUrl
   // - conditionally required
   // - should have a valid URL, if walletServiceUrl is given
   if (walletServiceUrl && invalidUrl(walletServiceWsUrl)) {
-    errors.walletServiceWsUrl = t`walletServiceWsUrl should be a valid URL.`;
+    invalidPayload.walletServiceWsUrl = t`walletServiceWsUrl should be a valid URL.`;
   }
 
-  // TODO: Refactor by segregating Failure from Errors
-  // - create networkSettingsUpdateErrors
-  // - implement reaction to networkSettingsUpdateFailure
-  yield put(networkSettingsUpdateErrors(errors));
-  if (Object.keys(errors).length > 0) {
+  yield put(networkSettingsUpdateInvalid(invalidPayload));
+  if (Object.keys(invalidPayload).length > 0) {
     return;
   }
 

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -1,5 +1,5 @@
 import { all, takeEvery, put, call, race, delay, select } from 'redux-saga/effects';
-import { config, wallet as oldWalletUtil } from '@hathor/wallet-lib';
+import { config } from '@hathor/wallet-lib';
 import { isEmpty } from 'lodash';
 import { t } from 'ttag';
 import {
@@ -10,13 +10,10 @@ import {
   networkSettingsUpdateSuccess,
   networkSettingsUpdateWaiting,
   types,
-  startWalletRequested,
   reloadWalletRequested,
-  networkSettingsPersistComplete,
   onExceptionCaptured
 } from '../actions';
 import {
-  HTTP_REQUEST_TIMEOUT,
   NETWORK,
   networkSettingsKeyMap,
   NETWORKSETTINGS_STATUS,
@@ -29,7 +26,6 @@ import {
 import {
   getFullnodeNetwork,
   getWalletServiceNetwork,
-  showPinScreenForResult
 } from './helpers';
 import { STORE } from '../store';
 
@@ -253,9 +249,10 @@ export function* persistNetworkSettings(action) {
 
   const wallet = yield select((state) => state.wallet);
   if (!wallet) {
-    // If we fall into this situation, the app should be killed for custom new network settings take effect.
+    // If we fall into this situation, the app should be killed
+    // for the custom new network settings take effect.
     const errMsg = 'Wallet not found while trying to persist the custom network settings.';
-    console.warn(errMsg)
+    console.warn(errMsg);
     yield put(onExceptionCaptured(errMsg, /* isFatal */ true));
     return;
   }
@@ -273,8 +270,7 @@ export function* persistNetworkSettings(action) {
 export function* cleanNetworkSettings() {
   try {
     STORE.removeItem(networkSettingsKeyMap.networkSettings);
-  }
-  catch (err) {
+  } catch (err) {
     console.error('Error while deleting the custom network settings from app storage.', err);
     yield 1;
   }

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -24,9 +24,8 @@ const feedbackFailedText = t`There was an error while customizing network settin
  * @param {object} networkSettingsStatus - status from redux store
  * @returns {boolean} - true if the status is successful, false otherwise
  */
-const hasSucceed = (networkSettingsStatus) => {
-  return networkSettingsStatus === NETWORKSETTINGS_STATUS.SUCCESSFUL;
-};
+// eslint-disable-next-line max-len
+const hasSucceed = (networkSettingsStatus) => networkSettingsStatus === NETWORKSETTINGS_STATUS.SUCCESSFUL;
 
 /**
  * Check if the network settings status is failed.
@@ -45,13 +44,13 @@ const hasFailed = (networkSettingsStatus) => networkSettingsStatus === NETWORKSE
 const isLoading = (networkSettingsStatus) => networkSettingsStatus === NETWORKSETTINGS_STATUS.LOADING;
 
 /**
- * Verifies if the invalidModel of the form has an error message. 
+ * Verifies if the invalidModel of the form has an error message.
  */
 function hasError(invalidModel) {
   return Object
     .values({ ...invalidModel })
     .reduce((_hasError, currValue) => _hasError || !isEmpty(currValue), false);
-};
+}
 
 /**
  * Validates the formModel, returning the invalidModel.
@@ -135,23 +134,21 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
 
   // eslint-disable-next-line max-len
   /* @param {'nodeUrl' | 'explorerUrl' | 'explorerServiceUrl' | 'walletServiceUrl' | 'walletServiceWsUrl' } name */
-  const handleInputChange = (name) => {
-    return (value) => {
-      // update inalid model
-      const invalidModelCopy = { ...invalidModel };
-      delete invalidModelCopy[name];
-      setInvalidModel(invalidModelCopy);
+  const handleInputChange = (name) => (value) => {
+    // update inalid model
+    const invalidModelCopy = { ...invalidModel };
+    delete invalidModelCopy[name];
+    setInvalidModel(invalidModelCopy);
 
-      // update form model
-      const form = {
-        ...formModel,
-        [name]: value,
-      } 
-      setFormModel(form);
-
-      // validate form model and update invalid model
-      setInvalidModel(validate(form));
+    // update form model
+    const form = {
+      ...formModel,
+      [name]: value,
     };
+    setFormModel(form);
+
+    // validate form model and update invalid model
+    setInvalidModel(validate(form));
   };
 
   const handleFeedbackModalDismiss = () => {

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -10,12 +10,23 @@ import NewHathorButton from '../../components/NewHathorButton';
 import SimpleInput from '../../components/SimpleInput';
 import { NETWORKSETTINGS_STATUS } from '../../constants';
 import errorIcon from '../../assets/images/icErrorBig.png';
+import checkIcon from '../../assets/images/icCheckBig.png';
 import Spinner from '../../components/Spinner';
 
 const customNetworkSettingsTitleText = t`Custom Network Settings`.toUpperCase();
 const warningText = t`Any token outside mainnet network bear no value. Only change if you know what you are doing.`;
 const feedbackLoadingText = t`Updating custom network settings...`;
+const feedbackSucceedText = t`Network settings customized with success.`;
 const feedbackFailedText = t`There was an error while customizing network settings. Please try again later.`;
+
+/**
+ * Check if the network settings status is successful.
+ * @param {object} networkSettingsStatus - status from redux store
+ * @returns {boolean} - true if the status is successful, false otherwise
+ */
+const hasSucceed = (networkSettingsStatus) => {
+  return networkSettingsStatus === NETWORKSETTINGS_STATUS.SUCCESSFUL;
+};
 
 /**
  * Check if the network settings status is failed.
@@ -180,6 +191,14 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
         <FeedbackModal
           icon={<Spinner />}
           text={feedbackLoadingText}
+        />
+      )}
+
+      {hasSucceed(networkSettingsStatus) && (
+        <FeedbackModal
+          icon={(<Image source={checkIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
+          text={feedbackSucceedText}
+          onDismiss={handleFeedbackModalDismiss}
         />
       )}
 

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -16,7 +16,7 @@ import Spinner from '../../components/Spinner';
 const customNetworkSettingsTitleText = t`Custom Network Settings`.toUpperCase();
 const warningText = t`Any token outside mainnet network bear no value. Only change if you know what you are doing.`;
 const feedbackLoadingText = t`Updating custom network settings...`;
-const feedbackSucceedText = t`Network settings customized with success.`;
+const feedbackSucceedText = t`Network settings successfully customized.`;
 const feedbackFailedText = t`There was an error while customizing network settings. Please try again later.`;
 
 /**

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, Image } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { t } from 'ttag';
 import { isEmpty } from 'lodash';
-import { networkSettingsUpdate, networkSettingsUpdateErrors, networkSettingsUpdateReady } from '../../actions';
+import { networkSettingsUpdateRequest, networkSettingsUpdateErrors, networkSettingsUpdateReady } from '../../actions';
 import FeedbackModal from '../../components/FeedbackModal';
 import HathorHeader from '../../components/HathorHeader';
 import NewHathorButton from '../../components/NewHathorButton';
@@ -152,7 +152,7 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
       return;
     }
 
-    dispatch(networkSettingsUpdate(formModel));
+    dispatch(networkSettingsUpdateRequest(formModel));
   };
 
   useEffect(() => {

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -135,7 +135,7 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
   // eslint-disable-next-line max-len
   /* @param {'nodeUrl' | 'explorerUrl' | 'explorerServiceUrl' | 'walletServiceUrl' | 'walletServiceWsUrl' } name */
   const handleInputChange = (name) => (value) => {
-    // update inalid model
+    // update invalid model
     const invalidModelCopy = { ...invalidModel };
     delete invalidModelCopy[name];
     setInvalidModel(invalidModelCopy);

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -8,40 +8,16 @@ import FeedbackModal from '../../components/FeedbackModal';
 import HathorHeader from '../../components/HathorHeader';
 import NewHathorButton from '../../components/NewHathorButton';
 import SimpleInput from '../../components/SimpleInput';
-import { NETWORKSETTINGS_STATUS } from '../../constants';
 import errorIcon from '../../assets/images/icErrorBig.png';
 import checkIcon from '../../assets/images/icCheckBig.png';
 import Spinner from '../../components/Spinner';
+import { hasSucceed, hasFailed, isLoading } from './helper';
 
 const customNetworkSettingsTitleText = t`Custom Network Settings`.toUpperCase();
 const warningText = t`Any token outside mainnet network bear no value. Only change if you know what you are doing.`;
 const feedbackLoadingText = t`Updating custom network settings...`;
 const feedbackSucceedText = t`Network settings successfully customized.`;
 const feedbackFailedText = t`There was an error while customizing network settings. Please try again later.`;
-
-/**
- * Check if the network settings status is successful.
- * @param {object} networkSettingsStatus - status from redux store
- * @returns {boolean} - true if the status is successful, false otherwise
- */
-// eslint-disable-next-line max-len
-const hasSucceed = (networkSettingsStatus) => networkSettingsStatus === NETWORKSETTINGS_STATUS.SUCCESSFUL;
-
-/**
- * Check if the network settings status is failed.
- * @param {object} networkSettingsStatus - status from redux store
- * @returns {boolean} - true if the status is failed, false otherwise
- */
-// eslint-disable-next-line max-len
-const hasFailed = (networkSettingsStatus) => networkSettingsStatus === NETWORKSETTINGS_STATUS.FAILED;
-
-/**
- * Check if the network settings status is loading.
- * @param {object} networkSettingsStatus - status from redux store
- * @returns {boolean} - true if the status is loading, false otherwise
- */
-// eslint-disable-next-line max-len
-const isLoading = (networkSettingsStatus) => networkSettingsStatus === NETWORKSETTINGS_STATUS.LOADING;
 
 /**
  * Verifies if the invalidModel of the form has an error message.

--- a/src/screens/NetworkSettings/NetworkPreSettingsScreen.js
+++ b/src/screens/NetworkSettings/NetworkPreSettingsScreen.js
@@ -21,10 +21,12 @@ import FeedbackModal from '../../components/FeedbackModal';
 import { networkSettingsPersistStore, networkSettingsUpdateReady } from '../../actions';
 import { PRE_SETTINGS_MAINNET, PRE_SETTINGS_TESTNET } from '../../constants';
 import { CustomNetworkSettingsNav } from './CustomNetworkSettingsScreen';
-import { feedbackFailedText, feedbackLoadingText, hasFailed, isLoading } from './helper';
+import { feedbackSucceedText, feedbackFailedText, feedbackLoadingText, hasFailed, isLoading, hasSucceed } from './helper';
 import errorIcon from '../../assets/images/icErrorBig.png';
+import checkIcon from '../../assets/images/icCheckBig.png';
 
 const presettingsTitleText = t`Network Pre-Settings`.toUpperCase();
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -97,6 +99,14 @@ export function NetworkPreSettingsScreen({ navigation }) {
         <FeedbackModal
           icon={<Spinner />}
           text={feedbackLoadingText}
+        />
+      )}
+
+      {hasSucceed(networkSettingsStatus) && (
+        <FeedbackModal
+          icon={(<Image source={checkIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
+          text={feedbackSucceedText}
+          onDismiss={handleFeedbackModalDismiss}
         />
       )}
 

--- a/src/screens/NetworkSettings/NetworkPreSettingsScreen.js
+++ b/src/screens/NetworkSettings/NetworkPreSettingsScreen.js
@@ -18,7 +18,7 @@ import HathorHeader from '../../components/HathorHeader';
 import NewHathorButton from '../../components/NewHathorButton';
 import Spinner from '../../components/Spinner';
 import FeedbackModal from '../../components/FeedbackModal';
-import { networkSettingsUpdateReady, networkSettingsUpdateSuccess } from '../../actions';
+import { networkSettingsPersistStore, networkSettingsUpdateReady } from '../../actions';
 import { PRE_SETTINGS_MAINNET, PRE_SETTINGS_TESTNET } from '../../constants';
 import { CustomNetworkSettingsNav } from './CustomNetworkSettingsScreen';
 import { feedbackFailedText, feedbackLoadingText, hasFailed, isLoading } from './helper';
@@ -76,8 +76,8 @@ export const NetworkPreSettingsNav = Symbol('NetworkPreSettings').toString();
 export function NetworkPreSettingsScreen({ navigation }) {
   const dispatch = useDispatch();
   const networkSettingsStatus = useSelector((state) => state.networkSettingsStatus);
-  const setMainnetNetwork = () => dispatch(networkSettingsUpdateSuccess(PRE_SETTINGS_MAINNET));
-  const setTestnetNetwork = () => dispatch(networkSettingsUpdateSuccess(PRE_SETTINGS_TESTNET));
+  const setMainnetNetwork = () => dispatch(networkSettingsPersistStore(PRE_SETTINGS_MAINNET));
+  const setTestnetNetwork = () => dispatch(networkSettingsPersistStore(PRE_SETTINGS_TESTNET));
   const setCustomNetwork = () => {
     navigation.push(CustomNetworkSettingsNav);
   };

--- a/src/screens/NetworkSettings/NetworkSettingsFlowStack.js
+++ b/src/screens/NetworkSettings/NetworkSettingsFlowStack.js
@@ -24,8 +24,14 @@ export const NetworkSettingsFlowStack = () => {
         name={NetworkSettingsDisclaimerNav}
         component={NetworkSettingsDisclaimerScreen}
       />
-      <FlowStack.Screen name={NetworkPreSettingsNav} component={NetworkPreSettingsScreen} />
-      <FlowStack.Screen name={CustomNetworkSettingsNav} component={CustomNetworkSettingsScreen} />
+      <FlowStack.Screen
+        name={NetworkPreSettingsNav}
+        component={NetworkPreSettingsScreen}
+      />
+      <FlowStack.Screen
+        name={CustomNetworkSettingsNav}
+        component={CustomNetworkSettingsScreen}
+      />
     </FlowStack.Navigator>
   );
 };

--- a/src/screens/NetworkSettings/helper.js
+++ b/src/screens/NetworkSettings/helper.js
@@ -2,7 +2,17 @@ import { t } from 'ttag';
 import { NETWORKSETTINGS_STATUS } from '../../constants';
 
 export const feedbackLoadingText = t`Updating custom network settings...`;
+export const feedbackSucceedText = t`Network settings customized with success.`;
 export const feedbackFailedText = t`There was an error while customizing network settings. Please try again later.`;
+
+/**
+ * Check if the network settings status is successful.
+ * @param {object} networkSettingsStatus - status from redux store
+ * @returns {boolean} - true if the status is successful, false otherwise
+ */
+export const hasSucceed = (networkSettingsStatus) => {
+  return networkSettingsStatus === NETWORKSETTINGS_STATUS.SUCCESSFUL;
+};
 
 /**
  * Check if the network settings status is failed.

--- a/src/screens/NetworkSettings/helper.js
+++ b/src/screens/NetworkSettings/helper.js
@@ -2,7 +2,7 @@ import { t } from 'ttag';
 import { NETWORKSETTINGS_STATUS } from '../../constants';
 
 export const feedbackLoadingText = t`Updating custom network settings...`;
-export const feedbackSucceedText = t`Network settings customized with success.`;
+export const feedbackSucceedText = t`Network settings successfully customized.`;
 export const feedbackFailedText = t`There was an error while customizing network settings. Please try again later.`;
 
 /**

--- a/src/screens/NetworkSettings/helper.js
+++ b/src/screens/NetworkSettings/helper.js
@@ -10,9 +10,9 @@ export const feedbackFailedText = t`There was an error while customizing network
  * @param {object} networkSettingsStatus - status from redux store
  * @returns {boolean} - true if the status is successful, false otherwise
  */
-export const hasSucceed = (networkSettingsStatus) => {
+export function hasSucceed(networkSettingsStatus) {
   return networkSettingsStatus === NETWORKSETTINGS_STATUS.SUCCESSFUL;
-};
+}
 
 /**
  * Check if the network settings status is failed.


### PR DESCRIPTION
This PR aims to improve the Network Settings Actions by decomposing it in actions that conveys a better semantic.

### Acceptance Criteria

- rename action to NETWORKSETTINGS_UPDATE_REQUEST
- add action NETWORKSETTINGS_UPDATE_STATE
- add action NETWORKSETTINGS_PERSIST_STORE
- add action NETWORKSETTINGS_UPDATE_WAITING
- refactor action NETWORKSETTINGS_UPDATE_SUCCESS
- refactor action NETWORKSETTINGS_UPDATE_INVALID
- refactor action NETWORKSETTINGS_UPDATE_FAILURE
- add docstring to action NETWORKSETTINGS_UPDATE_READY
- refactor NetworkStatusBar
- refactor saga effect persistNetworkSettings
- resolve all the lint issues

>[!WARNING]
>The following video has a legacy behavior when showing the network status bar alert for mainnet settings when removing only the wallet service URLs fields. This bar should show up only if the required fields diverges from the what is set to be the mainnet. You find the video with the correct behavior after this one.

https://github.com/HathorNetwork/hathor-wallet-mobile/assets/5992210/047e9290-1c29-48ad-8333-b5751df7ba3a

Correct behavior regarding network status bar:

https://github.com/HathorNetwork/hathor-wallet-mobile/assets/5992210/84491bef-4904-4424-b5f3-fd413af8a50f




Closes: https://github.com/HathorNetwork/hathor-wallet-mobile/issues/358

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
