### PR TITLE
fix: unable to open push notification details modal over any screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -86,6 +86,7 @@ import WalletConnectModal from './components/WalletConnect/WalletConnectModal';
 import { COLORS, HathorTheme } from './styles/themes';
 import { NetworkSettingsFlowNav, NetworkSettingsFlowStack } from './screens/NetworkSettings';
 import { NetworkStatusBar } from './components/NetworkSettings/NetworkStatusBar';
+import ShowPushNotificationTxDetails from './components/ShowPushNotificationTxDetails';
 
 /**
  * This Stack Navigator is exhibited when there is no wallet initialized on the local storage.
@@ -725,6 +726,7 @@ const App = () => (
           theme={HathorTheme}
           ref={navigationRef}
         >
+          <ShowPushNotificationTxDetails />
           <NetworkStatusBar />
           <RootStack />
         </NavigationContainer>

--- a/src/components/ShowPushNotificationTxDetails.js
+++ b/src/components/ShowPushNotificationTxDetails.js
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { t } from 'ttag';
@@ -9,7 +10,8 @@ const txNotFoundTitle = t`Transation not found`;
 const txNotFoundBody = t`The transaction has not arrived yet in your wallet. Do you want to retry?`;
 const txNotFoundButton = t`Retry`;
 
-export default function ShowPushNotificationTxDetails(props) {
+export default function ShowPushNotificationTxDetails() {
+  const navigation = useNavigation();
   const txDetails = useSelector((state) => state.pushNotification.txDetails);
   const dispatch = useDispatch();
 
@@ -26,7 +28,7 @@ export default function ShowPushNotificationTxDetails(props) {
 
   const renderPushTxDetailsModal = () => (
     <PushTxDetailsModal
-      navigation={props.navigation}
+      navigation={navigation}
       tx={txDetails.tx}
       tokens={txDetails.tokens}
       onRequestClose={() => dispatch(pushCleanTxDetails())}

--- a/src/constants.js
+++ b/src/constants.js
@@ -254,3 +254,8 @@ export const NETWORK_PRIVATENET = 'privatenet';
 export const MAX_RETRIES = 8;
 export const INITIAL_RETRY_LATENCY = 300; // ms
 export const LATENCY_MULTIPLIER = 30; // multiplier per iteration
+/**
+ * Timeout for await wallet load in the context of tx details loading.
+ * It awaits 5 minutes.
+ */
+export const TX_DETAILS_TIMEOUT = 5 * 60 * 1000; // 5 minutes

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -46,6 +46,7 @@ import {
   pushNotificationKey,
   PUSH_CHANNEL_TRANSACTION,
   PUSH_ACTION,
+  TX_DETAILS_TIMEOUT,
 } from '../constants';
 import { getPushNotificationSettings } from '../utils';
 import { STORE } from '../store';
@@ -55,6 +56,17 @@ import { WALLET_STATUS } from './wallet';
 import { logger } from '../logger';
 
 const log = logger('push-notification-saga');
+log.haltingTxDetailsLoading = () => log.debug('Halting tx details loading.');
+log.timeoutTxDetailsLoading = () => {
+  const msg = 'Timeout during tx details loading.';
+  log.error(msg);
+  return msg;
+};
+log.errorTxDetailsLoading = () => {
+  const msg = 'Error loading tx details during wallet loading.'
+  log.error(msg);
+  return msg;
+};
 
 const TRANSACTION_CHANNEL_NAME = t`Transaction`;
 const PUSH_ACTION_TITLE = t`Open`;
