### PR TITLE
fix: Closes keyboard on PinScreen

### DIFF
--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -91,6 +91,9 @@ class PinScreen extends React.Component {
     }
 
     this.focusEvent = this.props.navigation.addListener('focus', () => {
+      // Ensure the keyboard is hidden when the screen is focused, even if it was already mounted
+      Keyboard.dismiss();
+      // Clear the pin
       this.setState({ pin: '', pinColor: COLORS.textColor, error: null });
     });
   }


### PR DESCRIPTION
This is related to a bug reported on #318.

The OS keyboard was being incorrectly displayed on the Pin Screen in specific situations where the application had been stopped while showing the OS keyboard.

### Acceptance Criteria
- The OS keyboard should never be displayed on the PinScreen

### Testing
To test the results of this fix:
- Open the app with a loaded wallet
- Navigate to "Receive" and then "Payment Request"
- Insert an amount and keep the numeric keyboard active
- Send the app to background
- Wait for 5 minutes
- Switch back to the app
- The Pin Screen should be displayed _without_ the OS Keyboard overlay

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
