### PR TITLE
fix: nano-contract history pagination and list order

### DIFF
--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -57,7 +57,7 @@ msgid "[Last] dddd [•] HH:mm"
 msgstr "[Sidste] dddd [•] HH:mm"
 
 #.  See https://momentjs.com/docs/#/displaying/calendar-time/
-#: src/models.js:107 src/utils.js:416
+#: src/models.js:107 src/utils.js:426
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH:mm"
 
@@ -432,8 +432,8 @@ msgstr "Ord"
 msgid "Enter your seed words separated by space"
 msgstr "Indtast dine seed-ord adskilt med mellemrum"
 
-#: src/components/NanoContract/NanoContractDetails.js:194
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:282
+#: src/components/NanoContract/NanoContractDetails.js:238
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:289
 #: src/screens/LoadHistoryScreen.js:51 src/screens/LoadWalletErrorScreen.js:20
 #: src/screens/NanoContract/NanoContractRegisterScreen.js:161
 msgid "Try again"
@@ -458,7 +458,7 @@ msgid "There's been an error connecting to the server."
 msgstr ""
 
 #: src/screens/LoadWalletErrorScreen.js:21 src/screens/PinScreen.js:268
-#: src/screens/Settings.js:154
+#: src/screens/Settings.js:161
 msgid "Reset wallet"
 msgstr "Nulstil wallet"
 
@@ -541,7 +541,7 @@ msgstr "Lås Hathor-wallet op"
 msgid "Cancel"
 msgstr "Annuller"
 
-#: src/screens/PushNotification.js:58 src/screens/Settings.js:128
+#: src/screens/PushNotification.js:58 src/screens/Settings.js:135
 msgid "Push Notification"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr "MODTAG"
 
 #.  translator: Used when the QR Code Scanner is opened, and user will manually
 #.  enter the information.
-#: src/screens/RegisterToken.js:27 src/screens/SendScanQRCode.js:89
+#: src/screens/RegisterToken.js:27 src/screens/SendScanQRCode.js:87
 msgid "Manual info"
 msgstr "Manuel information"
 
@@ -660,7 +660,7 @@ msgstr "Skift pinkode"
 msgid "Lock wallet"
 msgstr "Lås wallet"
 
-#: src/screens/SendAddressInput.js:53 src/screens/SendScanQRCode.js:97
+#: src/screens/SendAddressInput.js:53 src/screens/SendScanQRCode.js:95
 msgid "SEND"
 msgstr "SEND"
 
@@ -706,7 +706,7 @@ msgstr "Din overførsel af **${ _this.amountAndToken }** er bekræftet"
 msgid "Address"
 msgstr "Adresse"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:288
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:291
 #: src/screens/SendConfirmScreen.js:168
 msgid "Send"
 msgstr "Send"
@@ -719,53 +719,53 @@ msgstr "Ugyldig QR-kode"
 msgid "OK"
 msgstr "Okay"
 
-#: src/screens/SendScanQRCode.js:73
+#: src/screens/SendScanQRCode.js:71
 #, javascript-format
 msgid "You don't have the requested token [${ tokenLabel }]"
 msgstr "Du har ikke den anmodede token [${ tokenLabel }]"
 
-#: src/screens/SendScanQRCode.js:105
+#: src/screens/SendScanQRCode.js:103
 #: src/screens/WalletConnect/WalletConnectScan.js:49
 msgid "Scan the QR code"
 msgstr "Scan QR-koden"
 
-#: src/screens/Settings.js:97
+#: src/screens/Settings.js:104
 msgid "You are connected to"
 msgstr "Du er tilsluttet til"
 
-#: src/screens/Settings.js:105
+#: src/screens/Settings.js:112
 msgid "General Settings"
 msgstr ""
 
-#: src/screens/Settings.js:109
+#: src/screens/Settings.js:116
 msgid "Connected to"
 msgstr "Forbundet til"
 
-#: src/screens/Settings.js:122
+#: src/screens/Settings.js:129
 msgid "Security"
 msgstr "Sikkerhed"
 
-#: src/screens/Settings.js:135
+#: src/screens/Settings.js:142
 msgid "Create a new token"
 msgstr "Opret en ny token"
 
-#: src/screens/Settings.js:142
+#: src/screens/Settings.js:149
 msgid "Register a token"
 msgstr "Registrer en token"
 
-#: src/screens/Settings.js:158
+#: src/screens/Settings.js:165
 msgid "About"
 msgstr "Om"
 
-#: src/screens/Settings.js:165
+#: src/screens/Settings.js:172
 msgid "Unique app identifier"
 msgstr ""
 
-#: src/screens/Settings.js:179
+#: src/screens/Settings.js:186
 msgid "Developer Settings"
 msgstr ""
 
-#: src/screens/Settings.js:181
+#: src/screens/Settings.js:188
 msgid "Network Settings"
 msgstr ""
 
@@ -900,27 +900,27 @@ msgstr ""
 msgid "walletServiceWsUrl is required when walletServiceUrl is filled."
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:229
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
 msgid "Node URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:239
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:242
 msgid "Explorer URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:248
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
 msgid "Explorer Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:257
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:260
 msgid "Transaction Mining Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:268
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:271
 msgid "Wallet Service URL (optional)"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:277
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:280
 msgid "Wallet Service WS URL (optional)"
 msgstr ""
 
@@ -959,9 +959,9 @@ msgstr ""
 msgid "Load First Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:158
+#: src/components/NanoContract/NanoContractDetails.js:202
 #: src/components/NanoContract/SelectAddressModal.js:105
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:202
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:209
 #: src/screens/NanoContract/NanoContractRegisterScreen.js:177
 msgid "Loading"
 msgstr ""
@@ -971,7 +971,7 @@ msgid "Loading first wallet address."
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:142
-#: src/components/NanoContract/NanoContractTransactionHeader.js:88
+#: src/components/NanoContract/NanoContractTransactionHeader.js:85
 #: src/components/NanoContract/NanoContractsListItem.js:57
 #: src/components/TxDetailsModal.js:106
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:83
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Nano Contract Registration"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractTransactionScreen.js:37
+#: src/screens/NanoContract/NanoContractTransactionScreen.js:39
 msgid "Nano Contract Transaction"
 msgstr ""
 
@@ -1007,81 +1007,81 @@ msgstr ""
 msgid "Contract successfully registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:45
+#: src/sagas/nanoContract.js:44
 msgid "Nano Contract already registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:46
+#: src/sagas/nanoContract.js:45
 msgid "Wallet is not ready yet to register a Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:47
+#: src/sagas/nanoContract.js:46
 msgid "The informed address does not belong to the wallet."
 msgstr ""
 
-#: src/sagas/nanoContract.js:48
+#: src/sagas/nanoContract.js:47
 msgid "Nano Contract not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:49
+#: src/sagas/nanoContract.js:48
 msgid "Error while trying to get Nano Contract state."
 msgstr ""
 
-#: src/sagas/nanoContract.js:50
+#: src/sagas/nanoContract.js:49
 msgid "Blueprint not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:51
+#: src/sagas/nanoContract.js:50
 msgid "Couldn't get Blueprint info."
 msgstr ""
 
-#: src/sagas/nanoContract.js:52
+#: src/sagas/nanoContract.js:51
 msgid "Nano Contract not registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:53
+#: src/sagas/nanoContract.js:52
 msgid "Error while trying to download Nano Contract transactions history."
 msgstr ""
 
-#: src/sagas/networkSettings.js:91
+#: src/sagas/networkSettings.js:86
 msgid "Custom Network Settings cannot be empty."
 msgstr ""
 
-#: src/sagas/networkSettings.js:98
+#: src/sagas/networkSettings.js:93
 msgid "explorerUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:105
+#: src/sagas/networkSettings.js:100
 msgid "explorerServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:112
+#: src/sagas/networkSettings.js:107
 msgid "txMiningServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:119
+#: src/sagas/networkSettings.js:114
 msgid "nodeUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:126
+#: src/sagas/networkSettings.js:121
 msgid "walletServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:133
+#: src/sagas/networkSettings.js:128
 msgid "walletServiceWsUrl should be a valid URL."
 msgstr ""
 
 #.  If we fall into this situation, the app should be killed
 #.  for the custom new network settings take effect.
-#: src/sagas/networkSettings.js:296
+#: src/sagas/networkSettings.js:291
 msgid "Wallet not found while trying to persist the custom network settings."
 msgstr ""
 
-#: src/sagas/pushNotification.js:59
+#: src/sagas/pushNotification.js:71
 msgid "Transaction"
 msgstr "Transaktion"
 
-#: src/sagas/pushNotification.js:60
+#: src/sagas/pushNotification.js:72
 msgid "Open"
 msgstr "Åben"
 
@@ -1093,21 +1093,21 @@ msgstr ""
 msgid "Error loading the details of some tokens."
 msgstr ""
 
-#: src/sagas/wallet.js:749
+#: src/sagas/wallet.js:781
 msgid "Wallet is not ready to load addresses."
 msgstr ""
 
 #.  This will show the message in the feedback content at SelectAddressModal
-#: src/sagas/wallet.js:766
+#: src/sagas/wallet.js:797
 msgid "There was an error while loading wallet addresses. Try again."
 msgstr ""
 
-#: src/sagas/wallet.js:776
+#: src/sagas/wallet.js:807
 msgid "Wallet is not ready to load the first address."
 msgstr ""
 
 #.  This will show the message in the feedback content
-#: src/sagas/wallet.js:792
+#: src/sagas/wallet.js:823
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
 
@@ -1243,16 +1243,16 @@ msgstr "Del"
 msgid "Propagating transaction to the network."
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:15
+#: src/components/ShowPushNotificationTxDetails.js:16
 msgid "Transation not found"
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:16
+#: src/components/ShowPushNotificationTxDetails.js:17
 msgid ""
 "The transaction has not arrived yet in your wallet. Do you want to retry?"
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:17
+#: src/components/ShowPushNotificationTxDetails.js:18
 msgid "Retry"
 msgstr ""
 
@@ -1279,12 +1279,12 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:47
+#: src/components/NanoContract/NanoContractTransactionHeader.js:44
 #: src/components/TxDetailsModal.js:104
 msgid "Transaction ID"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:92