@@ -616,16 +628,52 @@ export function* loadTxDetails(action) {
   const { txId } = action.payload;
   const isLocked = yield select((state) => state.lockScreen);
   if (isLocked) {
+    log.debug('Awaiting wallet unlock to resume tx details loading.');
     const { resetWallet } = yield race({
-      // Wait for the unlock screen to be dismissed, and wallet to be loaded
-      unlockWallet: all([take(isUnlockScreen), take(types.START_WALLET_SUCCESS)]),
+      // Wait for the unlock screen to be dismissed
+      unlockWallet: take(isUnlockScreen),
       resetWallet: take(types.RESET_WALLET)
     });
+
     if (resetWallet) {
-      log.debug('Halting loadTxDetails.');
+      log.debug('User has chosen to reset wallet during tx details loading.');
+      log.haltingTxDetailsLoading();
       return;
     }
-    log.debug('Continuing loadTxDetails after unlock screen.');
+
+    // Halt if wallet loading has already failed
+    const walletStatus = yield select((state) => state.walletStartState);
+    if (walletStatus === WALLET_STATUS.FAILED) {
+      // It shoun'd have happen.
+      log.error('Error loading tx details while wallet has failed.');
+      log.haltingTxDetailsLoading();
+      return;
+    }
+
+    // Await wallet load if wallet is not ready yet, otherwise continue
+    if (walletStatus !== WALLET_STATUS.READY) {
+      // Await wallet load until timeout or error.
+      const { error, timeout } = yield race({
+        ready: take(types.START_WALLET_SUCCESS),
+        error: take(types.WALLET_STATE_ERROR),
+        timeout: delay(TX_DETAILS_TIMEOUT),
+      });
+
+      // It doesn't make sense to await more than that for a notification.
+      if (timeout) {
+        yield put(onExceptionCaptured(log.timeoutTxDetailsLoading()));
+        log.haltingTxDetailsLoading();
+        return;
+      }
+
+      if (error) {
+        yield put(onExceptionCaptured(log.errorTxDetailsLoading()));
+        log.haltingTxDetailsLoading();
+        return;
+      }
+    }
+
+    log.debug('Continuing tx details loading after unlock screen.');
   }
 
   try {

--- a/src/sagas/pushNotification.js
+++ b/src/sagas/pushNotification.js
@@ -644,7 +644,8 @@ export function* loadTxDetails(action) {
     // Halt if wallet loading has already failed
     const walletStatus = yield select((state) => state.walletStartState);
     if (walletStatus === WALLET_STATUS.FAILED) {
-      // It shoun'd have happen.
+      // It shouldn't happen because this very effect is invoked only after
+      // wallet load succeeds.
       log.error('Error loading tx details while wallet has failed.');
       log.haltingTxDetailsLoading();
       return;

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -17,7 +17,6 @@ import TokenSelect from '../components/TokenSelect';
 import SimpleButton from '../components/SimpleButton';
 import OfflineBar from '../components/OfflineBar';
 import { tokenFetchBalanceRequested, updateSelectedToken } from '../actions';
-import ShowPushNotificationTxDetails from '../components/ShowPushNotificationTxDetails';
 import AskForPushNotificationRefresh from '../components/AskForPushNotificationRefresh';
 
 /**
@@ -78,7 +77,6 @@ class Dashboard extends React.Component {
 
     return (
       <View style={{ flex: 1 }}>
-        <ShowPushNotificationTxDetails navigation={this.props.navigation} />
         <AskForPushNotification navigation={this.props.navigation} />
         <AskForPushNotificationRefresh />
         <TokenSelect

--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -57,7 +57,7 @@ class SendScanQRCode extends React.Component {
     if (!qrcode.isValid) {
       this.showAlertError(qrcode.error);
     } else if (qrcode.token && qrcode.amount) {
-      // If token is registered then navigates to confirmation screen 
+      // If token is registered then navigates to confirmation screen
       if (qrcode.token.uid in this.props.tokens) {
         const params = {
           address: qrcode.address,


### PR DESCRIPTION
### Acceptance Criteria
- It should make tx details modal open over any screen
- It should make tx details modal open after a simple unlock without a relead

#### Unlocking wallet without reload after tap over notification
[fix-unable-to-open-tx-modal-on-any-screen.webm](https://github.com/user-attachments/assets/8de0cedf-0875-42f5-a09b-d4c15821122b)

Closes: https://github.com/HathorNetwork/internal-issues/issues/346

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
