### PR TITLE
Chore: Bump version to `v0.26.1`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,8 +79,8 @@ android {
         applicationId "network.hathor.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 62
-        versionName "0.26.0"
+        versionCode 63
+        versionName "0.26.1"
         missingDimensionStrategy "react-native-camera", "general"
     }
     signingConfigs {

--- a/ios/HathorMobile.xcodeproj/project.pbxproj
+++ b/ios/HathorMobile.xcodeproj/project.pbxproj
@@ -520,7 +520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.26.0;
+				MARKETING_VERSION = 0.26.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -548,7 +548,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.26.0;
+				MARKETING_VERSION = 0.26.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "HathorMobile",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "HathorMobile",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HathorMobile",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=9.0.0"


### PR DESCRIPTION
### Acceptance Criteria
- #396
- #397
- #399

### Checklist
- [X] Make sure you updated the `CURRENT_PROJECT_VERSION` with the appropriate release-candidate version in `ios/HathorMobile.xcodeproj/project.pbxproj`
- [X] Make sure you updated the `MARKETING_VERSION` with the appropriate version in `ios/HathorMobile.xcodeproj/project.pbxproj`
- [X] Make sure you updated the version attribute in `package.json`
- [X] Make sure you updated the version attribute in `package-lock.json`
- [X] Make sure you incremented the `versionCode` attribute in `android/app/build.gradle`
- [X] Make sure you updated the `versionName` with the appropriate version, including the release candidate number in `android/app/build.gradle`