+#: src/components/NanoContract/NanoContractTransactionHeader.js:89
 #: src/components/TxDetailsModal.js:105
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:116
 msgid "Blueprint Method"
@@ -1389,7 +1389,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:106
+#: src/components/NanoContract/NanoContractTransactionHeader.js:103
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:124
 msgid "Caller"
 msgstr ""
@@ -1398,13 +1398,17 @@ msgstr ""
 msgid "Couldn't determine address, select one"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:48
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:50
 #, javascript-format
 msgid "Position ${ idx }"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:93
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:98
 msgid "Arguments"
+msgstr ""
+
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:103
+msgid "Loading arguments."
 msgstr ""
 
 #: src/components/WalletConnect/NanoContract/NewNanoContractTransactionModal.js:72
@@ -1432,46 +1436,46 @@ msgstr ""
 msgid "Read More."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:184
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:191
 msgid "Nano Contract Not Found"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:185
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:192
 msgid ""
 "The Nano Contract requested is not registered. First register the Nano "
 "Contract to interact with it."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:188
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:235
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:195
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:242
 msgid "Decline Transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:203
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:210
 msgid "Loading transaction information."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:231
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:238
 msgid "Accept Transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:245
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:252
 msgid "Sending transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:246
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:253
 msgid "Please wait."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:272
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:279
 msgid "Transaction successfully sent."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:274
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:281
 msgid "Ok, close"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:280
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:287
 msgid "Error while sending transaction."
 msgstr ""
 
@@ -1509,21 +1513,16 @@ msgstr ""
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:174
+#: src/components/NanoContract/NanoContractDetails.js:177
 msgid "Load More"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:200
+#: src/components/NanoContract/NanoContractDetails.js:203
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:214
+#: src/components/NanoContract/NanoContractDetails.js:217
 msgid "Nano Contract Transactions Error"
-msgstr ""
-
-#: src/components/NanoContract/NanoContractDetailsHeader.js:146
-#: src/components/NanoContract/NanoContractsListItem.js:59
-msgid "Blueprint Name"
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:150
@@ -1538,24 +1537,33 @@ msgstr ""
 msgid "Unregister contract"
 msgstr ""
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:96
+#: src/components/NanoContract/NanoContractTransactionActionList.js:44
+msgid "No Actions"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionList.js:45
+msgid "See full transaction details on Public Explorer."
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionListItem.js:108
+#, javascript-format
+msgid "Deposit ${ tokenSymbol }"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionListItem.js:109
+msgid "Withdrawal ${ tokenSymbol }"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionHeader.js:93
 msgid "Date and Time"
 msgstr ""
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:103
+#: src/components/NanoContract/NanoContractTransactionHeader.js:100
 #: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
 msgstr ""
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 #: src/components/NanoContract/NanoContractTransactionHeader.js:106
-msgid "Caller"
-msgstr ""
-
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:109
 msgid "See transaction details"
 msgstr ""
 
@@ -1607,8 +1615,4 @@ msgstr ""
 
 #: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
-msgstr ""
-
-#: src/components/NanoContract/UnregisterNanoContractModal.js:50
-msgid "No, go back"
 msgstr ""

--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -1098,16 +1098,16 @@ msgid "Wallet is not ready to load addresses."
 msgstr ""
 
 #.  This will show the message in the feedback content at SelectAddressModal
-#: src/sagas/wallet.js:765
+#: src/sagas/wallet.js:766
 msgid "There was an error while loading wallet addresses. Try again."
 msgstr ""
 
-#: src/sagas/wallet.js:775
+#: src/sagas/wallet.js:776
 msgid "Wallet is not ready to load the first address."
 msgstr ""
 
 #.  This will show the message in the feedback content
-#: src/sagas/wallet.js:791
+#: src/sagas/wallet.js:792
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
 
@@ -1509,12 +1509,21 @@ msgstr ""
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:159
+#: src/components/NanoContract/NanoContractDetails.js:174
+msgid "Load More"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetails.js:200
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:173
+#: src/components/NanoContract/NanoContractDetails.js:214
 msgid "Nano Contract Transactions Error"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetailsHeader.js:146
+#: src/components/NanoContract/NanoContractsListItem.js:59
+msgid "Blueprint Name"
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:150
@@ -1538,6 +1547,11 @@ msgstr ""
 #: src/components/NanoContract/NanoContractTransactionHeader.js:103
 #: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
+msgstr ""
+
+#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
+#: src/components/NanoContract/NanoContractTransactionHeader.js:106
+msgid "Caller"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
@@ -1593,4 +1607,8 @@ msgstr ""
 
 #: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
+msgstr ""
+
+#: src/components/NanoContract/UnregisterNanoContractModal.js:50
+msgid "No, go back"
 msgstr ""

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -57,7 +57,7 @@ msgid "[Last] dddd [•] HH:mm"
 msgstr "[Última] dddd [•] HH:mm"
 
 #.  See https://momentjs.com/docs/#/displaying/calendar-time/
-#: src/models.js:107 src/utils.js:416
+#: src/models.js:107 src/utils.js:426
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH:mm"
 
@@ -443,8 +443,8 @@ msgstr "Palavras"
 msgid "Enter your seed words separated by space"
 msgstr "Digite suas palavras separadas por espaços"
 
-#: src/components/NanoContract/NanoContractDetails.js:194
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:282
+#: src/components/NanoContract/NanoContractDetails.js:238
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:289
 #: src/screens/LoadHistoryScreen.js:51 src/screens/LoadWalletErrorScreen.js:20
 #: src/screens/NanoContract/NanoContractRegisterScreen.js:161
 msgid "Try again"
@@ -469,7 +469,7 @@ msgid "There's been an error connecting to the server."
 msgstr "Ocorreu um erro ao conectar com o servidor."
 
 #: src/screens/LoadWalletErrorScreen.js:21 src/screens/PinScreen.js:268
-#: src/screens/Settings.js:154
+#: src/screens/Settings.js:161
 msgid "Reset wallet"
 msgstr "Resetar Wallet"
 
@@ -554,7 +554,7 @@ msgstr "Desbloqueie sua Hathor Wallet"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/screens/PushNotification.js:58 src/screens/Settings.js:128
+#: src/screens/PushNotification.js:58 src/screens/Settings.js:135
 msgid "Push Notification"
 msgstr "Notificação"
 
@@ -591,7 +591,7 @@ msgstr "RECEBER"
 
 #.  translator: Used when the QR Code Scanner is opened, and user will manually
 #.  enter the information.
-#: src/screens/RegisterToken.js:27 src/screens/SendScanQRCode.js:89
+#: src/screens/RegisterToken.js:27 src/screens/SendScanQRCode.js:87
 msgid "Manual info"
 msgstr "Digitar"
 
@@ -676,7 +676,7 @@ msgstr "Mudar PIN"
 msgid "Lock wallet"
 msgstr "Bloquear a wallet"
 
-#: src/screens/SendAddressInput.js:53 src/screens/SendScanQRCode.js:97
+#: src/screens/SendAddressInput.js:53 src/screens/SendScanQRCode.js:95
 msgid "SEND"
 msgstr "ENVIAR"
 
@@ -722,7 +722,7 @@ msgstr "Sua transferência de **${ this.amountAndToken }** foi confirmada"
 msgid "Address"
 msgstr "Endereço"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:288
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:291
 #: src/screens/SendConfirmScreen.js:168
 msgid "Send"
 msgstr "Enviar"
@@ -735,53 +735,53 @@ msgstr "QR code inválido"
 msgid "OK"
 msgstr "OK"
 
-#: src/screens/SendScanQRCode.js:73
+#: src/screens/SendScanQRCode.js:71
 #, javascript-format
 msgid "You don't have the requested token [${ tokenLabel }]"
 msgstr "Você não tem o token requisitado [${ tokenLabel }]"
 
-#: src/screens/SendScanQRCode.js:105
+#: src/screens/SendScanQRCode.js:103
 #: src/screens/WalletConnect/WalletConnectScan.js:49
 msgid "Scan the QR code"
 msgstr "Leia o QR code"
 
-#: src/screens/Settings.js:97
+#: src/screens/Settings.js:104
 msgid "You are connected to"
 msgstr "Você está conectado à"
 
-#: src/screens/Settings.js:105
+#: src/screens/Settings.js:112
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
-#: src/screens/Settings.js:109
+#: src/screens/Settings.js:116
 msgid "Connected to"
 msgstr "Conectado ao servidor"
 
-#: src/screens/Settings.js:122
+#: src/screens/Settings.js:129
 msgid "Security"
 msgstr "Segurança"
 
-#: src/screens/Settings.js:135
+#: src/screens/Settings.js:142
 msgid "Create a new token"
 msgstr "Criar um novo token"
 
-#: src/screens/Settings.js:142
+#: src/screens/Settings.js:149
 msgid "Register a token"
 msgstr "Registrar um token"
 
-#: src/screens/Settings.js:158
+#: src/screens/Settings.js:165
 msgid "About"
 msgstr "Sobre"
 
-#: src/screens/Settings.js:165
+#: src/screens/Settings.js:172
 msgid "Unique app identifier"
 msgstr "Identificador único do aplicativo"
 
-#: src/screens/Settings.js:179
+#: src/screens/Settings.js:186
 msgid "Developer Settings"
 msgstr "Configurações do Desenvolvedor"
 
-#: src/screens/Settings.js:181
+#: src/screens/Settings.js:188
 msgid "Network Settings"
 msgstr "Configurações de Rede"
 
@@ -917,33 +917,35 @@ msgstr "txMiningServiceUrl é obrigatório."
 
 #: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:62
 msgid "walletServiceUrl is required when walletServiceWsUrl is filled."
-msgstr "walletServiceUrl é obrigatório quando walletServiceWsUrl está preenchido."
+msgstr ""
+"walletServiceUrl é obrigatório quando walletServiceWsUrl está preenchido."
 
 #: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:65
 msgid "walletServiceWsUrl is required when walletServiceUrl is filled."
