### PR TITLE
fix: custom network settings form

### DIFF
--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -677,11 +677,11 @@ msgstr "SEND ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Din overførsel behandles"
 
-#: src/sagas/helpers.js:132 src/screens/SendConfirmScreen.js:104
+#: src/sagas/helpers.js:136 src/screens/SendConfirmScreen.js:104
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Indtast din 6-cifrede pin for at godkende overførslen"
 
-#: src/sagas/helpers.js:133 src/screens/SendConfirmScreen.js:105
+#: src/sagas/helpers.js:137 src/screens/SendConfirmScreen.js:105
 msgid "Authorize operation"
 msgstr "Autoriserer overførslen"
 
@@ -693,7 +693,7 @@ msgstr "Din overførsel af **${ _this.amountAndToken }** er bekræftet"
 msgid "Address"
 msgstr "Adresse"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:264
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:288
 #: src/screens/SendConfirmScreen.js:168
 msgid "Send"
 msgstr "Send"
@@ -760,11 +760,11 @@ msgstr ""
 msgid "Unregister"
 msgstr "Afmeld"
 
-#: src/screens/UnregisterToken.js:112
+#: src/screens/UnregisterToken.js:108
 msgid "UNREGISTER TOKEN"
 msgstr "AFREGISTRER TOKEN"
 
-#: src/screens/UnregisterToken.js:117
+#: src/screens/UnregisterToken.js:113
 msgid ""
 "If you unregister this token **you won't be able to execute operations with "
 "it**, unless you register it again."
@@ -772,17 +772,17 @@ msgstr ""
 "Hvis du afregistrerer denne token, **kan du ikke udføre funktioner med "
 "den**, medmindre du registrerer den igen."
 
-#: src/screens/UnregisterToken.js:120
+#: src/screens/UnregisterToken.js:116
 msgid ""
 "You won't lose your tokens, they will just not appear on this wallet anymore."
 msgstr "Du mister ikke dine tokens, de vises bare ikke længere i denne wallet."
 
-#: src/screens/UnregisterToken.js:124
+#: src/screens/UnregisterToken.js:120
 #, javascript-format
 msgid "I want to unregister the token **${ tokenLabel }**"
 msgstr "Jeg vil afregistrere token **${ tokenLabel }**"
 
-#: src/screens/UnregisterToken.js:139
+#: src/screens/UnregisterToken.js:135
 msgid "Unregister token"
 msgstr "Afregistrer token"
 
@@ -874,27 +874,35 @@ msgstr ""
 msgid "txMiningServiceUrl is required."
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:205
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:62
+msgid "walletServiceUrl is required when walletServiceWsUrl is filled."
+msgstr ""
+
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:65
+msgid "walletServiceWsUrl is required when walletServiceUrl is filled."
+msgstr ""
+
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:229
 msgid "Node URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:214
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:239
 msgid "Explorer URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:223
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:248
 msgid "Explorer Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:257
 msgid "Transaction Mining Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:243
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:268
 msgid "Wallet Service URL (optional)"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:277
 msgid "Wallet Service WS URL (optional)"
 msgstr ""
 
@@ -951,23 +959,23 @@ msgstr ""
 msgid "Wallet not found while trying to persist the custom network settings."
 msgstr ""
 
-#: src/sagas/pushNotification.js:57
+#: src/sagas/pushNotification.js:59
 msgid "Transaction"
 msgstr "Ingen transaktioner"
 
-#: src/sagas/pushNotification.js:58
+#: src/sagas/pushNotification.js:60
 msgid "Open"
 msgstr "Åben"
 
-#: src/components/AskForPushNotification.js:21
+#: src/components/AskForPushNotification.js:22
 msgid "Do you want to enable push notifications for this wallet?"
 msgstr ""
 
-#: src/components/AskForPushNotification.js:22
+#: src/components/AskForPushNotification.js:23
 msgid "You can always change this later in the settings menu"
 msgstr ""
 
-#: src/components/AskForPushNotification.js:23
+#: src/components/AskForPushNotification.js:24
 msgid "Yes, enable"
 msgstr ""
 

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -693,11 +693,11 @@ msgstr "ENVIAR ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Sua transferência está sendo processada"
 
-#: src/sagas/helpers.js:132 src/screens/SendConfirmScreen.js:104
+#: src/sagas/helpers.js:136 src/screens/SendConfirmScreen.js:104
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Digite seu PIN de 6 dígitos para autorizar a operação"
 
