### PR TITLE
chore: bump wallet-lib to v1.6.0 [15]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "6.4.0",
         "@fortawesome/react-native-fontawesome": "0.2.7",
         "@hathor/unleash-client": "0.1.0",
-        "@hathor/wallet-lib": "1.5.0",
+        "@hathor/wallet-lib": "1.6.0",
         "@notifee/react-native": "5.7.0",
         "@react-native-async-storage/async-storage": "1.19.0",
         "@react-native-firebase/app": "16.7.0",
@@ -2550,20 +2550,20 @@
       }
     },
     "node_modules/@hathor/wallet-lib": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-1.5.0.tgz",
-      "integrity": "sha512-H0wOuzaS+iUhADGG8fxvNpLddkM0BFjCAjt1nLml5Oe6DkTj5VtA2a7+aT1DR4qxUcPRmCo9D+azbMDiwbXtIA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-1.6.0.tgz",
+      "integrity": "sha512-gEsvbCFUwuj+kZya55oiEYzNWYSIWjrFQkqefET1Grtjs812i9dL7EueMFEwvqpm9yr9AlJuweGFj1lAkS8ucg==",
       "dependencies": {
         "axios": "1.6.8",
         "bitcore-lib": "8.25.10",
         "bitcore-mnemonic": "8.25.10",
         "buffer": "6.0.3",
         "crypto-js": "4.2.0",
-        "isomorphic-ws": "4.0.1",
+        "isomorphic-ws": "5.0.0",
         "level": "8.0.0",
         "lodash": "4.17.21",
         "long": "4.0.0",
-        "ws": "7.5.9"
+        "ws": "8.17.0"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -2597,6 +2597,26 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
+    "node_modules/@hathor/wallet-lib/node_modules/ws": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
@@ -11780,9 +11800,9 @@
       }
     },
     "node_modules/isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "peerDependencies": {
         "ws": "*"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@fortawesome/free-solid-svg-icons": "6.4.0",
     "@fortawesome/react-native-fontawesome": "0.2.7",
     "@hathor/unleash-client": "0.1.0",
-    "@hathor/wallet-lib": "1.5.0",
+    "@hathor/wallet-lib": "1.6.0",
     "@notifee/react-native": "5.7.0",
     "@react-native-async-storage/async-storage": "1.19.0",
     "@react-native-firebase/app": "16.7.0",


### PR DESCRIPTION
### Acceptance Criteria
- it should bump wallet-lib dependency to version 1.6.0

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
