### PR TITLE
fix: Release candidate version checker on CI

### DIFF
--- a/scripts/check_version
+++ b/scripts/check_version
@@ -57,28 +57,28 @@ if [[ x${STRIPPED_PACKAGE_VERSION}x != x${IOS_MARKETING_VERSION_2}x ]]; then
 fi
 
 # Check the format of iOS' CURRENT_PROJECT_VERSION
-# If it's a release version (without hyphen in package version), it should be 1.0.0
-# If it's a release candidate version (with hyphen in package version), it should be 0.rc.0, where rc is taken from package version
+# If it's a release version (without hyphen in package version), it should be 1.0.X
+# If it's a release candidate version (with hyphen in package version), it should be 0.rc.X, where rc is taken from package version
 if [ -z "$STRIPPED_PACKAGE_CANDIDATE" ]; then
-  if [[ x${IOS_PROJECT_VERSION_1}x != x1.0.0x ]]; then
-      echo "Invalid format (expected 1.0.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^1\.0\.[0-9]{1,3}$ ]]; then
+      echo "Invalid format (expected 1.0.X) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1
   fi
 
-  if [[ x${IOS_PROJECT_VERSION_2}x != x1.0.0x ]]; then
-      echo "Invalid format (expected 1.0.0) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  if [[ ! "$IOS_PROJECT_VERSION_2" =~ ^1\.0\.[0-9]{1,3}$ ]]; then
+      echo "Invalid format (expected 1.0.X) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1
   fi
 else
   RCVERSION=${STRIPPED_PACKAGE_CANDIDATE//[^0-9]/}
 #  echo "RCVERSION: $RCVERSION"
-  if [[ x${IOS_PROJECT_VERSION_1}x != x0.${RCVERSION}.0x ]]; then
-      echo "Invalid format (expected 0.$RCVERSION.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^0\.${RCVERSION}\.[0-9]{1,3}$ ]]; then
+      echo "Invalid format (expected 0.$RCVERSION.X) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1
   fi
 
-  if [[ x${IOS_PROJECT_VERSION_2}x != x0.${RCVERSION}.0x ]]; then
-      echo "Invalid format (expected 0.$RCVERSION.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  if [[ ! "$IOS_PROJECT_VERSION_2" =~ ^0\.${RCVERSION}\.[0-9]{1,3}$ ]]; then
+      echo "Invalid format (expected 0.$RCVERSION.X) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1
   fi
 fi

--- a/scripts/check_version
+++ b/scripts/check_version
@@ -1,23 +1,32 @@
 #!/bin/bash
 
+# Read the official version number from package.json file
 PACKAGE_VERSION=`grep '"version":' ./package.json | cut -d '"' -f4`
+
+# Read the version number from the Android Gradle build file
 ANDROID_GRADLE_VERSION=`grep "versionName " ./android/app/build.gradle | cut -d '"' -f2`
+
+# Read the version number (MARKETING_VERSION and CURRENT_PROJECT_VERSION) from the iOS project file
 TEMP_IOS_VAR=`perl -n -e '/MARKETING_VERSION = (.*);/ && print "$1\n"' ./ios/HathorMobile.xcodeproj/project.pbxproj`
 TEMP_IOS_PROJECT_VERSION=`perl -n -e '/CURRENT_PROJECT_VERSION = (.*);/ && print "$1\n"' ./ios/HathorMobile.xcodeproj/project.pbxproj`
+
+# The iOS version number is repeated two times
 IOS_MARKETING_VERSION_1=`echo $TEMP_IOS_VAR | awk '{print $1}'`
 IOS_MARKETING_VERSION_2=`echo $TEMP_IOS_VAR | awk '{print $2}'`
 IOS_PROJECT_VERSION_1=`echo $TEMP_IOS_PROJECT_VERSION | awk '{print $1}'`
 IOS_PROJECT_VERSION_2=`echo $TEMP_IOS_PROJECT_VERSION | awk '{print $2}'`
 
-# This will read everything of the string up to the first dash.
+# The version number from the package.json file is split into two parts
 STRIPPED_PACKAGE_VERSION=$(echo $PACKAGE_VERSION| cut -d- -f1);
 if [[ "$PACKAGE_VERSION" == *-* ]]; then
+  # If the version contains a hyphen, extract the second part as the release candidate
   STRIPPED_PACKAGE_CANDIDATE=$(echo $PACKAGE_VERSION | cut -d- -f2)
 else
+  # Otherwise, the release candidate is empty
   STRIPPED_PACKAGE_CANDIDATE=""
 fi
 
-# For debugging:
+# Variables for debugging
  echo package: x${PACKAGE_VERSION}x
  echo stripped: x${STRIPPED_PACKAGE_VERSION}x
  echo stripped rc: x${STRIPPED_PACKAGE_CANDIDATE}x
@@ -27,13 +36,16 @@ fi
  echo ios pv1: x${IOS_PROJECT_VERSION_1}x
  echo ios pv2: x${IOS_PROJECT_VERSION_2}x
 
+# Initialize the error code with a success
 EXITCODE=0
 
+# Check if the version numbers from the package and Android are different
 if [[ x${PACKAGE_VERSION}x != x${ANDROID_GRADLE_VERSION}x ]]; then
 	echo Version different in package.json \($PACKAGE_VERSION\) and android/app/build.gradle
 	EXITCODE=-1
 fi
 
+# Check if the version numbers from the package and iOS MARKETING_VERSION are different
 if [[ x${STRIPPED_PACKAGE_VERSION}x != x${IOS_MARKETING_VERSION_1}x ]]; then
   echo Version different in package.json \($PACKAGE_VERSION\) and first MARKETING_VERSION \($IOS_MARKETING_VERSION_1\) on ios/HathorMobile.xcodeproj/project.pbxproj
 	EXITCODE=-1
@@ -44,18 +56,20 @@ if [[ x${STRIPPED_PACKAGE_VERSION}x != x${IOS_MARKETING_VERSION_2}x ]]; then
 	EXITCODE=-1
 fi
 
-# This will check the format of IOS' CURRENT_PROJECT_VERSION
+# Check the format of iOS' CURRENT_PROJECT_VERSION
+# If it's a release version (without hyphen in package version), it should be 1.0.0
+# If it's a release candidate version (with hyphen in package version), it should be 0.rc.0, where rc is taken from package version
 if [ -z "$STRIPPED_PACKAGE_CANDIDATE" ]; then
-  # If this is a release version, check that the CURRENT_PROJECT_VERSION is 1.0.0
   if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^1\.0\.0$ ]]; then
       echo "Invalid format (expected 1.0.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+      EXITCODE=-1
   fi
 
   if [[ ! "$IOS_PROJECT_VERSION_2" =~ ^1\.0\.0$ ]]; then
       echo "Invalid format (expected 1.0.0) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+      EXITCODE=-1
   fi
 else