-#: src/sagas/helpers.js:133 src/screens/SendConfirmScreen.js:105
+#: src/sagas/helpers.js:137 src/screens/SendConfirmScreen.js:105
 msgid "Authorize operation"
 msgstr "Autorizar operação"
 
@@ -709,7 +709,7 @@ msgstr "Sua transferência de **${ this.amountAndToken }** foi confirmada"
 msgid "Address"
 msgstr "Endereço"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:264
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:288
 #: src/screens/SendConfirmScreen.js:168
 msgid "Send"
 msgstr "Enviar"
@@ -776,11 +776,11 @@ msgstr "Configurações de Rede"
 msgid "Unregister"
 msgstr "Desregistrar"
 
-#: src/screens/UnregisterToken.js:112
+#: src/screens/UnregisterToken.js:108
 msgid "UNREGISTER TOKEN"
 msgstr "DESREGISTRAR TOKEN"
 
-#: src/screens/UnregisterToken.js:117
+#: src/screens/UnregisterToken.js:113
 msgid ""
 "If you unregister this token **you won't be able to execute operations with "
 "it**, unless you register it again."
@@ -788,19 +788,19 @@ msgstr ""
 "Se você desregistrar esse token **você não conseguirá mais executar "
 "operações com ele**, a não ser que você o registre novamente."
 
-#: src/screens/UnregisterToken.js:120
+#: src/screens/UnregisterToken.js:116
 msgid ""
 "You won't lose your tokens, they will just not appear on this wallet anymore."
 msgstr ""
 "Você não irá perder os seus tokens, eles apenas não irão mais aparecer nessa "
 "wallet."
 
-#: src/screens/UnregisterToken.js:124
+#: src/screens/UnregisterToken.js:120
 #, javascript-format
 msgid "I want to unregister the token **${ tokenLabel }**"
 msgstr "Eu quero desregistrar o token **${ tokenLabel }**"
 
-#: src/screens/UnregisterToken.js:139
+#: src/screens/UnregisterToken.js:135
 msgid "Unregister token"
 msgstr "Desregistrar token"
 
@@ -897,27 +897,35 @@ msgstr "explorerServiceUrl é obrigatório."
 msgid "txMiningServiceUrl is required."
 msgstr "txMiningServiceUrl é obrigatório."
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:205
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:62
+msgid "walletServiceUrl is required when walletServiceWsUrl is filled."
+msgstr "walletServiceUrl é obrigatório quando walletServiceWsUrl está preenchido."
+
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:65
+msgid "walletServiceWsUrl is required when walletServiceUrl is filled."
+msgstr "walletServiceWsUrl é obrigatório quando walletServiceUrl está preenchido"
+
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:229
 msgid "Node URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:214
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:239
 msgid "Explorer URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:223
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:248
 msgid "Explorer Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:257
 msgid "Transaction Mining Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:243
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:268
 msgid "Wallet Service URL (optional)"
 msgstr "Wallet Service URL (opcional)"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:277
 msgid "Wallet Service WS URL (optional)"
 msgstr "Wallet Service WS URL (opcional)"
 
@@ -978,23 +986,23 @@ msgid "Wallet not found while trying to persist the custom network settings."
 msgstr ""
 "Wallet não encontrada ao persistir a configuração personalizada da rede."
 
-#: src/sagas/pushNotification.js:57
+#: src/sagas/pushNotification.js:59
 msgid "Transaction"
 msgstr "Transação"
 
-#: src/sagas/pushNotification.js:58
+#: src/sagas/pushNotification.js:60
 msgid "Open"
 msgstr "Abrir"
 
-#: src/components/AskForPushNotification.js:21
+#: src/components/AskForPushNotification.js:22
 msgid "Do you want to enable push notifications for this wallet?"
 msgstr "Você deseja habilitar as notificações para esta wallet?"
 
-#: src/components/AskForPushNotification.js:22
+#: src/components/AskForPushNotification.js:23
 msgid "You can always change this later in the settings menu"
 msgstr "Você sempre pode alterar as configurações depois no menu"
 
-#: src/components/AskForPushNotification.js:23
+#: src/components/AskForPushNotification.js:24
 msgid "Yes, enable"
 msgstr "Sim, habilitar"
 

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -679,11 +679,11 @@ msgstr "ОТПРАВИТЬ ${ tokenNameUpperCase }"
 msgid "Your transfer is being processed"
 msgstr "Ваш перевод обрабатывается"
 