-msgstr "walletServiceWsUrl é obrigatório quando walletServiceUrl está preenchido"
+msgstr ""
+"walletServiceWsUrl é obrigatório quando walletServiceUrl está preenchido"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:229
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
 msgid "Node URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:239
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:242
 msgid "Explorer URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:248
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
 msgid "Explorer Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:257
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:260
 msgid "Transaction Mining Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:268
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:271
 msgid "Wallet Service URL (optional)"
 msgstr "Wallet Service URL (opcional)"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:277
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:280
 msgid "Wallet Service WS URL (optional)"
 msgstr "Wallet Service WS URL (opcional)"
 
@@ -985,9 +987,9 @@ msgstr "Ver contrato"
 msgid "Load First Addresses Error"
 msgstr "Erro ao carregar primeiro endereço da wallet"
 
-#: src/components/NanoContract/NanoContractDetails.js:158
+#: src/components/NanoContract/NanoContractDetails.js:202
 #: src/components/NanoContract/SelectAddressModal.js:105
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:202
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:209
 #: src/screens/NanoContract/NanoContractRegisterScreen.js:177
 msgid "Loading"
 msgstr "Carregando"
@@ -997,7 +999,7 @@ msgid "Loading first wallet address."
 msgstr "Carregando primeiro endereço da wallet."
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:142
-#: src/components/NanoContract/NanoContractTransactionHeader.js:88
+#: src/components/NanoContract/NanoContractTransactionHeader.js:85
 #: src/components/NanoContract/NanoContractsListItem.js:57
 #: src/components/TxDetailsModal.js:106
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:83
@@ -1025,7 +1027,7 @@ msgstr "Registrar Nano Contract"
 msgid "Nano Contract Registration"
 msgstr "Registro do Nano Contract"
 
-#: src/screens/NanoContract/NanoContractTransactionScreen.js:37
+#: src/screens/NanoContract/NanoContractTransactionScreen.js:39
 msgid "Nano Contract Transaction"
 msgstr "Transação do Nano Contract"
 
@@ -1033,82 +1035,82 @@ msgstr "Transação do Nano Contract"
 msgid "Contract successfully registered."
 msgstr "Nano Contract registrado com sucesso."
 
-#: src/sagas/nanoContract.js:45
+#: src/sagas/nanoContract.js:44
 msgid "Nano Contract already registered."
 msgstr "Nano Contract já registrado."
 
-#: src/sagas/nanoContract.js:46
+#: src/sagas/nanoContract.js:45
 msgid "Wallet is not ready yet to register a Nano Contract."
 msgstr "A wallet não está pronta ainda para registrar Nano Contracts."
 
-#: src/sagas/nanoContract.js:47
+#: src/sagas/nanoContract.js:46
 msgid "The informed address does not belong to the wallet."
 msgstr "O endereço informado não pertence a esta carteira."
 
-#: src/sagas/nanoContract.js:48
+#: src/sagas/nanoContract.js:47
 msgid "Nano Contract not found."
 msgstr "Nano Contract não encontrado"
 
-#: src/sagas/nanoContract.js:49
+#: src/sagas/nanoContract.js:48
 msgid "Error while trying to get Nano Contract state."
 msgstr "Erro ao obter o estado do Nano Contract."
 
-#: src/sagas/nanoContract.js:50
+#: src/sagas/nanoContract.js:49
 msgid "Blueprint not found."
 msgstr "Blueprint não encontrado."
 
-#: src/sagas/nanoContract.js:51
+#: src/sagas/nanoContract.js:50
 msgid "Couldn't get Blueprint info."
 msgstr "Não foi possível carregar informações do Blueprint."
 
-#: src/sagas/nanoContract.js:52
+#: src/sagas/nanoContract.js:51
 msgid "Nano Contract not registered."
 msgstr "Nano Contract não registrado."
 
-#: src/sagas/nanoContract.js:53
+#: src/sagas/nanoContract.js:52
 msgid "Error while trying to download Nano Contract transactions history."
 msgstr "Error ao fazer download do histórico de transações do Nano Contract."
 
-#: src/sagas/networkSettings.js:91
+#: src/sagas/networkSettings.js:86
 msgid "Custom Network Settings cannot be empty."
 msgstr "As Configurações de Rede não podem estar vazias."
 
-#: src/sagas/networkSettings.js:98
+#: src/sagas/networkSettings.js:93
 msgid "explorerUrl should be a valid URL."
 msgstr "explorerUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:105
+#: src/sagas/networkSettings.js:100
 msgid "explorerServiceUrl should be a valid URL."
 msgstr "explorerServiceUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:112
+#: src/sagas/networkSettings.js:107
 msgid "txMiningServiceUrl should be a valid URL."
 msgstr "txMiningServiceUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:119
+#: src/sagas/networkSettings.js:114
 msgid "nodeUrl should be a valid URL."
 msgstr "nodeUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:126
+#: src/sagas/networkSettings.js:121
 msgid "walletServiceUrl should be a valid URL."
 msgstr "walletServiceUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:133
+#: src/sagas/networkSettings.js:128
 msgid "walletServiceWsUrl should be a valid URL."
 msgstr "walletServiceWsUrl deve ser uma URL válida."
 
 #.  If we fall into this situation, the app should be killed
 #.  for the custom new network settings take effect.
-#: src/sagas/networkSettings.js:296
+#: src/sagas/networkSettings.js:291
 msgid "Wallet not found while trying to persist the custom network settings."
 msgstr ""
 "Wallet não encontrada ao persistir a configuração personalizada da rede."
 
-#: src/sagas/pushNotification.js:59
+#: src/sagas/pushNotification.js:71
 msgid "Transaction"
 msgstr "Transação"
 
-#: src/sagas/pushNotification.js:60
+#: src/sagas/pushNotification.js:72
 msgid "Open"
 msgstr "Abrir"
 
@@ -1120,21 +1122,21 @@ msgstr "A wallet não está pronta ainda."
 msgid "Error loading the details of some tokens."
 msgstr "Ocorreu um erro durante o carregamento de detalhes de alguns tokens."
 
-#: src/sagas/wallet.js:749
+#: src/sagas/wallet.js:781
 msgid "Wallet is not ready to load addresses."
 msgstr "A wallet não está pronta para carregar os endereços."
 
 #.  This will show the message in the feedback content at SelectAddressModal
-#: src/sagas/wallet.js:765
+#: src/sagas/wallet.js:797
 msgid "There was an error while loading wallet addresses. Try again."
 msgstr "Ocorreu um erro ao carregar os endereços da wallet. Tente novamente."
 
-#: src/sagas/wallet.js:775
+#: src/sagas/wallet.js:807
 msgid "Wallet is not ready to load the first address."
 msgstr "A wallet não está pronta para carregar o primeiro endereço."
 
 #.  This will show the message in the feedback content
-#: src/sagas/wallet.js:791
+#: src/sagas/wallet.js:823
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
 "Ocorreu um erro ao carregar o primeiro endereço da wallet. Tente novamente."
@@ -1274,16 +1276,16 @@ msgstr "Compartilhar"
 msgid "Propagating transaction to the network."
 msgstr "Propagando a transação para a rede."
 
-#: src/components/ShowPushNotificationTxDetails.js:15
+#: src/components/ShowPushNotificationTxDetails.js:16
 msgid "Transation not found"
 msgstr "Transação não encontrada"
 
-#: src/components/ShowPushNotificationTxDetails.js:16
+#: src/components/ShowPushNotificationTxDetails.js:17
 msgid ""
 "The transaction has not arrived yet in your wallet. Do you want to retry?"
 msgstr "A transação ainda não chegou na sua carteira. Deseja tentar novamente?"
 
-#: src/components/ShowPushNotificationTxDetails.js:17
+#: src/components/ShowPushNotificationTxDetails.js:18
 msgid "Retry"
 msgstr "Tentar novamente"
 
@@ -1309,12 +1311,12 @@ msgstr "Inválida"
 msgid "Description"
 msgstr "Descrição"
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:47
+#: src/components/NanoContract/NanoContractTransactionHeader.js:44
 #: src/components/TxDetailsModal.js:104
 msgid "Transaction ID"
 msgstr "ID da Transação"
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:92
+#: src/components/NanoContract/NanoContractTransactionHeader.js:89
 #: src/components/TxDetailsModal.js:105
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:116
 msgid "Blueprint Method"
@@ -1426,7 +1428,7 @@ msgstr "Nome do Blueprint"
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:106
+#: src/components/NanoContract/NanoContractTransactionHeader.js:103
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:124
 msgid "Caller"
 msgstr "Caller"
@@ -1435,14 +1437,18 @@ msgstr "Caller"
 msgid "Couldn't determine address, select one"
 msgstr "Não foi possível determinar um endereço, selecione um"
 
-#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:48
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:50
 #, javascript-format
 msgid "Position ${ idx }"
 msgstr "Posição ${ idx }"
 
-#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:93
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:98
 msgid "Arguments"
 msgstr "Argumentos"
+
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:103
+msgid "Loading arguments."
+msgstr "Carregando argumentos."
 
 #: src/components/WalletConnect/NanoContract/NewNanoContractTransactionModal.js:72
 msgid "You have received a new Nano Contract Transaction. Please"
@@ -1471,11 +1477,11 @@ msgstr ""
 msgid "Read More."
 msgstr "Ler mais."
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:184
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:191
 msgid "Nano Contract Not Found"
 msgstr "Nano Contract não encontrado"
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:185
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:192
 msgid ""
 "The Nano Contract requested is not registered. First register the Nano "
 "Contract to interact with it."
@@ -1483,36 +1489,36 @@ msgstr ""
 "O Nano Contract solicitado não está registrado. Primeiro registre o Nano "
 "Contract para interagir com ele."
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:188
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:235
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:195
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:242
 msgid "Decline Transaction"
 msgstr "Recusar transação"
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:203
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:210
 msgid "Loading transaction information."
 msgstr "Carregando informações da transação."
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:231
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:238
 msgid "Accept Transaction"
 msgstr "Aceitar transação"
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:245
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:252
 msgid "Sending transaction"
 msgstr "Enviando transação"
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:246
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:253
 msgid "Please wait."
 msgstr "Por favor, espere."
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:272
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:279
 msgid "Transaction successfully sent."
 msgstr "Transação enviada com sucesso."
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:274
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:281
 msgid "Ok, close"
 msgstr "Ok, fechar"
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:280
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:287
 msgid "Error while sending transaction."
 msgstr "Ocorreu um erro durante o envio da transação."
 
