### PR TITLE
chore: version bump pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 Please go the the `Preview` tab and select the appropriate Pull Request template:
 
-* [Feature Branch](?expand=1&template=feature_branch_pr_template.md) - Use this PR template when you are creating a feature branch pull-request
-* [Version Bump](?expand=1&template=version_bump_pr_template.md) - Use this PR template when you are creating a version bump pull-request
+* [Feature Branch](?expand=1&template=feature_branch_pr_template.md) - Use this template when you are creating a feature branch pull-request
+* [Version Bump](?expand=1&template=version_bump_pr_template.md) - Use this template when you are creating a version bump pull-request

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
-### Acceptance Criteria
-- Include here all things that this PR should solve
+Please go the the `Preview` tab and select the appropriate Pull Request template:
 
-
-### Security Checklist
-- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
+* [Feature Branch](?expand=1&template=feature_branch_pr_template.md) - Use this PR template when you are merging a feature branch into `dev`
+* [Version Bump](?expand=1&template=version_bump_pr_template.md) - Use this PR template when you are merging a version bump branch into `dev`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 Please go the the `Preview` tab and select the appropriate Pull Request template:
 
-* [Feature Branch](?expand=1&template=feature_branch_pr_template.md) - Use this PR template when you are merging a feature branch into `dev`
-* [Version Bump](?expand=1&template=version_bump_pr_template.md) - Use this PR template when you are merging a version bump branch into `dev`
+* [Feature Branch](?expand=1&template=feature_branch_pr_template.md) - Use this PR template when you are creating a feature branch pull-request
+* [Version Bump](?expand=1&template=version_bump_pr_template.md) - Use this PR template when you are creating a version bump pull-request

--- a/.github/PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md
@@ -1,0 +1,5 @@
+### Acceptance Criteria
+- Include here all things that this PR should solve
+
+### Security Checklist
+- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

--- a/.github/PULL_REQUEST_TEMPLATE/version_bump_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/version_bump_pr_template.md
@@ -1,5 +1,5 @@
 ### Acceptance Criteria
-- Include here all things that this PR should solve
+- Include links to all PRs that will be included in this version
 
 ### Checklist
 - [ ] Make sure you updated the `CURRENT_PROJECT_VERSION` with the appropriate release-candidate version in `ios/HathorMobile.xcodeproj/project.pbxproj`

--- a/.github/PULL_REQUEST_TEMPLATE/version_bump_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/version_bump_pr_template.md
@@ -8,6 +8,3 @@
 - [ ] Make sure you updated the version attribute in `package-lock.json`
 - [ ] Make sure you incremented the `versionCode` attribute in `android/app/build.gradle`
 - [ ] Make sure you updated the `versionName` with the appropriate version, including the release candidate number in `android/app/build.gradle`
-
-### Security Checklist
-- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

--- a/.github/PULL_REQUEST_TEMPLATE/version_bump_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/version_bump_pr_template.md
@@ -1,0 +1,13 @@
+### Acceptance Criteria
+- Include here all things that this PR should solve
+
+### Checklist
+- [ ] Make sure you updated the `CURRENT_PROJECT_VERSION` with the appropriate release-candidate version in `ios/HathorMobile.xcodeproj/project.pbxproj`
+- [ ] Make sure you updated the `MARKETING_VERSION` with the appropriate version in `ios/HathorMobile.xcodeproj/project.pbxproj`
+- [ ] Make sure you updated the version attribute in `package.json`
+- [ ] Make sure you updated the version attribute in `package-lock.json`
+- [ ] Make sure you incremented the `versionCode` attribute in `android/app/build.gradle`
+- [ ] Make sure you updated the `versionName` with the appropriate version, including the release candidate number in `android/app/build.gradle`
+
+### Security Checklist
+- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


### PR DESCRIPTION
### Acceptance Criteria
- We should have a default PR template with links to two PR templates -- the version bump and the feature branch PR templates
- The version bump PR template should have a checklist for when creating a version bump in the wallet-mobile


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