-#: src/sagas/helpers.js:132 src/screens/SendConfirmScreen.js:104
+#: src/sagas/helpers.js:136 src/screens/SendConfirmScreen.js:104
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Введите 6-значный PIN-код для авторизации операции"
 
-#: src/sagas/helpers.js:133 src/screens/SendConfirmScreen.js:105
+#: src/sagas/helpers.js:137 src/screens/SendConfirmScreen.js:105
 msgid "Authorize operation"
 msgstr "Авторизовать операцию"
 
@@ -695,7 +695,7 @@ msgstr "Ваш перевод **${ this.amountAndToken }** был подтвер
 msgid "Address"
 msgstr "Адрес"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:264
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:288
 #: src/screens/SendConfirmScreen.js:168
 msgid "Send"
 msgstr "Отправить"
@@ -762,11 +762,11 @@ msgstr ""
 msgid "Unregister"
 msgstr "Отменить регистрацию"
 
-#: src/screens/UnregisterToken.js:112
+#: src/screens/UnregisterToken.js:108
 msgid "UNREGISTER TOKEN"
 msgstr "ОТМЕНИТЬ РЕГИСТРАЦИЮ ТОКЕНА"
 
-#: src/screens/UnregisterToken.js:117
+#: src/screens/UnregisterToken.js:113
 msgid ""
 "If you unregister this token **you won't be able to execute operations with "
 "it**, unless you register it again."
@@ -774,19 +774,19 @@ msgstr ""
 "Если вы отмените регистрацию этого токена, **вы не сможете выполнять "
 "операции с ним**, пока не зарегистрируете его снова."
 
-#: src/screens/UnregisterToken.js:120
+#: src/screens/UnregisterToken.js:116
 msgid ""
 "You won't lose your tokens, they will just not appear on this wallet anymore."
 msgstr ""
 "Вы не потеряете свои токены, они просто больше не будут появляться на этом "
 "кошельке."
 
-#: src/screens/UnregisterToken.js:124
+#: src/screens/UnregisterToken.js:120
 #, javascript-format
 msgid "I want to unregister the token **${ tokenLabel }**"
 msgstr "Я хочу отменить регистрацию токена **${ tokenLabel }**"
 
-#: src/screens/UnregisterToken.js:139
+#: src/screens/UnregisterToken.js:135
 msgid "Unregister token"
 msgstr "Отменить регистрацию токена"
 
@@ -878,27 +878,35 @@ msgstr ""
 msgid "txMiningServiceUrl is required."
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:205
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:62
+msgid "walletServiceUrl is required when walletServiceWsUrl is filled."
+msgstr ""
+
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:65
+msgid "walletServiceWsUrl is required when walletServiceUrl is filled."
+msgstr ""
+
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:229
 msgid "Node URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:214
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:239
 msgid "Explorer URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:223
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:248
 msgid "Explorer Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:257
 msgid "Transaction Mining Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:243
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:268
 msgid "Wallet Service URL (optional)"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:277
 msgid "Wallet Service WS URL (optional)"
 msgstr ""
 
@@ -955,23 +963,23 @@ msgstr ""
 msgid "Wallet not found while trying to persist the custom network settings."
 msgstr ""
 
-#: src/sagas/pushNotification.js:57
+#: src/sagas/pushNotification.js:59
 msgid "Transaction"
 msgstr "Нет транзакций"
 
-#: src/sagas/pushNotification.js:58
+#: src/sagas/pushNotification.js:60
 msgid "Open"
 msgstr "Открыть"
 
-#: src/components/AskForPushNotification.js:21
+#: src/components/AskForPushNotification.js:22
 msgid "Do you want to enable push notifications for this wallet?"
 msgstr ""
 
-#: src/components/AskForPushNotification.js:22
+#: src/components/AskForPushNotification.js:23
 msgid "You can always change this later in the settings menu"
 msgstr ""
 
-#: src/components/AskForPushNotification.js:23
+#: src/components/AskForPushNotification.js:24
 msgid "Yes, enable"
 msgstr ""
 

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -671,12 +671,12 @@ msgstr ""
 msgid "Your transfer is being processed"
 msgstr ""
 
-#: src/sagas/helpers.js:132
+#: src/sagas/helpers.js:136
 #: src/screens/SendConfirmScreen.js:104
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr ""
 
-#: src/sagas/helpers.js:133
+#: src/sagas/helpers.js:137
 #: src/screens/SendConfirmScreen.js:105
 msgid "Authorize operation"
 msgstr ""