@@ -1552,22 +1558,17 @@ msgstr "Confirmar novo endereço"
 msgid "Go back"
 msgstr "Voltar"
 
-#: src/components/NanoContract/NanoContractDetails.js:174
+#: src/components/NanoContract/NanoContractDetails.js:177
 msgid "Load More"
 msgstr "Carregar mais"
 
-#: src/components/NanoContract/NanoContractDetails.js:200
+#: src/components/NanoContract/NanoContractDetails.js:203
 msgid "Loading Nano Contract transactions."
 msgstr "Carregando transações do Nano Contract"
 
-#: src/components/NanoContract/NanoContractDetails.js:214
+#: src/components/NanoContract/NanoContractDetails.js:217
 msgid "Nano Contract Transactions Error"
 msgstr "Erro em Transações do Nano Contract"
-
-#: src/components/NanoContract/NanoContractDetailsHeader.js:146
-#: src/components/NanoContract/NanoContractsListItem.js:59
-msgid "Blueprint Name"
-msgstr "Nome do Blueprint"
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:150
 msgid "Registered Address"
@@ -1581,24 +1582,34 @@ msgstr "Ver detalhes"
 msgid "Unregister contract"
 msgstr "Desregistrar contract"
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:96
+#: src/components/NanoContract/NanoContractTransactionActionList.js:44
+msgid "No Actions"
+msgstr "Nenhuma Action"
+
+#: src/components/NanoContract/NanoContractTransactionActionList.js:45
+msgid "See full transaction details on Public Explorer."
+msgstr "Ver todos os detalhes da transação no Explorer Público."
+
+#: src/components/NanoContract/NanoContractTransactionActionListItem.js:108
+#, javascript-format
+msgid "Deposit ${ tokenSymbol }"
+msgstr "Depósito ${ tokenSymbol }"
+
+#: src/components/NanoContract/NanoContractTransactionActionListItem.js:109
+#, javascript-format
+msgid "Withdrawal ${ tokenSymbol }"
+msgstr "Saque ${ tokenSymbol }"
+
+#: src/components/NanoContract/NanoContractTransactionHeader.js:93
 msgid "Date and Time"
 msgstr "Data & Hora"
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:103
+#: src/components/NanoContract/NanoContractTransactionHeader.js:100
 #: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
 msgstr "Desta wallet"
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 #: src/components/NanoContract/NanoContractTransactionHeader.js:106
-msgid "Caller"
-msgstr "Caller"
-
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:109
 msgid "See transaction details"
 msgstr "Ver detalhes"
 
@@ -1651,7 +1662,3 @@ msgstr "Confirma que deseja desregistrar este Nano Contract?"
 #: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
 msgstr "Sim, desregistrar"
-
-#: src/components/NanoContract/UnregisterNanoContractModal.js:50
-msgid "No, go back"
-msgstr "Não, voltar"

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -1552,13 +1552,22 @@ msgstr "Confirmar novo endereço"
 msgid "Go back"
 msgstr "Voltar"
 
-#: src/components/NanoContract/NanoContractDetails.js:159
+#: src/components/NanoContract/NanoContractDetails.js:174
+msgid "Load More"
+msgstr "Carregar mais"
+
+#: src/components/NanoContract/NanoContractDetails.js:200
 msgid "Loading Nano Contract transactions."
 msgstr "Carregando transações do Nano Contract"
 
-#: src/components/NanoContract/NanoContractDetails.js:173
+#: src/components/NanoContract/NanoContractDetails.js:214
 msgid "Nano Contract Transactions Error"
 msgstr "Erro em Transações do Nano Contract"
+
+#: src/components/NanoContract/NanoContractDetailsHeader.js:146
+#: src/components/NanoContract/NanoContractsListItem.js:59
+msgid "Blueprint Name"
+msgstr "Nome do Blueprint"
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:150
 msgid "Registered Address"
@@ -1582,6 +1591,11 @@ msgstr "Data & Hora"
 #: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
 msgstr "Desta wallet"
+
+#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
+#: src/components/NanoContract/NanoContractTransactionHeader.js:106
+msgid "Caller"
+msgstr "Caller"
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 #: src/components/NanoContract/NanoContractTransactionHeader.js:109
@@ -1637,3 +1651,7 @@ msgstr "Confirma que deseja desregistrar este Nano Contract?"
 #: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
 msgstr "Sim, desregistrar"
+
+#: src/components/NanoContract/UnregisterNanoContractModal.js:50
+msgid "No, go back"
+msgstr "Não, voltar"

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -58,7 +58,7 @@ msgid "[Last] dddd [•] HH:mm"
 msgstr "[Последний] dddd [•] HH:mm"
 
 #.  See https://momentjs.com/docs/#/displaying/calendar-time/
-#: src/models.js:107 src/utils.js:416
+#: src/models.js:107 src/utils.js:426
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH:mm"
 
@@ -433,8 +433,8 @@ msgstr "Слова"
 msgid "Enter your seed words separated by space"
 msgstr "Введите seed-фразу"
 
-#: src/components/NanoContract/NanoContractDetails.js:194
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:282
+#: src/components/NanoContract/NanoContractDetails.js:238
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:289
 #: src/screens/LoadHistoryScreen.js:51 src/screens/LoadWalletErrorScreen.js:20
 #: src/screens/NanoContract/NanoContractRegisterScreen.js:161
 msgid "Try again"
@@ -459,7 +459,7 @@ msgid "There's been an error connecting to the server."
 msgstr ""
 
 #: src/screens/LoadWalletErrorScreen.js:21 src/screens/PinScreen.js:268
-#: src/screens/Settings.js:154
+#: src/screens/Settings.js:161
 msgid "Reset wallet"
 msgstr "Сбросить кошелек"
 
@@ -543,7 +543,7 @@ msgstr "Разблокировать Hathor Wallet"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/screens/PushNotification.js:58 src/screens/Settings.js:128
+#: src/screens/PushNotification.js:58 src/screens/Settings.js:135
 msgid "Push Notification"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr "ПОЛУЧИТЬ"
 
 #.  translator: Used when the QR Code Scanner is opened, and user will manually
 #.  enter the information.
-#: src/screens/RegisterToken.js:27 src/screens/SendScanQRCode.js:89
+#: src/screens/RegisterToken.js:27 src/screens/SendScanQRCode.js:87
 msgid "Manual info"
 msgstr "Ручной ввод"
 
@@ -661,7 +661,7 @@ msgstr "Изменить PIN-код"
 msgid "Lock wallet"
 msgstr "Заблокировать кошелек"
 
-#: src/screens/SendAddressInput.js:53 src/screens/SendScanQRCode.js:97
+#: src/screens/SendAddressInput.js:53 src/screens/SendScanQRCode.js:95
 msgid "SEND"
 msgstr "ОТПРАВИТЬ"
 
@@ -708,7 +708,7 @@ msgstr "Ваш перевод **${ this.amountAndToken }** был подтвер
 msgid "Address"
 msgstr "Адрес"
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:288
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:291
 #: src/screens/SendConfirmScreen.js:168
 msgid "Send"
 msgstr "Отправить"
@@ -721,53 +721,53 @@ msgstr "Неверный QR-код"
 msgid "OK"
 msgstr "OK"
 
-#: src/screens/SendScanQRCode.js:73
+#: src/screens/SendScanQRCode.js:71
 #, javascript-format
 msgid "You don't have the requested token [${ tokenLabel }]"
 msgstr "У вас нет запрошенного токена [${ tokenLabel }]"
 
-#: src/screens/SendScanQRCode.js:105
+#: src/screens/SendScanQRCode.js:103
 #: src/screens/WalletConnect/WalletConnectScan.js:49
 msgid "Scan the QR code"
 msgstr "Сканировать QR-код"
 
-#: src/screens/Settings.js:97
+#: src/screens/Settings.js:104
 msgid "You are connected to"
 msgstr "Вы подключены к"
 
-#: src/screens/Settings.js:105
+#: src/screens/Settings.js:112
 msgid "General Settings"
 msgstr ""
 
-#: src/screens/Settings.js:109
+#: src/screens/Settings.js:116
 msgid "Connected to"
 msgstr "Подключены к"
 
-#: src/screens/Settings.js:122
+#: src/screens/Settings.js:129
 msgid "Security"
 msgstr "Безопасность"
 
-#: src/screens/Settings.js:135
+#: src/screens/Settings.js:142
 msgid "Create a new token"
 msgstr "Создать новый токен"
 
-#: src/screens/Settings.js:142
+#: src/screens/Settings.js:149
 msgid "Register a token"
 msgstr "Зарегистрировать токен"
 
-#: src/screens/Settings.js:158
+#: src/screens/Settings.js:165
 msgid "About"
 msgstr "О нас"
 
-#: src/screens/Settings.js:165
+#: src/screens/Settings.js:172
 msgid "Unique app identifier"
 msgstr ""
 
-#: src/screens/Settings.js:179
+#: src/screens/Settings.js:186
 msgid "Developer Settings"
 msgstr ""
 
-#: src/screens/Settings.js:181
+#: src/screens/Settings.js:188
 msgid "Network Settings"
 msgstr ""
 
@@ -904,27 +904,27 @@ msgstr ""
 msgid "walletServiceWsUrl is required when walletServiceUrl is filled."
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:229
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
 msgid "Node URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:239
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:242
 msgid "Explorer URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:248
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
 msgid "Explorer Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:257
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:260
 msgid "Transaction Mining Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:268
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:271
 msgid "Wallet Service URL (optional)"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:277
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:280
 msgid "Wallet Service WS URL (optional)"
 msgstr ""
 
@@ -963,9 +963,9 @@ msgstr ""
 msgid "Load First Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:158
+#: src/components/NanoContract/NanoContractDetails.js:202
 #: src/components/NanoContract/SelectAddressModal.js:105
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:202
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:209
 #: src/screens/NanoContract/NanoContractRegisterScreen.js:177
 msgid "Loading"
 msgstr ""
