### PR TITLE
feat: sending appVersion as a property on unleash

### DIFF
--- a/src/sagas/featureToggle.js
+++ b/src/sagas/featureToggle.js
@@ -6,6 +6,7 @@
  */
 
 import { Platform } from 'react-native';
+import VersionNumber from 'react-native-version-number';
 import { UnleashClient, EVENTS as UnleashEvents } from 'unleash-proxy-client';
 import { get } from 'lodash';
 
@@ -89,11 +90,15 @@ export function* monitorFeatureFlags(currentRetry = 0) {
     disableRefresh: true, // Disable it, we will handle it ourselves
     appName: `wallet-mobile-${Platform.OS}`,
   });
+
+  const { appVersion } = VersionNumber;
+
   const options = {
     userId: getUniqueId(),
     properties: {
       platform: Platform.OS,
       stage: STAGE,
+      appVersion,
     },
   };
 


### PR DESCRIPTION
### Acceptance Criteria
- We should send the `appVersion` to Unleash so we can filter users depending on their versions

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
