### PR TITLE
Feat: Allow user to close numeric keyboard on iOS

### DIFF
--- a/src/screens/CreateTokenAmount.js
+++ b/src/screens/CreateTokenAmount.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { KeyboardAvoidingView, Text, View } from 'react-native';
+import { Keyboard, KeyboardAvoidingView, Pressable, Text, View } from 'react-native';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
 import { t, jt } from 'ttag';
@@ -115,44 +115,46 @@ class CreateTokenAmount extends React.Component {
 
     return (
       <View style={{ flex: 1 }}>
-        <HathorHeader
-          title={t`CREATE TOKEN`}
-          onBackPress={() => this.props.navigation.goBack()}
-          onCancel={() => this.props.navigation.getParent().goBack()}
-        />
-        <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
-          <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>
-            <View style={{ marginTop: 24 }}>
-              <InputLabel style={{ textAlign: 'center', marginBottom: 16 }}>
-                {t`Amount of ${this.name} (${this.symbol})`}
-              </InputLabel>
-              <AmountTextInput
-                ref={this.inputRef}
-                autoFocus
-                onAmountUpdate={this.onAmountChange}
-                value={this.state.amount}
-              />
+        <Pressable style={{ flex: 1 }} onPress={() => Keyboard.dismiss()}>
+          <HathorHeader
+            title={t`CREATE TOKEN`}
+            onBackPress={() => this.props.navigation.goBack()}
+            onCancel={() => this.props.navigation.getParent().goBack()}
+          />
+          <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getKeyboardAvoidingViewTopDistance()}>
+            <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>
+              <View style={{ marginTop: 24 }}>
+                <InputLabel style={{ textAlign: 'center', marginBottom: 16 }}>
+                  {t`Amount of ${this.name} (${this.symbol})`}
+                </InputLabel>
+                <AmountTextInput
+                  ref={this.inputRef}
+                  autoFocus
+                  onAmountUpdate={this.onAmountChange}
+                  value={this.state.amount}
+                />
+              </View>
+              <View>
+                <InfoBox
+                  items={[
+                    <Text>{t`Deposit:`} <Strong style={amountStyle}>
+                      {hathorLib.numberUtils.prettyValue(this.state.deposit)} HTR
+                    </Strong></Text>,
+                    <Text>
+                      {jt`You have ${amountAvailableText} HTR available`}
+                    </Text>
+                  ]}
+                />
+                <NewHathorButton
+                  title={t`Next`}
+                  disabled={this.isButtonDisabled()}
+                  onPress={this.onButtonPress}
+                />
+              </View>
             </View>
-            <View>
-              <InfoBox
-                items={[
-                  <Text>{t`Deposit:`} <Strong style={amountStyle}>
-                    {hathorLib.numberUtils.prettyValue(this.state.deposit)} HTR
-                  </Strong></Text>,
-                  <Text>
-                    {jt`You have ${amountAvailableText} HTR available`}
-                  </Text>
-                ]}
-              />
-              <NewHathorButton
-                title={t`Next`}
-                disabled={this.isButtonDisabled()}
-                onPress={this.onButtonPress}
-              />
-            </View>
-          </View>
-          <OfflineBar style={{ position: 'relative' }} />
-        </KeyboardAvoidingView>
+            <OfflineBar style={{ position: 'relative' }} />
+          </KeyboardAvoidingView>
+        </Pressable>
       </View>
     );
   }

--- a/src/screens/Receive.js
+++ b/src/screens/Receive.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { Dimensions, Keyboard, View } from 'react-native';
+import { Dimensions, Keyboard, Pressable, View } from 'react-native';
 import { t } from 'ttag';
 
 import { TabBar, TabView } from 'react-native-tab-view';
@@ -102,18 +102,20 @@ class ReceiveScreen extends React.Component {
 
     return (
       <View style={{ flex: 1 }}>
-        <HathorHeader
-          title={t`RECEIVE`}
-          withBorder
-        />
-        <TabView
-          renderTabBar={(props) => renderTabBar(props)}
-          navigationState={this.state}
-          renderScene={this.renderScene}
-          onIndexChange={this.handleIndexChange}
-          initialLayout={{ width: Dimensions.get('window').width }}
-        />
-        <OfflineBar />
+        <Pressable style={{ flex: 1 }} onPress={() => Keyboard.dismiss()}>
+          <HathorHeader
+            title={t`RECEIVE`}
+            withBorder
+          />
+          <TabView
+            renderTabBar={(props) => renderTabBar(props)}
+            navigationState={this.state}
+            renderScene={this.renderScene}
+            onIndexChange={this.handleIndexChange}
+            initialLayout={{ width: Dimensions.get('window').width }}
+          />
+          <OfflineBar />
+        </Pressable>
       </View>
     );
   }

--- a/src/screens/SendAmountInput.js
+++ b/src/screens/SendAmountInput.js
@@ -7,7 +7,12 @@
 
 import React from 'react';
 import {
-  KeyboardAvoidingView, StyleSheet, Text, View,
+  Keyboard,
+  KeyboardAvoidingView,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
 } from 'react-native';
 import { connect } from 'react-redux';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