@@ -975,7 +975,7 @@ msgid "Loading first wallet address."
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:142
-#: src/components/NanoContract/NanoContractTransactionHeader.js:88
+#: src/components/NanoContract/NanoContractTransactionHeader.js:85
 #: src/components/NanoContract/NanoContractsListItem.js:57
 #: src/components/TxDetailsModal.js:106
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:83
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Nano Contract Registration"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractTransactionScreen.js:37
+#: src/screens/NanoContract/NanoContractTransactionScreen.js:39
 msgid "Nano Contract Transaction"
 msgstr ""
 
@@ -1011,81 +1011,81 @@ msgstr ""
 msgid "Contract successfully registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:45
+#: src/sagas/nanoContract.js:44
 msgid "Nano Contract already registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:46
+#: src/sagas/nanoContract.js:45
 msgid "Wallet is not ready yet to register a Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:47
+#: src/sagas/nanoContract.js:46
 msgid "The informed address does not belong to the wallet."
 msgstr ""
 
-#: src/sagas/nanoContract.js:48
+#: src/sagas/nanoContract.js:47
 msgid "Nano Contract not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:49
+#: src/sagas/nanoContract.js:48
 msgid "Error while trying to get Nano Contract state."
 msgstr ""
 
-#: src/sagas/nanoContract.js:50
+#: src/sagas/nanoContract.js:49
 msgid "Blueprint not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:51
+#: src/sagas/nanoContract.js:50
 msgid "Couldn't get Blueprint info."
 msgstr ""
 
-#: src/sagas/nanoContract.js:52
+#: src/sagas/nanoContract.js:51
 msgid "Nano Contract not registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:53
+#: src/sagas/nanoContract.js:52
 msgid "Error while trying to download Nano Contract transactions history."
 msgstr ""
 
-#: src/sagas/networkSettings.js:91
+#: src/sagas/networkSettings.js:86
 msgid "Custom Network Settings cannot be empty."
 msgstr ""
 
-#: src/sagas/networkSettings.js:98
+#: src/sagas/networkSettings.js:93
 msgid "explorerUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:105
+#: src/sagas/networkSettings.js:100
 msgid "explorerServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:112
+#: src/sagas/networkSettings.js:107
 msgid "txMiningServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:119
+#: src/sagas/networkSettings.js:114
 msgid "nodeUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:126
+#: src/sagas/networkSettings.js:121
 msgid "walletServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:133
+#: src/sagas/networkSettings.js:128
 msgid "walletServiceWsUrl should be a valid URL."
 msgstr ""
 
 #.  If we fall into this situation, the app should be killed
 #.  for the custom new network settings take effect.
-#: src/sagas/networkSettings.js:296
+#: src/sagas/networkSettings.js:291
 msgid "Wallet not found while trying to persist the custom network settings."
 msgstr ""
 
-#: src/sagas/pushNotification.js:59
+#: src/sagas/pushNotification.js:71
 msgid "Transaction"
 msgstr ""
 
-#: src/sagas/pushNotification.js:60
+#: src/sagas/pushNotification.js:72
 msgid "Open"
 msgstr "Открыть"
 
@@ -1097,21 +1097,21 @@ msgstr ""
 msgid "Error loading the details of some tokens."
 msgstr ""
 
-#: src/sagas/wallet.js:749
+#: src/sagas/wallet.js:781
 msgid "Wallet is not ready to load addresses."
 msgstr ""
 
 #.  This will show the message in the feedback content at SelectAddressModal
-#: src/sagas/wallet.js:765
+#: src/sagas/wallet.js:797
 msgid "There was an error while loading wallet addresses. Try again."
 msgstr ""
 
-#: src/sagas/wallet.js:775
+#: src/sagas/wallet.js:807
 msgid "Wallet is not ready to load the first address."
 msgstr ""
 
 #.  This will show the message in the feedback content
-#: src/sagas/wallet.js:791
+#: src/sagas/wallet.js:823
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
 
@@ -1233,16 +1233,16 @@ msgstr "Поделиться"
 msgid "Propagating transaction to the network."
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:15
+#: src/components/ShowPushNotificationTxDetails.js:16
 msgid "Transation not found"
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:16
+#: src/components/ShowPushNotificationTxDetails.js:17
 msgid ""
 "The transaction has not arrived yet in your wallet. Do you want to retry?"
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:17
+#: src/components/ShowPushNotificationTxDetails.js:18
 msgid "Retry"
 msgstr ""
 
@@ -1268,12 +1268,12 @@ msgstr ""
 msgid "Description"
 msgstr "Описание"
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:47
+#: src/components/NanoContract/NanoContractTransactionHeader.js:44
 #: src/components/TxDetailsModal.js:104
 msgid "Transaction ID"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:92
+#: src/components/NanoContract/NanoContractTransactionHeader.js:89
 #: src/components/TxDetailsModal.js:105
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:116
 msgid "Blueprint Method"
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:106
+#: src/components/NanoContract/NanoContractTransactionHeader.js:103
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:124
 msgid "Caller"
 msgstr ""
@@ -1387,13 +1387,17 @@ msgstr ""
 msgid "Couldn't determine address, select one"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:48
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:50
 #, javascript-format
 msgid "Position ${ idx }"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:93
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:98
 msgid "Arguments"
+msgstr ""
+
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:103
+msgid "Loading arguments."
 msgstr ""
 
 #: src/components/WalletConnect/NanoContract/NewNanoContractTransactionModal.js:72
@@ -1421,46 +1425,46 @@ msgstr ""
 msgid "Read More."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:184
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:191
 msgid "Nano Contract Not Found"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:185
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:192
 msgid ""
 "The Nano Contract requested is not registered. First register the Nano "
 "Contract to interact with it."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:188
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:235
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:195
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:242
 msgid "Decline Transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:203
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:210
 msgid "Loading transaction information."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:231
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:238
 msgid "Accept Transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:245
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:252
 msgid "Sending transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:246
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:253
 msgid "Please wait."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:272
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:279
 msgid "Transaction successfully sent."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:274
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:281
 msgid "Ok, close"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:280
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:287
 msgid "Error while sending transaction."
 msgstr ""
 
@@ -1498,21 +1502,16 @@ msgstr ""
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:174
+#: src/components/NanoContract/NanoContractDetails.js:177
 msgid "Load More"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:200
+#: src/components/NanoContract/NanoContractDetails.js:203
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:214
+#: src/components/NanoContract/NanoContractDetails.js:217
 msgid "Nano Contract Transactions Error"
-msgstr ""
-
-#: src/components/NanoContract/NanoContractDetailsHeader.js:146
-#: src/components/NanoContract/NanoContractsListItem.js:59
-msgid "Blueprint Name"
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:150
@@ -1527,24 +1526,33 @@ msgstr ""
 msgid "Unregister contract"
 msgstr ""
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:96
+#: src/components/NanoContract/NanoContractTransactionActionList.js:44
+msgid "No Actions"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionList.js:45
+msgid "See full transaction details on Public Explorer."
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionListItem.js:108
+#, javascript-format
+msgid "Deposit ${ tokenSymbol }"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionListItem.js:109
+msgid "Withdrawal ${ tokenSymbol }"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionHeader.js:93
 msgid "Date and Time"
 msgstr ""
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:103
+#: src/components/NanoContract/NanoContractTransactionHeader.js:100
 #: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
 msgstr ""
 
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 #: src/components/NanoContract/NanoContractTransactionHeader.js:106
-msgid "Caller"
-msgstr ""
-
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:109
 msgid "See transaction details"
 msgstr ""
 
@@ -1596,8 +1604,4 @@ msgstr ""
 
 #: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
-msgstr ""
-
-#: src/components/NanoContract/UnregisterNanoContractModal.js:50
-msgid "No, go back"
 msgstr ""

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -1498,12 +1498,21 @@ msgstr ""
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:159
+#: src/components/NanoContract/NanoContractDetails.js:174
+msgid "Load More"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetails.js:200
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:173
+#: src/components/NanoContract/NanoContractDetails.js:214
 msgid "Nano Contract Transactions Error"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetailsHeader.js:146
+#: src/components/NanoContract/NanoContractsListItem.js:59
+msgid "Blueprint Name"
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:150
@@ -1527,6 +1536,11 @@ msgstr ""
 #: src/components/NanoContract/NanoContractTransactionHeader.js:103
 #: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
+msgstr ""
+
+#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
+#: src/components/NanoContract/NanoContractTransactionHeader.js:106
+msgid "Caller"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
@@ -1582,4 +1596,8 @@ msgstr ""
 
 #: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
+msgstr ""
+
+#: src/components/NanoContract/UnregisterNanoContractModal.js:50
+msgid "No, go back"
 msgstr ""

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -48,7 +48,7 @@ msgid "[Last] dddd [•] HH:mm"
 msgstr ""
 
 #: src/models.js:107
-#: src/utils.js:416
+#: src/utils.js:426
 #.  See https://momentjs.com/docs/#/displaying/calendar-time/
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr ""
@@ -421,8 +421,8 @@ msgstr ""
 msgid "Enter your seed words separated by space"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:194
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:282
+#: src/components/NanoContract/NanoContractDetails.js:238
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:289
 #: src/screens/LoadHistoryScreen.js:51
 #: src/screens/LoadWalletErrorScreen.js:20
 #: src/screens/NanoContract/NanoContractRegisterScreen.js:161
@@ -449,7 +449,7 @@ msgstr ""
 
 #: src/screens/LoadWalletErrorScreen.js:21
 #: src/screens/PinScreen.js:268
-#: src/screens/Settings.js:154
+#: src/screens/Settings.js:161
 msgid "Reset wallet"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgid "Cancel"
 msgstr ""
 
 #: src/screens/PushNotification.js:58
-#: src/screens/Settings.js:128
+#: src/screens/Settings.js:135
 msgid "Push Notification"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgid "RECEIVE"
 msgstr ""
 
 #: src/screens/RegisterToken.js:27
-#: src/screens/SendScanQRCode.js:89
+#: src/screens/SendScanQRCode.js:87
 #.  translator: Used when the QR Code Scanner is opened, and user will manually
 #.  enter the information.
 msgid "Manual info"
