### PR TITLE
fix: multiple alerts shown to QR reading

### DIFF
--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -22,7 +22,15 @@ const mapStateToProps = (state) => ({
 });
 
 class SendScanQRCode extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      isWaitingForUserInput: false,
+    }
+  }
+
   showAlertError = (message) => {
+    this.setState({ isWaitingForUserInput: true });
     Alert.alert(
       t`Invalid QR code`,
       message,
@@ -31,6 +39,7 @@ class SendScanQRCode extends React.Component {
           onPress: () => {
             // To avoid being stuck on an invalid QR code loop, navigate back.
             this.props.navigation.goBack();
+            this.setState({ isWaitingForUserInput: false });
           } },
       ],
       { cancelable: false },
@@ -38,6 +47,11 @@ class SendScanQRCode extends React.Component {
   }
 
   onSuccess = async (e) => {
+    if (this.state.isWaitingForUserInput) {
+      // Avoid multiple calls to this function while waiting for user input
+      return;
+    }
+
     const qrcode = parseQRCode(e.data);
     if (!qrcode.isValid) {
       this.showAlertError(qrcode.error);


### PR DESCRIPTION
Multiple alerts were being shown one over the other when the user tried to scan a QR Code and an error was raised.

### Acceptance Criteria
- Only one alert should be shown when an error occurs on Send Tokens


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