@@ -689,7 +689,7 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:264
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:288
 #: src/screens/SendConfirmScreen.js:168
 msgid "Send"
 msgstr ""
@@ -756,28 +756,28 @@ msgstr ""
 msgid "Unregister"
 msgstr ""
 
-#: src/screens/UnregisterToken.js:112
+#: src/screens/UnregisterToken.js:108
 msgid "UNREGISTER TOKEN"
 msgstr ""
 
-#: src/screens/UnregisterToken.js:117
+#: src/screens/UnregisterToken.js:113
 msgid ""
 "If you unregister this token **you won't be able to execute operations with "
 "it**, unless you register it again."
 msgstr ""
 
-#: src/screens/UnregisterToken.js:120
+#: src/screens/UnregisterToken.js:116
 msgid ""
 "You won't lose your tokens, they will just not appear on this wallet "
 "anymore."
 msgstr ""
 
-#: src/screens/UnregisterToken.js:124
+#: src/screens/UnregisterToken.js:120
 #, javascript-format
 msgid "I want to unregister the token **${ tokenLabel }**"
 msgstr ""
 
-#: src/screens/UnregisterToken.js:139
+#: src/screens/UnregisterToken.js:135
 msgid "Unregister token"
 msgstr ""
 
@@ -869,27 +869,35 @@ msgstr ""
 msgid "txMiningServiceUrl is required."
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:205
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:62
+msgid "walletServiceUrl is required when walletServiceWsUrl is filled."
+msgstr ""
+
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:65
+msgid "walletServiceWsUrl is required when walletServiceUrl is filled."
+msgstr ""
+
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:229
 msgid "Node URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:214
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:239
 msgid "Explorer URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:223
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:248
 msgid "Explorer Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:257
 msgid "Transaction Mining Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:243
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:268
 msgid "Wallet Service URL (optional)"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:277
 msgid "Wallet Service WS URL (optional)"
 msgstr ""
 
@@ -946,23 +954,23 @@ msgstr ""
 msgid "Wallet not found while trying to persist the custom network settings."
 msgstr ""
 
-#: src/sagas/pushNotification.js:57
+#: src/sagas/pushNotification.js:59
 msgid "Transaction"
 msgstr ""
 
-#: src/sagas/pushNotification.js:58
+#: src/sagas/pushNotification.js:60
 msgid "Open"
 msgstr ""
 
-#: src/components/AskForPushNotification.js:21
+#: src/components/AskForPushNotification.js:22
 msgid "Do you want to enable push notifications for this wallet?"
 msgstr ""
 
-#: src/components/AskForPushNotification.js:22
+#: src/components/AskForPushNotification.js:23
 msgid "You can always change this later in the settings menu"
 msgstr ""
 