@@ -654,7 +654,7 @@ msgid "Lock wallet"
 msgstr ""
 
 #: src/screens/SendAddressInput.js:53
-#: src/screens/SendScanQRCode.js:97
+#: src/screens/SendScanQRCode.js:95
 msgid "SEND"
 msgstr ""
 
@@ -704,7 +704,7 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:288
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:291
 #: src/screens/SendConfirmScreen.js:168
 msgid "Send"
 msgstr ""
@@ -717,53 +717,53 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: src/screens/SendScanQRCode.js:73
+#: src/screens/SendScanQRCode.js:71
 #, javascript-format
 msgid "You don't have the requested token [${ tokenLabel }]"
 msgstr ""
 
-#: src/screens/SendScanQRCode.js:105
+#: src/screens/SendScanQRCode.js:103
 #: src/screens/WalletConnect/WalletConnectScan.js:49
 msgid "Scan the QR code"
 msgstr ""
 
-#: src/screens/Settings.js:97
+#: src/screens/Settings.js:104
 msgid "You are connected to"
 msgstr ""
 
-#: src/screens/Settings.js:105
+#: src/screens/Settings.js:112
 msgid "General Settings"
 msgstr ""
 
-#: src/screens/Settings.js:109
+#: src/screens/Settings.js:116
 msgid "Connected to"
 msgstr ""
 
-#: src/screens/Settings.js:122
+#: src/screens/Settings.js:129
 msgid "Security"
 msgstr ""
 
-#: src/screens/Settings.js:135
+#: src/screens/Settings.js:142
 msgid "Create a new token"
 msgstr ""
 
-#: src/screens/Settings.js:142
+#: src/screens/Settings.js:149
 msgid "Register a token"
 msgstr ""
 
-#: src/screens/Settings.js:158
+#: src/screens/Settings.js:165
 msgid "About"
 msgstr ""
 
-#: src/screens/Settings.js:165
+#: src/screens/Settings.js:172
 msgid "Unique app identifier"
 msgstr ""
 
-#: src/screens/Settings.js:179
+#: src/screens/Settings.js:186
 msgid "Developer Settings"
 msgstr ""
 
-#: src/screens/Settings.js:181
+#: src/screens/Settings.js:188
 msgid "Network Settings"
 msgstr ""
 
@@ -897,27 +897,27 @@ msgstr ""
 msgid "walletServiceWsUrl is required when walletServiceUrl is filled."
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:229
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
 msgid "Node URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:239
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:242
 msgid "Explorer URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:248
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
 msgid "Explorer Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:257
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:260
 msgid "Transaction Mining Service URL"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:268
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:271
 msgid "Wallet Service URL (optional)"
 msgstr ""
 
-#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:277
+#: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:280
 msgid "Wallet Service WS URL (optional)"
 msgstr ""
 
@@ -956,9 +956,9 @@ msgstr ""
 msgid "Load First Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:158
+#: src/components/NanoContract/NanoContractDetails.js:202
 #: src/components/NanoContract/SelectAddressModal.js:105
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:202
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:209
 #: src/screens/NanoContract/NanoContractRegisterScreen.js:177
 msgid "Loading"
 msgstr ""
@@ -968,7 +968,7 @@ msgid "Loading first wallet address."
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:142
-#: src/components/NanoContract/NanoContractTransactionHeader.js:88
+#: src/components/NanoContract/NanoContractTransactionHeader.js:85
 #: src/components/NanoContract/NanoContractsListItem.js:57
 #: src/components/TxDetailsModal.js:106
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:83
@@ -996,7 +996,7 @@ msgstr ""
 msgid "Nano Contract Registration"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractTransactionScreen.js:37
+#: src/screens/NanoContract/NanoContractTransactionScreen.js:39
 msgid "Nano Contract Transaction"
 msgstr ""
 
@@ -1004,81 +1004,81 @@ msgstr ""
 msgid "Contract successfully registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:45
+#: src/sagas/nanoContract.js:44
 msgid "Nano Contract already registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:46
+#: src/sagas/nanoContract.js:45
 msgid "Wallet is not ready yet to register a Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:47
+#: src/sagas/nanoContract.js:46
 msgid "The informed address does not belong to the wallet."
 msgstr ""
 
-#: src/sagas/nanoContract.js:48
+#: src/sagas/nanoContract.js:47
 msgid "Nano Contract not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:49
+#: src/sagas/nanoContract.js:48
 msgid "Error while trying to get Nano Contract state."
 msgstr ""
 
-#: src/sagas/nanoContract.js:50
+#: src/sagas/nanoContract.js:49
 msgid "Blueprint not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:51
+#: src/sagas/nanoContract.js:50
 msgid "Couldn't get Blueprint info."
 msgstr ""
 
-#: src/sagas/nanoContract.js:52
+#: src/sagas/nanoContract.js:51
 msgid "Nano Contract not registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:53
+#: src/sagas/nanoContract.js:52
 msgid "Error while trying to download Nano Contract transactions history."
 msgstr ""
 
-#: src/sagas/networkSettings.js:91
+#: src/sagas/networkSettings.js:86
 msgid "Custom Network Settings cannot be empty."
 msgstr ""
 
-#: src/sagas/networkSettings.js:98
+#: src/sagas/networkSettings.js:93
 msgid "explorerUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:105
+#: src/sagas/networkSettings.js:100
 msgid "explorerServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:112
+#: src/sagas/networkSettings.js:107
 msgid "txMiningServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:119
+#: src/sagas/networkSettings.js:114
 msgid "nodeUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:126
+#: src/sagas/networkSettings.js:121
 msgid "walletServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:133
+#: src/sagas/networkSettings.js:128
 msgid "walletServiceWsUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:296
+#: src/sagas/networkSettings.js:291
 #.  If we fall into this situation, the app should be killed
 #.  for the custom new network settings take effect.
 msgid "Wallet not found while trying to persist the custom network settings."
 msgstr ""
 
-#: src/sagas/pushNotification.js:59
+#: src/sagas/pushNotification.js:71
 msgid "Transaction"
 msgstr ""
 
-#: src/sagas/pushNotification.js:60
+#: src/sagas/pushNotification.js:72
 msgid "Open"
 msgstr ""
 
@@ -1090,20 +1090,20 @@ msgstr ""
 msgid "Error loading the details of some tokens."
 msgstr ""
 
-#: src/sagas/wallet.js:749
+#: src/sagas/wallet.js:781
 msgid "Wallet is not ready to load addresses."
 msgstr ""
 
-#: src/sagas/wallet.js:765
+#: src/sagas/wallet.js:797
 #.  This will show the message in the feedback content at SelectAddressModal
 msgid "There was an error while loading wallet addresses. Try again."
 msgstr ""
 
-#: src/sagas/wallet.js:775
+#: src/sagas/wallet.js:807
 msgid "Wallet is not ready to load the first address."
 msgstr ""
 
-#: src/sagas/wallet.js:791
+#: src/sagas/wallet.js:823
 #.  This will show the message in the feedback content
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
@@ -1228,15 +1228,15 @@ msgstr ""
 msgid "Propagating transaction to the network."
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:15
+#: src/components/ShowPushNotificationTxDetails.js:16
 msgid "Transation not found"
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:16
+#: src/components/ShowPushNotificationTxDetails.js:17
 msgid "The transaction has not arrived yet in your wallet. Do you want to retry?"
 msgstr ""
 
-#: src/components/ShowPushNotificationTxDetails.js:17
+#: src/components/ShowPushNotificationTxDetails.js:18
 msgid "Retry"
 msgstr ""
 
@@ -1261,12 +1261,12 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:47
+#: src/components/NanoContract/NanoContractTransactionHeader.js:44
 #: src/components/TxDetailsModal.js:104
 msgid "Transaction ID"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:92
+#: src/components/NanoContract/NanoContractTransactionHeader.js:89
 #: src/components/TxDetailsModal.js:105
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:116
 msgid "Blueprint Method"
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:106
+#: src/components/NanoContract/NanoContractTransactionHeader.js:103
 #: src/components/WalletConnect/NanoContract/NanoContractExecInfo.js:124
 msgid "Caller"
 msgstr ""
@@ -1380,13 +1380,17 @@ msgstr ""
 msgid "Couldn't determine address, select one"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:48
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:50
 #, javascript-format
 msgid "Position ${ idx }"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:93
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:98
 msgid "Arguments"
+msgstr ""
+
+#: src/components/WalletConnect/NanoContract/NanoContractMethodArgs.js:103
+msgid "Loading arguments."
 msgstr ""
 
 #: src/components/WalletConnect/NanoContract/NewNanoContractTransactionModal.js:72
@@ -1413,46 +1417,46 @@ msgstr ""
 msgid "Read More."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:184
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:191
 msgid "Nano Contract Not Found"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:185
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:192
 msgid ""
 "The Nano Contract requested is not registered. First register the Nano "
 "Contract to interact with it."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:188
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:235
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:195
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:242
 msgid "Decline Transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:203
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:210
 msgid "Loading transaction information."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:231
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:238
 msgid "Accept Transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:245
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:252
 msgid "Sending transaction"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:246
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:253
 msgid "Please wait."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:272
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:279
 msgid "Transaction successfully sent."
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:274
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:281
 msgid "Ok, close"
 msgstr ""
 
-#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:280
+#: src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js:287
 msgid "Error while sending transaction."
 msgstr ""
 
@@ -1490,21 +1494,16 @@ msgstr ""
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:174
+#: src/components/NanoContract/NanoContractDetails.js:177
 msgid "Load More"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:200
+#: src/components/NanoContract/NanoContractDetails.js:203
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:214
+#: src/components/NanoContract/NanoContractDetails.js:217
 msgid "Nano Contract Transactions Error"
