### PR TITLE
Fix: QR Code registered token check

### DIFF
--- a/src/sagas/helpers.js
+++ b/src/sagas/helpers.js
@@ -153,7 +153,7 @@ export function isUnlockScreen(action) {
  * Get registered tokens from the wallet instance.
  * @param {HathorWallet} wallet
  * @param {boolean} excludeHTR If we should exclude the HTR token.
- * @returns {string[]}
+ * @returns {Promise<{ uid: string, symbol: string, name: string }[]>}
  */
 export async function getRegisteredTokens(wallet, excludeHTR = false) {
   const htrUid = hathorLib.constants.HATHOR_TOKEN_CONFIG.uid;
@@ -183,6 +183,17 @@ export async function getRegisteredTokens(wallet, excludeHTR = false) {
   }
 
   return tokens;
+}
+
+/**
+ * Check if a token is registered in the context of the saga functions.
+ * @param {HathorWallet} wallet
+ * @param {string} tokenUid
+ * @returns {Promise<boolean>}
+ */
+export async function isTokenRegistered(wallet, tokenUid) {
+  const tokens = await getRegisteredTokens(wallet);
+  return tokens.some((token) => token.uid === tokenUid);
 }
 
 export async function getFullnodeNetwork() {

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -46,7 +46,7 @@ import {
 } from '../constants';
 import { getPushNotificationSettings } from '../utils';
 import { STORE } from '../store';
-import { getNetworkSettings, isUnlockScreen, showPinScreenForResult } from './helpers';
+import { getNetworkSettings, isUnlockScreen, showPinScreenForResult, isTokenRegistered } from './helpers';
 import { messageHandler } from '../workers/pushNotificationHandler';
 import { WALLET_STATUS } from './wallet';
 
@@ -544,7 +544,7 @@ export const getTxDetails = async (wallet, txId) => {
       name: each.tokenName,
       symbol: each.tokenSymbol,
       balance: each.balance,
-      isRegistered: await wallet.storage.isTokenRegistered(each.tokenId),
+      isRegistered: await isTokenRegistered(each.tokenId),
     }))),
   });
 

--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -43,7 +43,10 @@ class SendScanQRCode extends React.Component {
     if (!qrcode.isValid) {
       this.showAlertError(qrcode.error);
     } else if (qrcode.token && qrcode.amount) {
-      if (this.props.tokens.find((stateToken) => stateToken.uid === qrcode.token.uid)) {
+      const isTokenRegistered = this.props.tokens.some(
+        (stateToken) => stateToken.uid === qrcode.token.uid
+      );
+      if (isTokenRegistered) {
         const params = {
           address: qrcode.address,
           token: qrcode.token,

--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -19,6 +19,7 @@ import { COLORS } from '../styles/themes';
 
 const mapStateToProps = (state) => ({
   wallet: state.wallet,
+  tokens: state.tokens,
 });
 
 class SendScanQRCode extends React.Component {
@@ -42,7 +43,7 @@ class SendScanQRCode extends React.Component {
     if (!qrcode.isValid) {
       this.showAlertError(qrcode.error);
     } else if (qrcode.token && qrcode.amount) {
-      if (await this.props.wallet.storage.isTokenRegistered(qrcode.token.uid)) {
+      if (this.props.tokens.find((stateToken) => stateToken.uid === qrcode.token.uid)) {
         const params = {
           address: qrcode.address,
           token: qrcode.token,


### PR DESCRIPTION
In two places the application was trying to check if a token was registered by querying the wallet storage object directly. However, this low level storage does not contain the default token, and that lead to false negative responses.

There are other higher level _helper_ sources that already take these implicit default tokens into consideration: those should be used instead. Namely, the `getRegisteredTokens` saga helper function and the redux state `tokens` property.

### Acceptance Criteria
- Registered tokens should be read from the helper functions


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
