### PR TITLE
fix: allows push notification settings only when using mainnet network

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ import { Linking, Platform, Text } from 'react-native';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 import { isEmpty } from 'lodash';
 import baseStyle from './styles/init';
-import { KEYCHAIN_USER } from './constants';
+import { KEYCHAIN_USER, NETWORK_MAINNET } from './constants';
 import { STORE } from './store';
 import { TxHistory } from './models';
 import { COLORS, STYLE } from './styles/themes';

--- a/src/utils.js
+++ b/src/utils.js
@@ -387,6 +387,11 @@ export const isPushNotificationAvailableForUser = (state) => (
   state.pushNotification.available
     // On iOS a simulator can't register a device token on APNS
     && state.pushNotification.deviceRegistered
+    // TODO: We should drop this condition when we add support other networks
+    // XXX: We don't have support in this app to generate device tokens
+    // to the FCM testnet app. Currently we embbed only the mainnet
+    // configuration file during the build.
+    && state.networkSettings.network === NETWORK_MAINNET
     // If Wallet Service URLs are empty it makes impossible to use the
     // Wallet Service API to register the device's token.
     && !isEmpty(state.networkSettings.walletServiceUrl)


### PR DESCRIPTION
### Acceptance Criteria
- It should add a condition to allow use the push notification settings only when using the mainnet network
- It should closes https://github.com/HathorNetwork/internal-issues/issues/285

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