-msgstr ""
-
-#: src/components/NanoContract/NanoContractDetailsHeader.js:146
-#: src/components/NanoContract/NanoContractsListItem.js:59
-msgid "Blueprint Name"
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:150
@@ -1519,24 +1518,33 @@ msgstr ""
 msgid "Unregister contract"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:96
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
+#: src/components/NanoContract/NanoContractTransactionActionList.js:44
+msgid "No Actions"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionList.js:45
+msgid "See full transaction details on Public Explorer."
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionListItem.js:108
+#, javascript-format
+msgid "Deposit ${ tokenSymbol }"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionActionListItem.js:109
+msgid "Withdrawal ${ tokenSymbol }"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionHeader.js:93
 msgid "Date and Time"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.js:103
+#: src/components/NanoContract/NanoContractTransactionHeader.js:100
 #: src/components/NanoContract/NanoContractTransactionsListItem.js:62
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 msgid "From this wallet"
 msgstr ""
 
 #: src/components/NanoContract/NanoContractTransactionHeader.js:106
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-msgid "Caller"
-msgstr ""
-
-#: src/components/NanoContract/NanoContractTransactionHeader.js:109
-#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 msgid "See transaction details"
 msgstr ""
 
@@ -1588,8 +1596,4 @@ msgstr ""
 
 #: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
-msgstr ""
-
-#: src/components/NanoContract/UnregisterNanoContractModal.js:50
-msgid "No, go back"
 msgstr ""

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -1490,12 +1490,21 @@ msgstr ""
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:159
+#: src/components/NanoContract/NanoContractDetails.js:174
+msgid "Load More"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetails.js:200
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.js:173
+#: src/components/NanoContract/NanoContractDetails.js:214
 msgid "Nano Contract Transactions Error"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetailsHeader.js:146
+#: src/components/NanoContract/NanoContractsListItem.js:59
+msgid "Blueprint Name"
 msgstr ""
 
 #: src/components/NanoContract/NanoContractDetailsHeader.js:150
@@ -1519,6 +1528,11 @@ msgstr ""
 #: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 msgid "From this wallet"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractTransactionHeader.js:106
+#.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
+msgid "Caller"
 msgstr ""
 
 #: src/components/NanoContract/NanoContractTransactionHeader.js:109
@@ -1574,4 +1588,8 @@ msgstr ""
 
 #: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
+msgstr ""
+
+#: src/components/NanoContract/UnregisterNanoContractModal.js:50
+msgid "No, go back"
 msgstr ""

--- a/src/actions.js
+++ b/src/actions.js
@@ -1126,8 +1126,12 @@ export const nanoContractHistoryLoading = (ncEntry) => ({
  * Nano Contract history has loaded success.
  * @param {Object} payload
  * @param {string} payload.ncId Nano Contract ID.
- * @param {Object[]} payload.history Nano Contract's history chunk as array.
- * @param {string} payload.after A new history chunk will be fetched after this hash.
+ * @param {Object[]?} payload.history A chunk of txs to initialize history
+ * @param {Object[]?} payload.beforeHistory A chunk of newer txs.
+ * @param {Object[]?} payload.afterHistory A chunk of older txs.
+ *
+ * @description
+ * The history options are mutually exclusive.
  */
 export const nanoContractHistorySuccess = (payload) => ({
   type: types.NANOCONTRACT_HISTORY_SUCCESS,

--- a/src/components/NanoContract/NanoContractDetails.js
+++ b/src/components/NanoContract/NanoContractDetails.js
@@ -137,7 +137,10 @@ export const NanoContractDetails = ({ nc }) => {
             )}
             keyExtractor={(item) => item.txId}
             refreshing={isLoading}
-            onRefresh={handleNewerTransactions} // pull gesture
+            // Enables the pull gesture to get newer transactions
+            onRefresh={handleNewerTransactions}
+            // Enables a button to load more of older transactions until the end
+            // By reaching the end, the button ceases to render
             ListFooterComponent={<LoadMoreButton lastTx={txHistory.slice(-1,).pop()} />}
             extraData={[isLoading, error]}
           />

--- a/src/components/NanoContract/NanoContractDetails.js
+++ b/src/components/NanoContract/NanoContractDetails.js
@@ -150,7 +150,7 @@ export const NanoContractDetails = ({ nc }) => {
 };
 
 /**
- * It show a button to 'Load More' transactions after the last one.
+ * It shows a button to 'Load More' transactions after the last one.
  * It hides the button when the last transaction is the initialize.
  *
  * @param {Object} prop Properties object

--- a/src/components/NanoContract/NanoContractDetails.js
+++ b/src/components/NanoContract/NanoContractDetails.js
@@ -23,6 +23,7 @@ import Spinner from '../Spinner';
 import errorIcon from '../../assets/images/icErrorBig.png';
 import SimpleButton from '../SimpleButton';
 import { FeedbackContent } from '../FeedbackContent';
+import NewHathorButton from '../NewHathorButton';
 
 /**
  * Retrieves Nano Contract details from Redux.
@@ -98,7 +99,7 @@ export const NanoContractDetails = ({ nc }) => {
   /**
    * Triggered when a user makes the pull gesture on the transaction history content.
    */
-  const handleNewTransactions = () => {
+  const handleNewerTransactions = () => {
     dispatch(nanoContractHistoryRequest({ ncId: nc.ncId, before: txHistory[0].txId }));
   };
 
@@ -136,11 +137,48 @@ export const NanoContractDetails = ({ nc }) => {
             )}
             keyExtractor={(item) => item.txId}
             refreshing={isLoading}
-            onRefresh={handleNewTransactions} // pull gesture
+            onRefresh={handleNewerTransactions} // pull gesture
+            ListFooterComponent={<LoadMoreButton lastTx={txHistory.slice(-1,).pop()} />}
+            extraData={[isLoading, error]}
           />
         )}
     </Wrapper>
   );
+};
+
+/**
+ * It show a button to 'Load More' transactions after the last one.
+ * It hides the button when the last transaction is the initialize.
+ *
+ * @param {Object} prop Properties object
+ * @param {{
+ *   ncId: string;
+ *   txId: string;
+ * }} prop.lastTx A transaction item from transaction history
+ */
+const LoadMoreButton = ({ lastTx }) => {
+  const dispatch = useDispatch();
+  const isInitializeTx = lastTx.ncMethod === 'initialize';
+
+  /**
+   * This handling will dispatch an action to request for
+   * older transactions after a txId.
+   */
+  const handleLoadMore = () => dispatch(nanoContractHistoryRequest({
+    ncId: lastTx.ncId,
+    after: lastTx.txId,
+  }));
+
+  return !isInitializeTx && (
+    <NewHathorButton
+      title={t`Load More`}
+      onPress={handleLoadMore}
+      discrete
+      wrapperStyle={{
+        marginTop: 16,
+      }}
+    />
+  )
 };
 
 /**

--- a/src/components/NanoContract/NanoContractDetails.js
+++ b/src/components/NanoContract/NanoContractDetails.js
@@ -6,7 +6,7 @@
  */
 
 import { useNavigation } from '@react-navigation/native';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   StyleSheet,
   View,
@@ -167,10 +167,10 @@ const LoadMoreButton = ({ lastTx }) => {
    * This handling will dispatch an action to request for
    * older transactions after a txId.
    */
-  const handleLoadMore = () => dispatch(nanoContractHistoryRequest({
+  const handleLoadMore = () => useCallback(dispatch(nanoContractHistoryRequest({
     ncId: lastTx.ncId,
     after: lastTx.txId,
-  }));
+  })), [lastTx]);
 
   return !isInitializeTx && (
     <NewHathorButton

--- a/src/components/NanoContract/NanoContractDetails.js
+++ b/src/components/NanoContract/NanoContractDetails.js
@@ -86,6 +86,8 @@ export const NanoContractDetails = ({ nc }) => {
        * it will be set during the load.
        */
       dispatch(nanoContractHistoryRequest({ ncId: nc.ncId, after: null }));
+    } else {
+      dispatch(nanoContractHistoryRequest({ ncId: nc.ncId, after }))
     }
   }, []);
 

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -384,7 +384,6 @@ const initialState = {
      *   [ncId: string]: {
      *     isLoading: boolean;
      *     error: string;
-     *     after: string;
      *   };
      * }} holds the load state for each nano contract, including the after hash
      * from which a new history chunk should be fetched, exclusively.
