### PR TITLE
fix: cleaning of tokens and nano-contract registered after reload

### DIFF
--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1222,7 +1222,13 @@ export const onExceptionCaptured = (state, { payload }) => {
 };
 
 /**
- * On wallet reload, tokens data will be reloaded as well.
+ * On wallet reload, tokens and nano contract  data will be
+ * reloaded as well.
+ *
+ * Some flows can request a wallet reload such as:
+ *   - Disable wallet service
+ *   - Change network settings
+ *   - Loose network connection
  */
 export const onReloadWalletRequested = (state) => ({
   ...state,

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1229,6 +1229,7 @@ export const onReloadWalletRequested = (state) => ({
   tokensHistory: initialState.tokensHistory,
   tokensBalance: initialState.tokensBalance,
   loadHistoryStatus: initialState.loadHistoryStatus,
+  nanoContract: initialState.nanoContract,
 });
 
 const onWalletReloading = (state) => ({


### PR DESCRIPTION
### Acceptance Criteria
- It should set nanoContract redux state to its initial state after reload be requested

#### Changing network settings after register nano-contract

When we change the network settings, all registered tokens and nano-contracts are cleaned from storage, therefore the redux state should also resumes to its initial state.


https://github.com/HathorNetwork/hathor-wallet-mobile/assets/5992210/a3a1ed83-20c1-4598-93ab-7040f8bddeca



### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