-#: src/components/AskForPushNotification.js:23
+#: src/components/AskForPushNotification.js:24
 msgid "Yes, enable"
 msgstr ""
 

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -183,7 +183,7 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
   return (
     <KeyboardAvoidingView
       behavior='padding'
-      style={{flex: 1}}
+      style={{ flex: 1 }}
       keyboardVerticalOffset={48} /* some size for padding bottom on formWrapper */
     >
       <View style={styles.wrapper}>
@@ -223,64 +223,64 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
 
         <ScrollView>
           <View style={[styles.container, styles.formWrapper]}>
+            <SimpleInput
+              keyboardType='url'
+              containerStyle={styles.input}
+              label={t`Node URL`}
+              autoFocus
+              onChangeText={handleInputChange('nodeUrl')}
+              error={invalidModel.nodeUrl}
+              value={formModel.nodeUrl}
+            />
+
+            <SimpleInput
+              keyboardType='url'
+              containerStyle={styles.input}
+              label={t`Explorer URL`}
+              onChangeText={handleInputChange('explorerUrl')}
+              error={invalidModel.explorerUrl}
+              value={formModel.explorerUrl}
+            />
+
+            <SimpleInput
+              keyboardType='url'
+              containerStyle={styles.input}
+              label={t`Explorer Service URL`}
+              onChangeText={handleInputChange('explorerServiceUrl')}
+              error={invalidModel.explorerServiceUrl}
+              value={formModel.explorerServiceUrl}
+            />
+
+            <SimpleInput
+              keyboardType='url'
+              containerStyle={styles.input}
+              label={t`Transaction Mining Service URL`}
+              onChangeText={handleInputChange('txMiningServiceUrl')}
+              error={invalidModel.txMiningServiceUrl}
+              value={formModel.txMiningServiceUrl}
+            />
+
+            {walletServiceEnabled && (
+            <>
               <SimpleInput
                 keyboardType='url'
                 containerStyle={styles.input}
-                label={t`Node URL`}
-                autoFocus
-                onChangeText={handleInputChange('nodeUrl')}
-                error={invalidModel.nodeUrl}
-                value={formModel.nodeUrl}
+                label={t`Wallet Service URL (optional)`}
+                onChangeText={handleInputChange('walletServiceUrl')}
+                error={invalidModel.walletServiceUrl}
+                value={formModel.walletServiceUrl}
               />
 
               <SimpleInput
                 keyboardType='url'
                 containerStyle={styles.input}
-                label={t`Explorer URL`}
-                onChangeText={handleInputChange('explorerUrl')}
-                error={invalidModel.explorerUrl}
-                value={formModel.explorerUrl}
+                label={t`Wallet Service WS URL (optional)`}
+                onChangeText={handleInputChange('walletServiceWsUrl')}
+                error={invalidModel.walletServiceWsUrl}
+                value={formModel.walletServiceWsUrl}
               />
-
-              <SimpleInput
-                keyboardType='url'
-                containerStyle={styles.input}
-                label={t`Explorer Service URL`}
-                onChangeText={handleInputChange('explorerServiceUrl')}
-                error={invalidModel.explorerServiceUrl}
-                value={formModel.explorerServiceUrl}
-              />
-
-              <SimpleInput
-                keyboardType='url'
-                containerStyle={styles.input}
-                label={t`Transaction Mining Service URL`}
-                onChangeText={handleInputChange('txMiningServiceUrl')}
-                error={invalidModel.txMiningServiceUrl}
-                value={formModel.txMiningServiceUrl}
-              />
-
-              {walletServiceEnabled && (
-                <>
-                  <SimpleInput
-                    keyboardType='url'
-                    containerStyle={styles.input}
-                    label={t`Wallet Service URL (optional)`}
-                    onChangeText={handleInputChange('walletServiceUrl')}
-                    error={invalidModel.walletServiceUrl}
-                    value={formModel.walletServiceUrl}
-                  />
-
-                  <SimpleInput
-                    keyboardType='url'
-                    containerStyle={styles.input}
-                    label={t`Wallet Service WS URL (optional)`}
-                    onChangeText={handleInputChange('walletServiceWsUrl')}
-                    error={invalidModel.walletServiceWsUrl}
-                    value={formModel.walletServiceWsUrl}
-                  />
-                </>
-              )}
+            </>
+            )}
 
             <NewHathorButton
               disabled={hasError(invalidModel)}

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Image } from 'react-native';
+import { View, Text, StyleSheet, Image, ScrollView, KeyboardAvoidingView } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { t } from 'ttag';
 import { isEmpty } from 'lodash';