-  # If this is a release candidate version, check that the CURRENT_PROJECT_VERSION is 0.rc.0
   RCVERSION=${STRIPPED_PACKAGE_CANDIDATE//[^0-9]/}
   echo "RCVERSION: $RCVERSION"
   if [[ x${IOS_PROJECT_VERSION_1}x != x0.${RCVERSION}.0x ]]; then
@@ -69,4 +83,5 @@ else
   fi
 fi
 
+# Exit the script with the error code
 exit $EXITCODE

--- a/scripts/check_version
+++ b/scripts/check_version
@@ -27,14 +27,14 @@ else
 fi
 
 # Variables for debugging
- echo package: x${PACKAGE_VERSION}x
- echo stripped: x${STRIPPED_PACKAGE_VERSION}x
- echo stripped rc: x${STRIPPED_PACKAGE_CANDIDATE}x
- echo android: x${ANDROID_GRADLE_VERSION}x
- echo ios mv1: x${IOS_MARKETING_VERSION_1}x
- echo ios mv2: x${IOS_MARKETING_VERSION_2}x
- echo ios pv1: x${IOS_PROJECT_VERSION_1}x
- echo ios pv2: x${IOS_PROJECT_VERSION_2}x
+# echo package: x${PACKAGE_VERSION}x
+# echo stripped: x${STRIPPED_PACKAGE_VERSION}x
+# echo stripped rc: x${STRIPPED_PACKAGE_CANDIDATE}x
+# echo android: x${ANDROID_GRADLE_VERSION}x
+# echo ios mv1: x${IOS_MARKETING_VERSION_1}x
+# echo ios mv2: x${IOS_MARKETING_VERSION_2}x
+# echo ios pv1: x${IOS_PROJECT_VERSION_1}x
+# echo ios pv2: x${IOS_PROJECT_VERSION_2}x
 
 # Initialize the error code with a success
 EXITCODE=0
@@ -71,7 +71,7 @@ if [ -z "$STRIPPED_PACKAGE_CANDIDATE" ]; then
   fi
 else
   RCVERSION=${STRIPPED_PACKAGE_CANDIDATE//[^0-9]/}
-  echo "RCVERSION: $RCVERSION"
+#  echo "RCVERSION: $RCVERSION"
   if [[ x${IOS_PROJECT_VERSION_1}x != x0.${RCVERSION}.0x ]]; then
       echo "Invalid format (expected 0.$RCVERSION.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1

--- a/scripts/check_version
+++ b/scripts/check_version
@@ -11,13 +11,21 @@ IOS_PROJECT_VERSION_2=`echo $TEMP_IOS_PROJECT_VERSION | awk '{print $2}'`
 
 # This will read everything of the string up to the first dash.
 STRIPPED_PACKAGE_VERSION=$(echo $PACKAGE_VERSION| cut -d- -f1);
+if [[ "$PACKAGE_VERSION" == *-* ]]; then
+  STRIPPED_PACKAGE_CANDIDATE=$(echo $PACKAGE_VERSION | cut -d- -f2)
+else
+  STRIPPED_PACKAGE_CANDIDATE=""
+fi
 
 # For debugging:
-# echo package: x${PACKAGE_VERSION}x
-# echo stripped: x${STRIPPED_PACKAGE_VERSION}x
-# echo android: x${ANDROID_GRADLE_VERSION}x
-# echo ios pv1: x${IOS_MARKETING_VERSION_1}x
-# echo ios pv2: x${IOS_MARKETING_VERSION_2}x
+ echo package: x${PACKAGE_VERSION}x
+ echo stripped: x${STRIPPED_PACKAGE_VERSION}x
+ echo stripped rc: x${STRIPPED_PACKAGE_CANDIDATE}x
+ echo android: x${ANDROID_GRADLE_VERSION}x
+ echo ios mv1: x${IOS_MARKETING_VERSION_1}x
+ echo ios mv2: x${IOS_MARKETING_VERSION_2}x
+ echo ios pv1: x${IOS_PROJECT_VERSION_1}x
+ echo ios pv2: x${IOS_PROJECT_VERSION_2}x
 
 EXITCODE=0
 
@@ -36,13 +44,25 @@ if [[ x${STRIPPED_PACKAGE_VERSION}x != x${IOS_MARKETING_VERSION_2}x ]]; then
 	EXITCODE=-1
 fi
 
-# This will check the format of IOS' CURRENT_PROJECT_VERSION
-if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-    echo "Invalid format (expected X.X.X) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
-fi
+if [ -z "$STRIPPED_PACKAGE_CANDIDATE" ]; then
+  # This will check the format of IOS' CURRENT_PROJECT_VERSION
+  if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^1\.0\.0$ ]]; then
+      echo "Invalid format (expected 1.0.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  fi
 
