### PR TITLE
Fix: Pin not working on update

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -370,11 +370,7 @@ class AsyncStorageStore {
    * @async
    */
   async handleMigrationOldRegisteredTokens() {
-    const oldTokens = this.getItem('wallet:tokens');
-    if (!oldTokens) {
-      // There were no registered custom tokens: skipping token migration.
-      return;
-    }
+    const oldTokens = this.getItem('wallet:tokens') ?? [];
 
     const newTokens = {};
     for (const token of oldTokens) {

--- a/src/store.js
+++ b/src/store.js
@@ -371,6 +371,11 @@ class AsyncStorageStore {
    */
   async handleMigrationOldRegisteredTokens() {
     const oldTokens = this.getItem('wallet:tokens');
+    if (!oldTokens) {
+      // There were no registered custom tokens: skipping token migration.
+      return;
+    }
+
     const newTokens = {};
     for (const token of oldTokens) {
       newTokens[token.uid] = token;


### PR DESCRIPTION
In a specific update condition, the app would not accept the user's PIN code:
- The user should have a wallet on and already installed `v0.25.0` app
- This wallet should have no registered custom tokens, only HTR
- The user upgrades to `v0.26.0-rc7`
- The Pin Screen does not accept the valid Pin anymore

This would happen because the migration code expected registered custom tokens to be present. This PR fixes this.

### Acceptance Criteria
- The app should accept the user's old PIN after migration on the identified edge case


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