@@ -57,22 +57,23 @@ function validate(formModel) {
 }
 
 const styles = StyleSheet.create({
-  container: {
+  wrapper: {
     flex: 1,
   },
-  content: {
-    flex: 1,
-    padding: 16,
-    paddingBottom: 48,
+  container: {
+    paddingHorizontal: 16,
   },
   feedbackModalIcon: {
     height: 105,
     width: 105
   },
-  warningContainer: {
+  warningWrapper: {
+    paddingVertical: 16,
+  },
+  warningCard: {
+    flexShrink: 1,
     borderRadius: 8,
     backgroundColor: AlertUI.lightColor,
-    marginBottom: 32,
     borderWidth: 1,
     borderColor: AlertUI.baseHslColor.addLightness(4).toString(),
   },
@@ -81,12 +82,11 @@ const styles = StyleSheet.create({
     color: AlertUI.darkColor,
     padding: 12,
   },
+  formWrapper: {
+    paddingBottom: 16,
+  },
   input: {
     marginBottom: 24,
-  },
-  buttonContainer: {
-    alignSelf: 'stretch',
-    marginTop: 'auto',
   },
 });
 
@@ -167,104 +167,115 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
   }, []);
 
   return (
-    <View style={styles.container}>
-      <HathorHeader
-        title={customNetworkSettingsTitleText}
-        onBackPress={() => navigation.goBack()}
-      />
-
-      {isLoading(networkSettingsStatus) && (
-        <FeedbackModal
-          icon={<Spinner />}
-          text={feedbackLoadingText}
-        />
-      )}
-
-      {hasSucceed(networkSettingsStatus) && (
-        <FeedbackModal
-          icon={(<Image source={checkIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
-          text={feedbackSucceedText}
-          onDismiss={handleFeedbackModalDismiss}
-        />
-      )}
-
-      {hasFailed(networkSettingsStatus) && (
-        <FeedbackModal
-          icon={(<Image source={errorIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
-          text={feedbackFailedText}
-          onDismiss={handleFeedbackModalDismiss}
-        />
-      )}
-
-      <View style={styles.content}>
-        <View style={styles.warningContainer}>
-          <Text style={styles.warningMessage}>{warningText}</Text>
-        </View>
-        <SimpleInput
-          containerStyle={styles.input}
-          label={t`Node URL`}
-          autoFocus
-          onChangeText={handleInputChange('nodeUrl')}
-          error={invalidModel.nodeUrl}
-          value={formModel.nodeUrl}
+    <KeyboardAvoidingView
+      behavior='padding'
+      style={{flex: 1}}
+      keyboardVerticalOffset={48} /* some size for padding bottom on formWrapper */
+    >
+      <View style={styles.wrapper}>
+        <HathorHeader
+          title={customNetworkSettingsTitleText}
+          onBackPress={() => navigation.goBack()}
         />
 
-        <SimpleInput
-          containerStyle={styles.input}
-          label={t`Explorer URL`}
-          autoFocus
-          onChangeText={handleInputChange('explorerUrl')}
-          error={invalidModel.explorerUrl}
-          value={formModel.explorerUrl}
-        />
-
-        <SimpleInput
-          containerStyle={styles.input}
-          label={t`Explorer Service URL`}
-          autoFocus
-          onChangeText={handleInputChange('explorerServiceUrl')}
-          error={invalidModel.explorerServiceUrl}
-          value={formModel.explorerServiceUrl}
-        />
-
-        <SimpleInput
-          containerStyle={styles.input}
-          label={t`Transaction Mining Service URL`}
-          autoFocus
-          onChangeText={handleInputChange('txMiningServiceUrl')}
-          error={invalidModel.txMiningServiceUrl}
-          value={formModel.txMiningServiceUrl}
-        />
-
-        {walletServiceEnabled && (
-          <>
-            <SimpleInput
-              containerStyle={styles.input}
-              label={t`Wallet Service URL (optional)`}
-              autoFocus
-              onChangeText={handleInputChange('walletServiceUrl')}
-              error={invalidModel.walletServiceUrl}
-              value={formModel.walletServiceUrl}
-            />
-            <SimpleInput
-              containerStyle={styles.input}
-              label={t`Wallet Service WS URL (optional)`}
-              autoFocus
-              onChangeText={handleInputChange('walletServiceWsUrl')}
-              error={invalidModel.walletServiceWsUrl}
-              value={formModel.walletServiceWsUrl}
-            />
-          </>
+        {isLoading(networkSettingsStatus) && (
+          <FeedbackModal
+            icon={<Spinner />}
+            text={feedbackLoadingText}
+          />
         )}
 
-        <View style={styles.buttonContainer}>
-          <NewHathorButton
-            disabled={hasError(invalidModel)}
-            onPress={handleSubmit}
-            title={t`Send`}
+        {hasSucceed(networkSettingsStatus) && (
+          <FeedbackModal
+            icon={(<Image source={checkIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
+            text={feedbackSucceedText}
+            onDismiss={handleFeedbackModalDismiss}
           />
+        )}
+
+        {hasFailed(networkSettingsStatus) && (
+          <FeedbackModal
+            icon={(<Image source={errorIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
+            text={feedbackFailedText}
+            onDismiss={handleFeedbackModalDismiss}
+          />
+        )}
+
+        <View style={[styles.container, styles.warningWrapper]}>
+          <View style={styles.warningCard}>
+            <Text style={styles.warningMessage}>{warningText}</Text>
+          </View>
         </View>
+
+        <ScrollView>
+          <View style={[styles.container, styles.formWrapper]}>
+              <SimpleInput
+                keyboardType='url'
+                containerStyle={styles.input}
+                label={t`Node URL`}
+                autoFocus
+                onChangeText={handleInputChange('nodeUrl')}
+                error={invalidModel.nodeUrl}
+                value={formModel.nodeUrl}
+              />
+
+              <SimpleInput
+                keyboardType='url'
+                containerStyle={styles.input}
+                label={t`Explorer URL`}
+                onChangeText={handleInputChange('explorerUrl')}
+                error={invalidModel.explorerUrl}
+                value={formModel.explorerUrl}
+              />
+
+              <SimpleInput
+                keyboardType='url'
+                containerStyle={styles.input}
+                label={t`Explorer Service URL`}
+                onChangeText={handleInputChange('explorerServiceUrl')}
+                error={invalidModel.explorerServiceUrl}
+                value={formModel.explorerServiceUrl}
+              />
+
+              <SimpleInput
+                keyboardType='url'
+                containerStyle={styles.input}
+                label={t`Transaction Mining Service URL`}
+                onChangeText={handleInputChange('txMiningServiceUrl')}
+                error={invalidModel.txMiningServiceUrl}
+                value={formModel.txMiningServiceUrl}
+              />
+
+              {walletServiceEnabled && (
+                <>
+                  <SimpleInput
+                    keyboardType='url'
+                    containerStyle={styles.input}
+                    label={t`Wallet Service URL (optional)`}
+                    onChangeText={handleInputChange('walletServiceUrl')}
+                    error={invalidModel.walletServiceUrl}
+                    value={formModel.walletServiceUrl}
+                  />
+
+                  <SimpleInput
+                    keyboardType='url'
+                    containerStyle={styles.input}
+                    label={t`Wallet Service WS URL (optional)`}
+                    onChangeText={handleInputChange('walletServiceWsUrl')}
+                    error={invalidModel.walletServiceWsUrl}
+                    value={formModel.walletServiceWsUrl}
+                  />
+                </>
+              )}
+
+            <NewHathorButton
+              disabled={hasError(invalidModel)}
+              onPress={handleSubmit}
+              title={t`Send`}
+            />
+          </View>
+        </ScrollView>
       </View>
-    </View>
+    </KeyboardAvoidingView>
   );
 };

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -53,6 +53,20 @@ function validate(formModel) {
     invalidModel.txMiningServiceUrl = t`txMiningServiceUrl is required.`;
   }
 
+  // if any wallet-service fields have a value, then evaluate, otherwise pass
+  if (formModel.walletServiceUrl || formModel.walletServiceWsUrl) {
+    // if not both wallet-service fields have a value, then evaluate, otherwise pass
+    if (!(formModel.walletServiceUrl && formModel.walletServiceWsUrl)) {
+      // invalidade the one that don't have a value
+      if (!formModel.walletServiceUrl) {
+        invalidModel.walletServiceUrl = t`walletServiceUrl is required when walletServiceWsUrl is filled.`;
+      }
+      if (!formModel.walletServiceWsUrl) {
+        invalidModel.walletServiceWsUrl = t`walletServiceWsUrl is required when walletServiceUrl is filled.`;
+      }
+    }
+  }
+
   return invalidModel;
 }
 
@@ -104,18 +118,18 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
     nodeUrl: networkSettings.nodeUrl,
     explorerUrl: networkSettings.explorerUrl,
     explorerServiceUrl: networkSettings.explorerServiceUrl,
+    txMiningServiceUrl: networkSettings.txMiningServiceUrl || '',
     walletServiceUrl: networkSettings.walletServiceUrl || '',
     walletServiceWsUrl: networkSettings.walletServiceWsUrl || '',
-    txMiningServiceUrl: networkSettings.txMiningServiceUrl || '',
   });
 
   const [invalidModel, setInvalidModel] = useState({
     nodeUrl: networkSettingsInvalid?.nodeUrl || '',
     explorerUrl: networkSettingsInvalid?.explorerUrl || '',
     explorerServiceUrl: networkSettingsInvalid?.explorerServiceUrl || '',
+    txMiningServiceUrl: networkSettingsInvalid.txMiningServiceUrl || '',
     walletServiceUrl: networkSettingsInvalid?.walletServiceUrl || '',
     walletServiceWsUrl: networkSettingsInvalid?.walletServiceWsUrl || '',
-    txMiningServiceUrl: networkSettingsInvalid.txMiningServiceUrl || '',
   });
 
   // eslint-disable-next-line max-len

--- a/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
+++ b/src/screens/NetworkSettings/CustomNetworkSettingsScreen.js
@@ -11,14 +11,14 @@ import SimpleInput from '../../components/SimpleInput';
 import errorIcon from '../../assets/images/icErrorBig.png';
 import checkIcon from '../../assets/images/icCheckBig.png';
 import Spinner from '../../components/Spinner';
-import { hasSucceed, hasFailed, isLoading } from './helper';
+import { hasSucceeded, hasFailed, isLoading } from './helper';
 import { AlertUI } from '../../styles/themes';
 import { WALLET_SERVICE_FEATURE_TOGGLE } from '../../constants';
 
 const customNetworkSettingsTitleText = t`Custom Network Settings`.toUpperCase();
 const warningText = t`Any token outside mainnet network bear no value. Only change if you know what you are doing.`;
 const feedbackLoadingText = t`Updating custom network settings...`;
-const feedbackSucceedText = t`Network settings successfully customized.`;
+const feedbackSucceededText = t`Network settings successfully customized.`;
 const feedbackFailedText = t`There was an error while customizing network settings. Please try again later.`;
 
 /**
@@ -72,6 +72,9 @@ function validate(formModel) {
 
 const styles = StyleSheet.create({
   wrapper: {
+    flex: 1,
+  },
+  keyboardWrapper: {
     flex: 1,
   },
   container: {
@@ -183,7 +186,7 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
   return (
     <KeyboardAvoidingView
       behavior='padding'
-      style={{ flex: 1 }}
+      style={styles.keyboardWrapper}
       keyboardVerticalOffset={48} /* some size for padding bottom on formWrapper */
     >
       <View style={styles.wrapper}>
@@ -199,10 +202,10 @@ export const CustomNetworkSettingsScreen = ({ navigation }) => {
           />
         )}
 
-        {hasSucceed(networkSettingsStatus) && (
+        {hasSucceeded(networkSettingsStatus) && (
           <FeedbackModal
             icon={(<Image source={checkIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
-            text={feedbackSucceedText}
+            text={feedbackSucceededText}
             onDismiss={handleFeedbackModalDismiss}
           />
         )}

--- a/src/screens/NetworkSettings/NetworkPreSettingsScreen.js
+++ b/src/screens/NetworkSettings/NetworkPreSettingsScreen.js
@@ -21,7 +21,7 @@ import FeedbackModal from '../../components/FeedbackModal';
 import { networkSettingsPersistStore, networkSettingsUpdateReady } from '../../actions';
 import { PRE_SETTINGS_MAINNET, PRE_SETTINGS_TESTNET } from '../../constants';
 import { CustomNetworkSettingsNav } from './CustomNetworkSettingsScreen';
-import { feedbackSucceedText, feedbackFailedText, feedbackLoadingText, hasFailed, isLoading, hasSucceed } from './helper';
+import { feedbackSucceedText, feedbackFailedText, feedbackLoadingText, hasFailed, isLoading, hasSucceeded } from './helper';
 import errorIcon from '../../assets/images/icErrorBig.png';
 import checkIcon from '../../assets/images/icCheckBig.png';
 
@@ -102,7 +102,7 @@ export function NetworkPreSettingsScreen({ navigation }) {
         />
       )}
 
-      {hasSucceed(networkSettingsStatus) && (
+      {hasSucceeded(networkSettingsStatus) && (
         <FeedbackModal
           icon={(<Image source={checkIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
           text={feedbackSucceedText}

--- a/src/screens/NetworkSettings/helper.js
+++ b/src/screens/NetworkSettings/helper.js
@@ -10,7 +10,7 @@ export const feedbackFailedText = t`There was an error while customizing network
  * @param {object} networkSettingsStatus - status from redux store
  * @returns {boolean} - true if the status is successful, false otherwise
  */
-export function hasSucceed(networkSettingsStatus) {
+export function hasSucceeded(networkSettingsStatus) {
   return networkSettingsStatus === NETWORKSETTINGS_STATUS.SUCCESSFUL;
 }
 


### PR DESCRIPTION
### Acceptance Criteria
- Should add a scroll for custom network settings form, to avoid overflow of elements in the screen
- Should add a padding to keep the field on screen when the keyboard is open over the field
- Should add form validation for wallet-service fields, to avoid errors on saga processing
  - If any of the wallet-service fields are filled, then all the fields should be filled, otherwise an invalid error should appear in the empty field
  - if all the wallet-service fields are filled, or none are filled, then the form is allowed to be sent

It resolves: https://github.com/HathorNetwork/hathor-wallet-mobile/issues/458

iOS

https://github.com/HathorNetwork/hathor-wallet-mobile/assets/5992210/f861f1a2-e26a-4754-85a3-25c729c60666

Android

[custom-network-settings-android.webm](https://github.com/HathorNetwork/hathor-wallet-mobile/assets/5992210/7b775922-2068-4a87-9c98-f0af045e4e47)


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
