### PR TITLE
fix: push notification registration latency on PinScreen

### DIFF
--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -378,6 +378,7 @@ export function* loadWallet() {
       });
     } catch (error) {
       yield put(pushLoadWalletFailed({ error }));
+      return;
     }
   } else {
     walletService = yield select((state) => state.wallet);

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -362,7 +362,7 @@ export function* loadWallet() {
 
     // Delay 300ms to resume script execution in the next loop.
     // This solution liberates the PinScreen to dismiss.
-    yield race([delay(300)]);
+    yield delay(300);
 
     const seed = yield STORE.getWalletWords(pin);
     walletService = new HathorWalletServiceWallet({

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -15,6 +15,7 @@ import {
   take,
   takeLatest,
   debounce,
+  delay,
 } from 'redux-saga/effects';
 import messaging from '@react-native-firebase/messaging';
 import notifee from '@notifee/react-native';
@@ -358,6 +359,11 @@ export function* loadWallet() {
     const network = new Network(networkSettings.network);
 
     const pin = yield call(showPinScreenForResult, dispatch);
+
+    // Delay 300ms to resume script execution in the next loop.
+    // This solution liberates the PinScreen to dismiss.
+    yield race([delay(300)]);
+
     const seed = yield STORE.getWalletWords(pin);
     walletService = new HathorWalletServiceWallet({
       seed,

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -393,7 +393,7 @@ export function* loadWallet() {
  */
 const hasPostNotificationAuthorization = async () => {
   let status = await messaging().hasPermission();
-  if (status === messaging.AuthorizationStatus.BLOCKED) {
+  if (status === messaging.AuthorizationStatus.DENIED) {
     log.debug('Device not authorized to send push notification and blocked to ask permission.');
     return false;
   }

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -398,14 +398,14 @@ const hasPostNotificationAuthorization = async () => {
     return false;
   }
 
-  if (status === messaging.AuthorizationStatus.NOT_DETERMINED) {
-    log.debug('Device clean. Asking for permission to send push notification.');
+  if (status === messaging.AuthorizationStatus.NOT_DETERMINED
+  || status === messaging.AuthorizationStatus.EPHEMERAL
+  || status === messaging.AuthorizationStatus.PROVISIONAL) {
+    log.debug('Asking for permission to send push notification.');
     status = await messaging().requestPermission();
   }
 
-  log.debug('Device permission status: ', status);
-  return status === messaging.AuthorizationStatus.AUTHORIZED
-      || status === messaging.AuthorizationStatus.PROVISIONAL;
+  return status === messaging.AuthorizationStatus.AUTHORIZED;
 };
 
 /**


### PR DESCRIPTION
### Acceptance Criteria
- fix: PinScreen dismiss response
- fix: exits script after dispatch failure effect
- fix: replace BLOCKED to DENIED enum value
- fix: push notification authorization logic

PinScreen response latency now in miliseconds:

https://github.com/HathorNetwork/hathor-wallet-mobile/assets/5992210/97403ac8-0cf8-4cf3-b24a-d688483d5858

Closes: https://github.com/HathorNetwork/hathor-wallet-mobile/issues/415

---

# Performance Profiling

We have 2 major offenders:
- `generateAccessDataFromSeed` consuming ~4s
- `generateCreateWalletAuthData` consuming ~14s

Under `generateCreateWalletAuthData` we have other 3 offenders:
- `getXPrivKeyFromSeed` using ~4s
- `getXPubKeyFromSeed` using ~4s
- `getAuthXPubKeyFromSeed` using ~4s

Both `getXPubKeyFromSeed` and `getAuthXPubKeyFromSeed` calls `getXPrivKeyFromSeed` under the hood, which took almost all execution time. Therefore the real offender for this group is `getXPrivKeyFromSeed`.

![image](https://github.com/HathorNetwork/hathor-wallet-mobile/assets/5992210/87c06a12-93c7-4931-91cd-48ab65c35f63)

## Wallet `start`

Both methods `generateAccessDataFromSeed` and `generateCreateWalletAuthData` are called from wallet `start`. We start an instance of `HathorWalletServiceWallet` when a user is operating a fullnode's wallet facade.

There are 4 options to try to solve or reduce the effect of this latency, either:

1. We implement a common wallet API to mount an authentication payload that can be used to call wallet-service API without the need to instantiate `HathorWalletServiceWallet`.
1. We store the `HathorWalletServiceWallet` instance once it is started for the first time, which can decrease the latency for subsequent interactions with push notification operations.
1. We remove support of push notification for users operating a fullnode's wallet facade and make it a feature strict to wallet-service users; which would allow us to remove this logic to instantiate a `HathorWalletServiceWallet`.
1. We implement a lightweight wallet just for the purpose to call wallet-service APIs.

We can discuss other possibilities, these ones were the ones I identified quickly without thinking too much.

>[!NOTE]
> PM me to get the profiler.

---

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
