### PR TITLE
fix: Unable to send token by reading a QR code

### DIFF
--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -57,10 +57,7 @@ class SendScanQRCode extends React.Component {
     if (!qrcode.isValid) {
       this.showAlertError(qrcode.error);
     } else if (qrcode.token && qrcode.amount) {
-      const isTokenRegistered = this.props.tokens.some(
-        (stateToken) => stateToken.uid === qrcode.token.uid
-      );
-      if (isTokenRegistered) {
+      if (qrcode.token.uid in this.props.tokens) {
         const params = {
           address: qrcode.address,
           token: qrcode.token,

--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -57,6 +57,7 @@ class SendScanQRCode extends React.Component {
     if (!qrcode.isValid) {
       this.showAlertError(qrcode.error);
     } else if (qrcode.token && qrcode.amount) {
+      // If token is registered then navigates to confirmation screen 
       if (qrcode.token.uid in this.props.tokens) {
         const params = {
           address: qrcode.address,


### PR DESCRIPTION
### Context

I have fixed token duplication on the Dashboard screen by transforming the registered tokens list into a map, this way we would never have a duplication. However, I failed to cover the necessary change and left one case untouched, which caused this bug.

See the previous fix at: https://github.com/HathorNetwork/hathor-wallet-mobile/pull/431

### Acceptance Criteria
- It should restore the ability to read QR code when sending token

Closes: https://github.com/HathorNetwork/internal-issues/issues/345

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