-if [[ ! "$IOS_PROJECT_VERSION_2" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-    echo "Invalid format (expected X.X.X) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  if [[ ! "$IOS_PROJECT_VERSION_2" =~ ^1\.0\.0$ ]]; then
+      echo "Invalid format (expected 1.0.0) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  fi
+else
+  if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^0\.[0-9]{1,3}\.0$ ]]; then
+      echo "Invalid format (expected 0.X.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+      EXITCODE=-1
+  fi
+
+  if [[ ! "$IOS_PROJECT_VERSION_2" =~ ^0\.[0-9]{1,3}\.0$ ]]; then
+      echo "Invalid format (expected 0.X.0) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+      EXITCODE=-1
+  fi
 fi
 
 exit $EXITCODE

--- a/scripts/check_version
+++ b/scripts/check_version
@@ -83,5 +83,9 @@ else
   fi
 fi
 
+if [[ x${EXITCODE}x != x0x ]]; then
+  echo "Check version failed. Consider using 'make bump updateType=xx' to update the version"
+fi
+
 # Exit the script with the error code
 exit $EXITCODE

--- a/scripts/check_version
+++ b/scripts/check_version
@@ -60,12 +60,12 @@ fi
 # If it's a release version (without hyphen in package version), it should be 1.0.0
 # If it's a release candidate version (with hyphen in package version), it should be 0.rc.0, where rc is taken from package version
 if [ -z "$STRIPPED_PACKAGE_CANDIDATE" ]; then