@@ -392,7 +391,6 @@ const initialState = {
      * {
      *   '000001342d3c5b858a4d4835baea93fcc683fa615ff5892bd044459621a0340a': {
      *     isLoading: false,
-     *     after: '000075e15f015dc768065763acd9b563ec002e37182869965ff2c712bed83e1e',
      *   },
      * }
      */
@@ -1702,7 +1700,6 @@ export const onNanoContractHistoryClean = (state, { payload }) => ({
       [payload.ncId]: {
         ...(state.nanoContract.historyMeta[payload.ncId]),
         isLoading: false,
-        after: null,
         error: null,
       },
     },
@@ -1714,34 +1711,36 @@ export const onNanoContractHistoryClean = (state, { payload }) => ({
  * @param {{
  *   payload: {
  *     ncId: string;
- *     history: Object[];
- *     after: string;
+ *     history?: Object[];
+ *     beforeHistory?: Object[];
+ *     afterHistory?: Object[];
  *   }
  * }} action
  */
-export const onNanoContractHistorySuccess = (state, { payload }) => ({
-  ...state,
-  nanoContract: {
-    ...state.nanoContract,
-    history: {
-      ...state.nanoContract.history,
-      [payload.ncId]: [
-        // we are putting at the top because we expect an array with descending order.
-        ...payload.history,
-        ...(state.nanoContract.history[payload.ncId] || []),
-      ],
-    },
-    historyMeta: {
-      ...state.nanoContract.historyMeta,
-      [payload.ncId]: {
-        ...(state.nanoContract.historyMeta[payload.ncId]),
-        isLoading: false,
-        after: payload.after,
-        error: null,
+export const onNanoContractHistorySuccess = (state, { payload }) => {
+  return {
+    ...state,
+    nanoContract: {
+      ...state.nanoContract,
+      history: {
+        ...state.nanoContract.history,
+        [payload.ncId]: [
+          ...(payload.beforeHistory || []),
+          ...(payload.history || state.nanoContract.history[payload.ncId] || []),
+          ...(payload.afterHistory || []),
+        ],
+      },
+      historyMeta: {
+        ...state.nanoContract.historyMeta,
+        [payload.ncId]: {
+          ...(state.nanoContract.historyMeta[payload.ncId]),
+          isLoading: false,
+          error: null,
+        },
       },
     },
-  },
-});
+  }
+};
 
 /**
  * @param {Object} state

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1726,9 +1726,9 @@ export const onNanoContractHistorySuccess = (state, { payload }) => ({
     history: {
       ...state.nanoContract.history,
       [payload.ncId]: [
-        ...(state.nanoContract.history[payload.ncId] || []),
-        // we are putting at the bottom because we expect an array with descending order.
+        // we are putting at the top because we expect an array with descending order.
         ...payload.history,
+        ...(state.nanoContract.history[payload.ncId] || []),
       ],
     },
     historyMeta: {

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1717,30 +1717,28 @@ export const onNanoContractHistoryClean = (state, { payload }) => ({
  *   }
  * }} action
  */
-export const onNanoContractHistorySuccess = (state, { payload }) => {
-  return {
-    ...state,
-    nanoContract: {
-      ...state.nanoContract,
-      history: {
-        ...state.nanoContract.history,
-        [payload.ncId]: [
-          ...(payload.beforeHistory || []),
-          ...(payload.history || state.nanoContract.history[payload.ncId] || []),
-          ...(payload.afterHistory || []),
-        ],
-      },
-      historyMeta: {
-        ...state.nanoContract.historyMeta,
-        [payload.ncId]: {
-          ...(state.nanoContract.historyMeta[payload.ncId]),
-          isLoading: false,
-          error: null,
-        },
+export const onNanoContractHistorySuccess = (state, { payload }) => ({
+  ...state,
+  nanoContract: {
+    ...state.nanoContract,
+    history: {
+      ...state.nanoContract.history,
+      [payload.ncId]: [
+        ...(payload.beforeHistory || []),
+        ...(payload.history || state.nanoContract.history[payload.ncId] || []),
+        ...(payload.afterHistory || []),
+      ],
+    },
+    historyMeta: {
+      ...state.nanoContract.historyMeta,
+      [payload.ncId]: {
+        ...(state.nanoContract.historyMeta[payload.ncId]),
+        isLoading: false,
+        error: null,
       },
     },
-  }
-};
+  },
+});
 
 /**
  * @param {Object} state

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -189,17 +189,21 @@ export async function fetchHistory(ncId, count, after, wallet) {
   /**
    * @type {RawNcTxHistoryResponse} response
    */
-  const response = await ncApi.getNanoContractHistory(ncId, count, /* past */ null, /* future */ after);
+  const response = await ncApi.getNanoContractHistory(
+    ncId,
+    count,
+    /* past */ null,
+    /* future */ after
+  );
   const { success, history: rawHistory } = response;
 
   if (!success) {
     throw new Error('Failed to fetch nano contract history');
   }
-
   // We are interested to produce a list of transactions in descending order
   // because we want users to see newest txs first.
-  const historyReversed = new Array(rawHistory.length) 
-  for (const idx in rawHistory) {
+  const historyReversed = new Array(rawHistory.length)
+  for (let idx = 0; idx < rawHistory.length; idx += 1) {
     const rawTx = rawHistory[idx];
     const network = wallet.getNetworkObject();
     const caller = addressUtils.getAddressFromPubkey(rawTx.nc_pubkey, network).base58;

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -172,37 +172,45 @@ export function* registerNanoContract({ payload }) {
 
 /**
  * Fetch history from Nano Contract wallet's API.
- * @param {string} ncId Nano Contract ID
- * @param {number} count Maximum quantity of history items
- * @param {string} after Transaction hash to start to get items
- * @param {Object} wallet Wallet instance from redux state
+ * @req {Object} req
+ * @param {string} req.ncId Nano Contract ID
+ * @param {number} req.count Maximum quantity of items to fetch
+ * @param {string} req.before Transaction hash to start to get newer items
+ * @param {string} req.after Transaction hash to start to get older items
+ * @param {Object} req.wallet Wallet instance from redux state
  *
- * @description
- * We use `after` because we look at time from present to future, therefore `after` means
- * "from now on in the future".
+ * @returns {{
+ *   history: {};
+ * }}
  *
  * @throws {Error} when request code is greater then 399 or when response's success is false
  */
-export async function fetchHistory(ncId, count, after, wallet) {
-  // getNanoContractHistory returns a list of transactions by ascending order,
-  // however its pagination works by descending order.
-  // That's why we ask for new transactions `before` an specific tx.
-  // Pagination: future (newest tx) <- current last tx (before) -> past (oldest tx).
-  // Page order: past (oldest tx) -> future (newest tx).
+export async function fetchHistory(req) {
+  const {
+    wallet,
+    ncId,
+    count,
+    after,
+    before,
+  } = req;
   /**
    * @type {RawNcTxHistoryResponse} response
    */
   const response = await ncApi.getNanoContractHistory(
     ncId,
     count,
-    /* past */ null,
-    /* future */ after
+    after || null,
+    before || null,
   );
   const { success, history: rawHistory } = response;
 
   if (!success) {
     throw new Error('Failed to fetch nano contract history');
   }
+
+  /* TODO: Make it run concurrently while guaranting the order.
+  /* see https://github.com/HathorNetwork/hathor-wallet-mobile/issues/514
+   */
   const historyNewestToOldest = new Array(rawHistory.length)
   for (let idx = 0; idx < rawHistory.length; idx += 1) {
     const rawTx = rawHistory[idx];
@@ -236,13 +244,7 @@ export async function fetchHistory(ncId, count, after, wallet) {
     historyNewestToOldest[idx] = tx;
   }
 
-  let next = after;
-  if (historyNewestToOldest && historyNewestToOldest.length > 0) {
-    // The first item is the newest one. 
-    next = historyNewestToOldest[0].txId;
-  }
-
-  return { history: historyNewestToOldest, next };
+  return { history: historyNewestToOldest };
 }
 
 /**
@@ -250,13 +252,13 @@ export async function fetchHistory(ncId, count, after, wallet) {
  * @param {{
  *   payload: {
  *     ncId: string;
- *     after: string;
+ *     before?: string;
+ *     after?: string;
  *   }
  * }} action with request payload.
  */
 export function* requestHistoryNanoContract({ payload }) {
-  const { ncId, after } = payload;
-  const count = NANO_CONTRACT_TX_HISTORY_SIZE;
+  const { ncId, before, after } = payload;
   log.debug('Start processing request for nano contract transaction history...');
 
   const historyMeta = yield select((state) => state.nanoContract.historyMeta);
@@ -284,24 +286,38 @@ export function* requestHistoryNanoContract({ payload }) {
     return;
   }
 
-  if (after == null) {
+  if (before == null && after == null) {
     // it clean the history when starting load from the beginning
+    log.debug('Cleaning previous history to start over.');
     yield put(nanoContractHistoryClean({ ncId }));
   }
 
   try {
-    // fetch from fullnode
-    const { history, next } = yield call(fetchHistory, ncId, count, after, wallet);
+    const req = {
+      wallet,
+      ncId,
+      before,
+      after,
+      count: NANO_CONTRACT_TX_HISTORY_SIZE,
+    };
+    const { history } = yield call(fetchHistory, req);
 
-    if (after != null) {
-      // The first load has always `after` equals null. The first load means to be fast,
-      // but the subsequent ones are all request by user and we want slow down multiple
-      // calls to this effect.
+    if (after != null || before != null) {
+      // We want slow down multiple calls to this effect.
       yield delay(1000)
     }
 
     log.debug('Success fetching Nano Contract history.');
-    yield put(nanoContractHistorySuccess({ ncId, history, after: next }));
+    if (before != null) {
+      log.debug('Adding beforeHistory.');
+      yield put(nanoContractHistorySuccess({ ncId, beforeHistory: history }));
+    } else if (after != null) {
+      log.debug('Adding afterHistory.');
+      yield put(nanoContractHistorySuccess({ ncId, afterHistory: history }));
+    } else {
+      log.debug('Initializing history.');
+      yield put(nanoContractHistorySuccess({ ncId, history }));
+    }
   } catch (error) {
     log.error('Error while fetching Nano Contract history.', error);
     // break loading process and give feedback to user

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -225,7 +225,7 @@ export async function fetchHistory(req) {
     // See issue: https://github.com/HathorNetwork/hathor-wallet-lib/issues/732
     // Default to `false` if using Wallet Service.
     let isMine = false;
-    const useWalletService = consumeGenerator(isWalletServiceEnabled);
+    const useWalletService = consumeGenerator(isWalletServiceEnabled());
     if (!useWalletService) {
       // eslint-disable-next-line no-await-in-loop
       isMine = await wallet.isAddressMine(caller);

--- a/src/utils.js
+++ b/src/utils.js
@@ -426,6 +426,18 @@ export const getNanoContractFeatureToggle = (state) => (
 export const getTimestampFormat = (timestamp) => moment.unix(timestamp).format(t`DD MMM YYYY [•] HH:mm`)
 
 /**
+ * Extract the result of a generator function when it is done.
+ */
+export const consumeGenerator = (generator) => {
+  for (;;) {
+    const { value, done } = generator.next();
+    if (done) {
+      return value;
+    }
+  }
+}
+
+/**
  * Extract all the items of an async iterator/generator.
  *
  * @returns {Promise<unknown[]>} A promise of an array of unkown object.


### PR DESCRIPTION
### Acceptance Criteria
- It should fix nano contract transaction loading for newer transactions
- Add 'Load More' in the footer of transactions list, which triggers the request for older transactions when pressed
  - Hides the 'Load More' button when the last transaction of the list is the 'initialize'

#### Loading newer transactions

https://github.com/user-attachments/assets/781e6759-6db2-4e81-b3bc-c20641c097ed

#### Loading older transactions

https://github.com/user-attachments/assets/68f99f4e-b8be-4cf2-a02f-63f1268bfa18

The video above shows a list of transactions initialized with the newest transaction only. When the button 'Load More' is pressed a list of older transactions is loaded. The button 'Load More' didn't show after load because the list has reached its end.

---

Related issues:
- [ ] https://github.com/HathorNetwork/hathor-wallet-mobile/issues/514

---

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