@@ -143,12 +148,13 @@ class SendAmountInput extends React.Component {
     const tokenNameUpperCase = this.state.token.name.toUpperCase();
     return (
       <View style={{ flex: 1 }}>
-        <HathorHeader
-          withBorder
-          title={t`SEND ${tokenNameUpperCase}`}
-          onBackPress={() => this.props.navigation.goBack()}
-        />
-        <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getStatusBarHeight()}>
+        <Pressable style={{ flex: 1 }} onPress={() => Keyboard.dismiss()}>
+          <HathorHeader
+            withBorder
+            title={t`SEND ${tokenNameUpperCase}`}
+            onBackPress={() => this.props.navigation.goBack()}
+          />
+          <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getStatusBarHeight()}>
           <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>
             <View>
               <View style={{
@@ -183,6 +189,7 @@ class SendAmountInput extends React.Component {
           </View>
           <OfflineBar style={{ position: 'relative' }} />
         </KeyboardAvoidingView>
+        </Pressable>
       </View>
     );
   }

--- a/src/screens/SendAmountInput.js
+++ b/src/screens/SendAmountInput.js
@@ -155,40 +155,40 @@ class SendAmountInput extends React.Component {
             onBackPress={() => this.props.navigation.goBack()}
           />
           <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getStatusBarHeight()}>
-          <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>
-            <View>
-              <View style={{
-                flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 40,
-              }}
-              >
-                {renderGhostElement()}
-                <AmountTextInput
-                  ref={this.inputRef}
-                  autoFocus
-                  onAmountUpdate={this.onAmountChange}
-                  value={this.state.amount}
-                  allowOnlyInteger={this.isNFT()}
-                  style={{ flex: 1 }} // we need this so the placeholder doesn't break in android
-                                      // devices after erasing the text
-                                      // https://github.com/facebook/react-native/issues/30666
-                />
-                {IS_MULTI_TOKEN
-                  ? <TokenBox onPress={this.onTokenBoxPress} label={this.state.token.symbol} />
-                  : renderGhostElement()}
+            <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>
+              <View>
+                <View style={{
+                  flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 40,
+                }}
+                >
+                  {renderGhostElement()}
+                  <AmountTextInput
+                    ref={this.inputRef}
+                    autoFocus
+                    onAmountUpdate={this.onAmountChange}
+                    value={this.state.amount}
+                    allowOnlyInteger={this.isNFT()}
+                    style={{ flex: 1 }} // we need this so the placeholder doesn't break in android
+                                        // devices after erasing the text
+                                        // https://github.com/facebook/react-native/issues/30666
+                  />
+                  {IS_MULTI_TOKEN
+                    ? <TokenBox onPress={this.onTokenBoxPress} label={this.state.token.symbol} />
+                    : renderGhostElement()}
+                </View>
+                <InputLabel style={{ textAlign: 'center', marginTop: 8 }}>
+                  {getAvailableString()}
+                </InputLabel>
+                <Text style={styles.error}>{this.state.error}</Text>
               </View>
-              <InputLabel style={{ textAlign: 'center', marginTop: 8 }}>
-                {getAvailableString()}
-              </InputLabel>
-              <Text style={styles.error}>{this.state.error}</Text>
+              <NewHathorButton
+                title={t`Next`}
+                disabled={this.isButtonDisabled()}
+                onPress={this.onButtonPress}
+              />
             </View>
-            <NewHathorButton
-              title={t`Next`}
-              disabled={this.isButtonDisabled()}
-              onPress={this.onButtonPress}
-            />
-          </View>
-          <OfflineBar style={{ position: 'relative' }} />
-        </KeyboardAvoidingView>
+            <OfflineBar style={{ position: 'relative' }} />
+          </KeyboardAvoidingView>
         </Pressable>
       </View>
     );


### PR DESCRIPTION
# Summary
As described in #402 , the user is unable to close the numeric keyboard on iOS. On some occasions this causes a bad user experience.

This PR fixes this by adding a press event handler on the screens that exhibit a numeric keyboard.

### Acceptance Criteria
- The user should be able to close the numeric keyboard on iOS
- Fixes #402

> [!TIP] 
> In total, just a few lines had actual text modified. The rest of the modified lines were only due to indentation adjustments.
> To better visualize the actual changes I suggest using the "Hide whitespace" feature on GitHub, as it highlights only the words that were changed on this file, and not the indentation adjustments that were necessary:
>
> ![Ignore Whitespace Diff](https://github.com/HathorNetwork/hathor-wallet/assets/1299409/1b603254-b05e-4698-80bb-c6360fd227c0)


### Demonstration
Although the video does not exhibit the finger press locations, it's possible to understand the overall interaction: by pressing anywhere on the screen other than the numeric input, the user is able to close the numeric keyboard.

https://github.com/HathorNetwork/hathor-wallet-mobile/assets/1299409/3bb39761-7713-41dc-a35d-4c77dcfcde29

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