-  if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^1\.0\.0$ ]]; then
+  if [[ x${IOS_PROJECT_VERSION_1}x != x1.0.0x ]]; then
       echo "Invalid format (expected 1.0.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1
   fi
 
-  if [[ ! "$IOS_PROJECT_VERSION_2" =~ ^1\.0\.0$ ]]; then
+  if [[ x${IOS_PROJECT_VERSION_2}x != x1.0.0x ]]; then
       echo "Invalid format (expected 1.0.0) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1
   fi

--- a/scripts/check_version
+++ b/scripts/check_version
@@ -44,8 +44,9 @@ if [[ x${STRIPPED_PACKAGE_VERSION}x != x${IOS_MARKETING_VERSION_2}x ]]; then
 	EXITCODE=-1
 fi
 
+# This will check the format of IOS' CURRENT_PROJECT_VERSION
 if [ -z "$STRIPPED_PACKAGE_CANDIDATE" ]; then
-  # This will check the format of IOS' CURRENT_PROJECT_VERSION
+  # If this is a release version, check that the CURRENT_PROJECT_VERSION is 1.0.0
   if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^1\.0\.0$ ]]; then
       echo "Invalid format (expected 1.0.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
   fi
@@ -54,13 +55,16 @@ if [ -z "$STRIPPED_PACKAGE_CANDIDATE" ]; then
       echo "Invalid format (expected 1.0.0) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
   fi
 else
-  if [[ ! "$IOS_PROJECT_VERSION_1" =~ ^0\.[0-9]{1,3}\.0$ ]]; then
-      echo "Invalid format (expected 0.X.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  # If this is a release candidate version, check that the CURRENT_PROJECT_VERSION is 0.rc.0
+  RCVERSION=${STRIPPED_PACKAGE_CANDIDATE//[^0-9]/}
+  echo "RCVERSION: $RCVERSION"
+  if [[ x${IOS_PROJECT_VERSION_1}x != x0.${RCVERSION}.0x ]]; then
+      echo "Invalid format (expected 0.$RCVERSION.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_1}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1
   fi
 
-  if [[ ! "$IOS_PROJECT_VERSION_2" =~ ^0\.[0-9]{1,3}\.0$ ]]; then
-      echo "Invalid format (expected 0.X.0) for second CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
+  if [[ x${IOS_PROJECT_VERSION_2}x != x0.${RCVERSION}.0x ]]; then
+      echo "Invalid format (expected 0.$RCVERSION.0) for first CURRENT_PROJECT_VERSION (${IOS_PROJECT_VERSION_2}) on ios/HathorMobile.xcodeproj/project.pbxproj"
       EXITCODE=-1
   fi
 fi


### PR DESCRIPTION
### Acceptance Criteria
- CI should correctly validate all release candidate version declarations on the app
- Fixes #375 

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
