### PR TITLE
fix: About screen handles invalid build version number

### DIFF
--- a/src/screens/About.js
+++ b/src/screens/About.js
@@ -54,7 +54,8 @@ export class About extends React.Component {
       // iOS
       const build = VersionNumber.buildVersion.split('.');
       if (build.length !== 3) {
-        return (<Text style={this.style.text}>{JSON.stringify(VersionNumber)} (parse error)</Text>)
+        // Incorrect build version format. Inform the user but do not crash.
+        return this.renderVersionText(VersionNumber.appVersion, `${VersionNumber.buildVersion} (parse error)`);
       }
       if (build[0] === '0') {
         // This is a release candidate build


### PR DESCRIPTION
## Summary
When the iOS Build number becomes invalid for process reasons, the _About_ screen crashes. This PR fixes this and makes it display the `(parse error)` message instead:

![About Screen fixed](https://github.com/HathorNetwork/hathor-wallet-mobile/assets/1299409/f298a771-39e4-4578-87a5-9ea8d4b49b70)

## Acceptance Criteria
- About screen should not crash when the iOS Build Version is not in the expected format.