### PR TITLE
feat: add load older transactions on Nano Contract Details screen

### DIFF
--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -57,11 +57,11 @@ msgid "[Last] dddd [•] HH:mm"
 msgstr "[Sidste] dddd [•] HH:mm"
 
 #.  See https://momentjs.com/docs/#/displaying/calendar-time/
-#: src/models.js:107 src/utils.js:415
+#: src/models.js:107 src/utils.js:416
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH:mm"
 
-#: src/utils.js:160
+#: src/utils.js:161
 msgid "Invalid address"
 msgstr "Ugyldig adresse"
 
@@ -432,9 +432,9 @@ msgstr "Ord"
 msgid "Enter your seed words separated by space"
 msgstr "Indtast dine seed-ord adskilt med mellemrum"
 
-#: src/components/NanoContract/NanoContractDetails.component.js:194
+#: src/components/NanoContract/NanoContractDetails.js:235
 #: src/screens/LoadHistoryScreen.js:51 src/screens/LoadWalletErrorScreen.js:20
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:167
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:161
 msgid "Try again"
 msgstr ""
 
@@ -698,8 +698,8 @@ msgstr "Autoriserer overførslen"
 msgid "Your transfer of **${ this.amountAndToken }** has been confirmed"
 msgstr "Din overførsel af **${ _this.amountAndToken }** er bekræftet"
 
-#: src/components/NanoContract/EditAddressModal.component.js:60
-#: src/components/NanoContract/SelectAddressModal.component.js:117
+#: src/components/NanoContract/EditAddressModal.js:60
+#: src/components/NanoContract/SelectAddressModal.js:117
 #: src/screens/SendConfirmScreen.js:161
 msgid "Address"
 msgstr "Adresse"
@@ -932,53 +932,53 @@ msgstr ""
 msgid "Nano Contract Details"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:67
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:58
 msgid "Nano Contract ID is required."
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:157
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:151
 msgid "See contract"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:175
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:169
 msgid "Load First Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:158
-#: src/components/NanoContract/SelectAddressModal.component.js:105
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:183
+#: src/components/NanoContract/NanoContractDetails.js:199
+#: src/components/NanoContract/SelectAddressModal.js:105
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:177
 msgid "Loading"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:184
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:178
 msgid "Loading first wallet address."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:142
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:88
+#: src/components/NanoContract/NanoContractDetailsHeader.js:142
+#: src/components/NanoContract/NanoContractTransactionHeader.js:88
 #: src/components/NanoContract/NanoContractsListItem.js:57
 #: src/components/TxDetailsModal.js:106
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:193
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:187
 msgid "Nano Contract ID"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:201
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:195
 msgid "Wallet Address"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:211
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:205
 msgid "If you want to change the wallet address, you will be able to do"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:213
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:207
 msgid "after the contract is registered."
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:232
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:226
 msgid "Register Nano Contract"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:250
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:244
 msgid "Nano Contract Registration"
 msgstr ""
 
@@ -1060,21 +1060,21 @@ msgstr "Transaktion"
 msgid "Open"
 msgstr "Åben"
 
-#: src/sagas/wallet.js:744
+#: src/sagas/wallet.js:750
 msgid "Wallet is not ready to load addresses."
 msgstr ""
 
 #.  This will show the message in the feedback content at SelectAddressModal
-#: src/sagas/wallet.js:760
+#: src/sagas/wallet.js:766
 msgid "There was an error while loading wallet addresses. Try again."
 msgstr ""
 
-#: src/sagas/wallet.js:770
+#: src/sagas/wallet.js:776
 msgid "Wallet is not ready to load the first address."
 msgstr ""
 
 #.  This will show the message in the feedback content
-#: src/sagas/wallet.js:786
+#: src/sagas/wallet.js:792
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
 
@@ -1246,12 +1246,12 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:47
+#: src/components/NanoContract/NanoContractTransactionHeader.js:47
 #: src/components/TxDetailsModal.js:104
 msgid "Transaction ID"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:92
+#: src/components/NanoContract/NanoContractTransactionHeader.js:92
 #: src/components/TxDetailsModal.js:105
 msgid "Blueprint Method"
 msgstr ""
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "Nano Contract Status"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:79
+#: src/components/NanoContract/NanoContractDetailsHeader.js:79
 #: src/components/TxDetailsModal.js:120
 msgid "Nano Contract"
 msgstr ""
@@ -1302,79 +1302,83 @@ msgstr ""
 msgid "Custom network"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:41
+#: src/components/NanoContract/EditAddressModal.js:41
 msgid "New Nano Contract Address"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:49
+#: src/components/NanoContract/EditAddressModal.js:49
 msgid ""
 "This address signs any transaction you create with Nano Contracts method. "
 "Switching to a new one means"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:51
+#: src/components/NanoContract/EditAddressModal.js:51
 msgid "all future transactions will use this address."
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:57
+#: src/components/NanoContract/EditAddressModal.js:57
 msgid "Selected Information"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:67
+#: src/components/NanoContract/EditAddressModal.js:67
 msgid "Index"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:74
+#: src/components/NanoContract/EditAddressModal.js:74
 msgid "Confirm new address"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:78
+#: src/components/NanoContract/EditAddressModal.js:78
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:159
+#: src/components/NanoContract/NanoContractDetails.js:174
+msgid "Load More"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetails.js:200
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:173
+#: src/components/NanoContract/NanoContractDetails.js:214
 msgid "Nano Contract Transactions Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:146
+#: src/components/NanoContract/NanoContractDetailsHeader.js:146
 #: src/components/NanoContract/NanoContractsListItem.js:59
 msgid "Blueprint Name"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:150
+#: src/components/NanoContract/NanoContractDetailsHeader.js:150
 msgid "Registered Address"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:153
+#: src/components/NanoContract/NanoContractDetailsHeader.js:153
 msgid "See status details"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:154
+#: src/components/NanoContract/NanoContractDetailsHeader.js:154
 msgid "Unregister contract"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:96
+#: src/components/NanoContract/NanoContractTransactionHeader.js:96
 msgid "Date and Time"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:103
-#: src/components/NanoContract/NanoContractTransactionsListItem.component.js:62
+#: src/components/NanoContract/NanoContractTransactionHeader.js:103
+#: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:106
+#: src/components/NanoContract/NanoContractTransactionHeader.js:106
 msgid "Caller"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:109
+#: src/components/NanoContract/NanoContractTransactionHeader.js:109
 msgid "See transaction details"
 msgstr ""
 
@@ -1392,42 +1396,42 @@ msgstr ""
 msgid "Register new"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:90
+#: src/components/NanoContract/SelectAddressModal.js:90
 msgid "Choose New Wallet Address"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:97
+#: src/components/NanoContract/SelectAddressModal.js:97
 msgid "Load Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:106
+#: src/components/NanoContract/SelectAddressModal.js:106
 msgid "Loading wallet addresses."
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:114
+#: src/components/NanoContract/SelectAddressModal.js:114
 msgid "Current Information"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:115
+#: src/components/NanoContract/SelectAddressModal.js:115
 msgid "To change, select other address on the list below."
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:178
+#: src/components/NanoContract/SelectAddressModal.js:178
 msgid "index"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:39
+#: src/components/NanoContract/UnregisterNanoContractModal.js:39
 msgid "Unregister Nano Contract"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:41
+#: src/components/NanoContract/UnregisterNanoContractModal.js:41
 msgid "Are you sure you want to unregister this Nano Contract?"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:44
+#: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:50
+#: src/components/NanoContract/UnregisterNanoContractModal.js:50
 msgid "No, go back"
 msgstr ""

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -57,11 +57,11 @@ msgid "[Last] dddd [•] HH:mm"
 msgstr "[Última] dddd [•] HH:mm"
 
 #.  See https://momentjs.com/docs/#/displaying/calendar-time/
-#: src/models.js:107 src/utils.js:415
+#: src/models.js:107 src/utils.js:416
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH:mm"
 
-#: src/utils.js:160
+#: src/utils.js:161
 msgid "Invalid address"
 msgstr "Endereço inválido"
 
@@ -443,9 +443,9 @@ msgstr "Palavras"
 msgid "Enter your seed words separated by space"
 msgstr "Digite suas palavras separadas por espaços"
 
-#: src/components/NanoContract/NanoContractDetails.component.js:194
+#: src/components/NanoContract/NanoContractDetails.js:235
 #: src/screens/LoadHistoryScreen.js:51 src/screens/LoadWalletErrorScreen.js:20
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:167
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:161
 msgid "Try again"
 msgstr "Tente novamente"
 
@@ -714,8 +714,8 @@ msgstr "Autorizar operação"
 msgid "Your transfer of **${ this.amountAndToken }** has been confirmed"
 msgstr "Sua transferência de **${ this.amountAndToken }** foi confirmada"
 
-#: src/components/NanoContract/EditAddressModal.component.js:60
-#: src/components/NanoContract/SelectAddressModal.component.js:117
+#: src/components/NanoContract/EditAddressModal.js:60
+#: src/components/NanoContract/SelectAddressModal.js:117
 #: src/screens/SendConfirmScreen.js:161
 msgid "Address"
 msgstr "Endereço"
@@ -958,53 +958,53 @@ msgstr ""
 msgid "Nano Contract Details"
 msgstr "Detalhes do Nano Contract"
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:67
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:58
 msgid "Nano Contract ID is required."
 msgstr "ID do Nano Contract é obrigatório."
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:157
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:151
 msgid "See contract"
 msgstr "Ver contrato"
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:175
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:169
 msgid "Load First Addresses Error"
 msgstr "Erro ao carregar primeiro endereço da wallet"
 
-#: src/components/NanoContract/NanoContractDetails.component.js:158
-#: src/components/NanoContract/SelectAddressModal.component.js:105
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:183
+#: src/components/NanoContract/NanoContractDetails.js:199
+#: src/components/NanoContract/SelectAddressModal.js:105
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:177
 msgid "Loading"
 msgstr "Carregando"
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:184
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:178
 msgid "Loading first wallet address."
 msgstr "Carregando primeiro endereço da wallet."
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:142
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:88
+#: src/components/NanoContract/NanoContractDetailsHeader.js:142
+#: src/components/NanoContract/NanoContractTransactionHeader.js:88
 #: src/components/NanoContract/NanoContractsListItem.js:57
 #: src/components/TxDetailsModal.js:106
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:193
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:187
 msgid "Nano Contract ID"
 msgstr "ID do Nano Contract"
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:201
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:195
 msgid "Wallet Address"
 msgstr "Endereço da Carteira"
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:211
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:205
 msgid "If you want to change the wallet address, you will be able to do"
 msgstr "Se deseja alterar o endereço de assinatura, você pode alterar"
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:213
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:207
 msgid "after the contract is registered."
 msgstr "depois do contrato ser registrado."
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:232
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:226
 msgid "Register Nano Contract"
 msgstr "Registrar Nano Contract"
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:250
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:244
 msgid "Nano Contract Registration"
 msgstr "Registro do Nano Contract"
 
@@ -1087,22 +1087,21 @@ msgstr "Transação"
 msgid "Open"
 msgstr "Abrir"
 
-#: src/sagas/wallet.js:744
+#: src/sagas/wallet.js:750
 msgid "Wallet is not ready to load addresses."
 msgstr "A wallet não está pronta para carregar os endereços."
 
 #.  This will show the message in the feedback content at SelectAddressModal
-#: src/sagas/wallet.js:760
+#: src/sagas/wallet.js:766
 msgid "There was an error while loading wallet addresses. Try again."
-msgstr ""
-"Ocorreu um erro ao carregar os endereços da wallet. Tente novamente."
+msgstr "Ocorreu um erro ao carregar os endereços da wallet. Tente novamente."
 
-#: src/sagas/wallet.js:770
+#: src/sagas/wallet.js:776
 msgid "Wallet is not ready to load the first address."
 msgstr "A wallet não está pronta para carregar o primeiro endereço."
 
 #.  This will show the message in the feedback content
-#: src/sagas/wallet.js:786
+#: src/sagas/wallet.js:792
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
 "Ocorreu um erro ao carregar o primeiro endereço da wallet. Tente novamente."
@@ -1277,12 +1276,12 @@ msgstr "Inválida"
 msgid "Description"
 msgstr "Descrição"
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:47
+#: src/components/NanoContract/NanoContractTransactionHeader.js:47
 #: src/components/TxDetailsModal.js:104
 msgid "Transaction ID"
 msgstr "ID da Transação"
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:92
+#: src/components/NanoContract/NanoContractTransactionHeader.js:92
 #: src/components/TxDetailsModal.js:105
 msgid "Blueprint Method"
 msgstr "Método do Blueprint"
@@ -1295,7 +1294,7 @@ msgstr "Endereço de assinatura do Nano Contract"
 msgid "Nano Contract Status"
 msgstr "Status do Nano Contract"
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:79
+#: src/components/NanoContract/NanoContractDetailsHeader.js:79
 #: src/components/TxDetailsModal.js:120
 msgid "Nano Contract"
 msgstr "Nano Contract"
@@ -1340,11 +1339,11 @@ msgstr ""
 msgid "Custom network"
 msgstr "Rede personalizada"
 
-#: src/components/NanoContract/EditAddressModal.component.js:41
+#: src/components/NanoContract/EditAddressModal.js:41
 msgid "New Nano Contract Address"
 msgstr "Novo endereço para o Nano Contract"
 
-#: src/components/NanoContract/EditAddressModal.component.js:49
+#: src/components/NanoContract/EditAddressModal.js:49
 msgid ""
 "This address signs any transaction you create with Nano Contracts method. "
 "Switching to a new one means"
@@ -1352,69 +1351,73 @@ msgstr ""
 "Este endereço assina toda transação criada com os métodos do Nano Contract. "
 "Ao alterar para um novo endereço significa que"
 
-#: src/components/NanoContract/EditAddressModal.component.js:51
+#: src/components/NanoContract/EditAddressModal.js:51
 msgid "all future transactions will use this address."
 msgstr "todas as transações futuras usarão este endereço."
 
-#: src/components/NanoContract/EditAddressModal.component.js:57
+#: src/components/NanoContract/EditAddressModal.js:57
 msgid "Selected Information"
 msgstr "Informação Selecionada"
 
-#: src/components/NanoContract/EditAddressModal.component.js:67
+#: src/components/NanoContract/EditAddressModal.js:67
 msgid "Index"
 msgstr "Índice"
 
-#: src/components/NanoContract/EditAddressModal.component.js:74
+#: src/components/NanoContract/EditAddressModal.js:74
 msgid "Confirm new address"
 msgstr "Confirmar novo endereço"
 
-#: src/components/NanoContract/EditAddressModal.component.js:78
+#: src/components/NanoContract/EditAddressModal.js:78
 msgid "Go back"
 msgstr "Voltar"
 
-#: src/components/NanoContract/NanoContractDetails.component.js:159
+#: src/components/NanoContract/NanoContractDetails.js:174
+msgid "Load More"
+msgstr "Carregar mais"
+
+#: src/components/NanoContract/NanoContractDetails.js:200
 msgid "Loading Nano Contract transactions."
 msgstr "Carregando transações do Nano Contract"
 
-#: src/components/NanoContract/NanoContractDetails.component.js:173
+#: src/components/NanoContract/NanoContractDetails.js:214
 msgid "Nano Contract Transactions Error"
 msgstr "Erro em Transações do Nano Contract"
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:146
+#: src/components/NanoContract/NanoContractDetailsHeader.js:146
 #: src/components/NanoContract/NanoContractsListItem.js:59
 msgid "Blueprint Name"
 msgstr "Nome do Blueprint"
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:150
+#: src/components/NanoContract/NanoContractDetailsHeader.js:150
 msgid "Registered Address"
 msgstr "Endereço Registrado"
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:153
+#: src/components/NanoContract/NanoContractDetailsHeader.js:153
 msgid "See status details"
 msgstr "Ver detalhes"
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:154
+#: src/components/NanoContract/NanoContractDetailsHeader.js:154
 msgid "Unregister contract"
 msgstr "Desregistrar contract"
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:96
+#: src/components/NanoContract/NanoContractTransactionHeader.js:96
 msgid "Date and Time"
 msgstr "Data & Hora"
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:103
-#: src/components/NanoContract/NanoContractTransactionsListItem.component.js:62
+#: src/components/NanoContract/NanoContractTransactionHeader.js:103
+#: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
 msgstr "Desta wallet"
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:106
+#: src/components/NanoContract/NanoContractTransactionHeader.js:106
 msgid "Caller"
 msgstr "Caller"
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:109
+#: src/components/NanoContract/NanoContractTransactionHeader.js:109
 msgid "See transaction details"
 msgstr "Ver detalhes"
 
@@ -1432,42 +1435,42 @@ msgstr "Você pode acompanhar os Nano Contracts registrados nesta tela."
 msgid "Register new"
 msgstr "Registrar novo"
 
-#: src/components/NanoContract/SelectAddressModal.component.js:90
+#: src/components/NanoContract/SelectAddressModal.js:90
 msgid "Choose New Wallet Address"
 msgstr "Escolha o Novo Endereço"
 
-#: src/components/NanoContract/SelectAddressModal.component.js:97
+#: src/components/NanoContract/SelectAddressModal.js:97
 msgid "Load Addresses Error"
 msgstr "Erro ao carregar endereços"
 
-#: src/components/NanoContract/SelectAddressModal.component.js:106
+#: src/components/NanoContract/SelectAddressModal.js:106
 msgid "Loading wallet addresses."
 msgstr "Carregando endereços da wallet."
 
-#: src/components/NanoContract/SelectAddressModal.component.js:114
+#: src/components/NanoContract/SelectAddressModal.js:114
 msgid "Current Information"
 msgstr "Informação Atual"
 
-#: src/components/NanoContract/SelectAddressModal.component.js:115
+#: src/components/NanoContract/SelectAddressModal.js:115
 msgid "To change, select other address on the list below."
 msgstr "Para alterar, selecione outro endereço da lista abaixo."
 
-#: src/components/NanoContract/SelectAddressModal.component.js:178
+#: src/components/NanoContract/SelectAddressModal.js:178
 msgid "index"
 msgstr "índice"
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:39
+#: src/components/NanoContract/UnregisterNanoContractModal.js:39
 msgid "Unregister Nano Contract"
 msgstr "Desregistrar Nano Contract"
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:41
+#: src/components/NanoContract/UnregisterNanoContractModal.js:41
 msgid "Are you sure you want to unregister this Nano Contract?"
 msgstr "Confirma que deseja desregistrar este Nano Contract?"
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:44
+#: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
 msgstr "Sim, desregistrar"
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:50
+#: src/components/NanoContract/UnregisterNanoContractModal.js:50
 msgid "No, go back"
 msgstr "Não, voltar"

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -58,11 +58,11 @@ msgid "[Last] dddd [•] HH:mm"
 msgstr "[Последний] dddd [•] HH:mm"
 
 #.  See https://momentjs.com/docs/#/displaying/calendar-time/
-#: src/models.js:107 src/utils.js:415
+#: src/models.js:107 src/utils.js:416
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr "DD MMM YYYY [•] HH:mm"
 
-#: src/utils.js:160
+#: src/utils.js:161
 msgid "Invalid address"
 msgstr "Неправильный адрес"
 
@@ -433,9 +433,9 @@ msgstr "Слова"
 msgid "Enter your seed words separated by space"
 msgstr "Введите seed-фразу"
 
-#: src/components/NanoContract/NanoContractDetails.component.js:194
+#: src/components/NanoContract/NanoContractDetails.js:235
 #: src/screens/LoadHistoryScreen.js:51 src/screens/LoadWalletErrorScreen.js:20
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:167
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:161
 msgid "Try again"
 msgstr ""
 
@@ -700,8 +700,8 @@ msgstr "Авторизовать операцию"
 msgid "Your transfer of **${ this.amountAndToken }** has been confirmed"
 msgstr "Ваш перевод **${ this.amountAndToken }** был подтвержден"
 
-#: src/components/NanoContract/EditAddressModal.component.js:60
-#: src/components/NanoContract/SelectAddressModal.component.js:117
+#: src/components/NanoContract/EditAddressModal.js:60
+#: src/components/NanoContract/SelectAddressModal.js:117
 #: src/screens/SendConfirmScreen.js:161
 msgid "Address"
 msgstr "Адрес"
@@ -936,53 +936,53 @@ msgstr ""
 msgid "Nano Contract Details"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:67
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:58
 msgid "Nano Contract ID is required."
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:157
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:151
 msgid "See contract"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:175
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:169
 msgid "Load First Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:158
-#: src/components/NanoContract/SelectAddressModal.component.js:105
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:183
+#: src/components/NanoContract/NanoContractDetails.js:199
+#: src/components/NanoContract/SelectAddressModal.js:105
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:177
 msgid "Loading"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:184
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:178
 msgid "Loading first wallet address."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:142
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:88
+#: src/components/NanoContract/NanoContractDetailsHeader.js:142
+#: src/components/NanoContract/NanoContractTransactionHeader.js:88
 #: src/components/NanoContract/NanoContractsListItem.js:57
 #: src/components/TxDetailsModal.js:106
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:193
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:187
 msgid "Nano Contract ID"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:201
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:195
 msgid "Wallet Address"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:211
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:205
 msgid "If you want to change the wallet address, you will be able to do"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:213
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:207
 msgid "after the contract is registered."
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:232
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:226
 msgid "Register Nano Contract"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:250
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:244
 msgid "Nano Contract Registration"
 msgstr ""
 
@@ -1064,21 +1064,21 @@ msgstr ""
 msgid "Open"
 msgstr "Открыть"
 
-#: src/sagas/wallet.js:744
+#: src/sagas/wallet.js:750
 msgid "Wallet is not ready to load addresses."
 msgstr ""
 
 #.  This will show the message in the feedback content at SelectAddressModal
-#: src/sagas/wallet.js:760
+#: src/sagas/wallet.js:766
 msgid "There was an error while loading wallet addresses. Try again."
 msgstr ""
 
-#: src/sagas/wallet.js:770
+#: src/sagas/wallet.js:776
 msgid "Wallet is not ready to load the first address."
 msgstr ""
 
 #.  This will show the message in the feedback content
-#: src/sagas/wallet.js:786
+#: src/sagas/wallet.js:792
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
 
@@ -1235,12 +1235,12 @@ msgstr ""
 msgid "Description"
 msgstr "Описание"
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:47
+#: src/components/NanoContract/NanoContractTransactionHeader.js:47
 #: src/components/TxDetailsModal.js:104
 msgid "Transaction ID"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:92
+#: src/components/NanoContract/NanoContractTransactionHeader.js:92
 #: src/components/TxDetailsModal.js:105
 msgid "Blueprint Method"
 msgstr ""
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "Nano Contract Status"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:79
+#: src/components/NanoContract/NanoContractDetailsHeader.js:79
 #: src/components/TxDetailsModal.js:120
 msgid "Nano Contract"
 msgstr ""
@@ -1291,79 +1291,83 @@ msgstr ""
 msgid "Custom network"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:41
+#: src/components/NanoContract/EditAddressModal.js:41
 msgid "New Nano Contract Address"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:49
+#: src/components/NanoContract/EditAddressModal.js:49
 msgid ""
 "This address signs any transaction you create with Nano Contracts method. "
 "Switching to a new one means"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:51
+#: src/components/NanoContract/EditAddressModal.js:51
 msgid "all future transactions will use this address."
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:57
+#: src/components/NanoContract/EditAddressModal.js:57
 msgid "Selected Information"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:67
+#: src/components/NanoContract/EditAddressModal.js:67
 msgid "Index"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:74
+#: src/components/NanoContract/EditAddressModal.js:74
 msgid "Confirm new address"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:78
+#: src/components/NanoContract/EditAddressModal.js:78
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:159
+#: src/components/NanoContract/NanoContractDetails.js:174
+msgid "Load More"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetails.js:200
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:173
+#: src/components/NanoContract/NanoContractDetails.js:214
 msgid "Nano Contract Transactions Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:146
+#: src/components/NanoContract/NanoContractDetailsHeader.js:146
 #: src/components/NanoContract/NanoContractsListItem.js:59
 msgid "Blueprint Name"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:150
+#: src/components/NanoContract/NanoContractDetailsHeader.js:150
 msgid "Registered Address"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:153
+#: src/components/NanoContract/NanoContractDetailsHeader.js:153
 msgid "See status details"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:154
+#: src/components/NanoContract/NanoContractDetailsHeader.js:154
 msgid "Unregister contract"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:96
+#: src/components/NanoContract/NanoContractTransactionHeader.js:96
 msgid "Date and Time"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:103
-#: src/components/NanoContract/NanoContractTransactionsListItem.component.js:62
+#: src/components/NanoContract/NanoContractTransactionHeader.js:103
+#: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 msgid "From this wallet"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:106
+#: src/components/NanoContract/NanoContractTransactionHeader.js:106
 msgid "Caller"
 msgstr ""
 
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:109
+#: src/components/NanoContract/NanoContractTransactionHeader.js:109
 msgid "See transaction details"
 msgstr ""
 
@@ -1381,42 +1385,42 @@ msgstr ""
 msgid "Register new"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:90
+#: src/components/NanoContract/SelectAddressModal.js:90
 msgid "Choose New Wallet Address"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:97
+#: src/components/NanoContract/SelectAddressModal.js:97
 msgid "Load Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:106
+#: src/components/NanoContract/SelectAddressModal.js:106
 msgid "Loading wallet addresses."
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:114
+#: src/components/NanoContract/SelectAddressModal.js:114
 msgid "Current Information"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:115
+#: src/components/NanoContract/SelectAddressModal.js:115
 msgid "To change, select other address on the list below."
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:178
+#: src/components/NanoContract/SelectAddressModal.js:178
 msgid "index"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:39
+#: src/components/NanoContract/UnregisterNanoContractModal.js:39
 msgid "Unregister Nano Contract"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:41
+#: src/components/NanoContract/UnregisterNanoContractModal.js:41
 msgid "Are you sure you want to unregister this Nano Contract?"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:44
+#: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:50
+#: src/components/NanoContract/UnregisterNanoContractModal.js:50
 msgid "No, go back"
 msgstr ""

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -48,12 +48,12 @@ msgid "[Last] dddd [•] HH:mm"
 msgstr ""
 
 #: src/models.js:107
-#: src/utils.js:415
+#: src/utils.js:416
 #.  See https://momentjs.com/docs/#/displaying/calendar-time/
 msgid "DD MMM YYYY [•] HH:mm"
 msgstr ""
 
-#: src/utils.js:160
+#: src/utils.js:161
 msgid "Invalid address"
 msgstr ""
 
@@ -421,10 +421,10 @@ msgstr ""
 msgid "Enter your seed words separated by space"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:194
+#: src/components/NanoContract/NanoContractDetails.js:235
 #: src/screens/LoadHistoryScreen.js:51
 #: src/screens/LoadWalletErrorScreen.js:20
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:167
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:161
 msgid "Try again"
 msgstr ""
 
@@ -696,8 +696,8 @@ msgstr ""
 msgid "Your transfer of **${ this.amountAndToken }** has been confirmed"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:60
-#: src/components/NanoContract/SelectAddressModal.component.js:117
+#: src/components/NanoContract/EditAddressModal.js:60
+#: src/components/NanoContract/SelectAddressModal.js:117
 #: src/screens/SendConfirmScreen.js:161
 msgid "Address"
 msgstr ""
@@ -929,53 +929,53 @@ msgstr ""
 msgid "Nano Contract Details"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:67
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:58
 msgid "Nano Contract ID is required."
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:157
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:151
 msgid "See contract"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:175
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:169
 msgid "Load First Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:158
-#: src/components/NanoContract/SelectAddressModal.component.js:105
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:183
+#: src/components/NanoContract/NanoContractDetails.js:199
+#: src/components/NanoContract/SelectAddressModal.js:105
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:177
 msgid "Loading"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:184
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:178
 msgid "Loading first wallet address."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:142
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:88
+#: src/components/NanoContract/NanoContractDetailsHeader.js:142
+#: src/components/NanoContract/NanoContractTransactionHeader.js:88
 #: src/components/NanoContract/NanoContractsListItem.js:57
 #: src/components/TxDetailsModal.js:106
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:193
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:187
 msgid "Nano Contract ID"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:201
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:195
 msgid "Wallet Address"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:211
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:205
 msgid "If you want to change the wallet address, you will be able to do"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:213
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:207
 msgid "after the contract is registered."
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:232
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:226
 msgid "Register Nano Contract"
 msgstr ""
 
-#: src/screens/NanoContract/NanoContractRegisterScreen.js:250
+#: src/screens/NanoContract/NanoContractRegisterScreen.js:244
 msgid "Nano Contract Registration"
 msgstr ""
 
@@ -1057,20 +1057,20 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: src/sagas/wallet.js:744
+#: src/sagas/wallet.js:750
 msgid "Wallet is not ready to load addresses."
 msgstr ""
 
-#: src/sagas/wallet.js:760
+#: src/sagas/wallet.js:766
 #.  This will show the message in the feedback content at SelectAddressModal
 msgid "There was an error while loading wallet addresses. Try again."
 msgstr ""
 
-#: src/sagas/wallet.js:770
+#: src/sagas/wallet.js:776
 msgid "Wallet is not ready to load the first address."
 msgstr ""
 
-#: src/sagas/wallet.js:786
+#: src/sagas/wallet.js:792
 #.  This will show the message in the feedback content
 msgid "There was an error while loading first wallet address. Try again."
 msgstr ""
@@ -1228,12 +1228,12 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:47
+#: src/components/NanoContract/NanoContractTransactionHeader.js:47
 #: src/components/TxDetailsModal.js:104
 msgid "Transaction ID"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:92
+#: src/components/NanoContract/NanoContractTransactionHeader.js:92
 #: src/components/TxDetailsModal.js:105
 msgid "Blueprint Method"
 msgstr ""
@@ -1246,7 +1246,7 @@ msgstr ""
 msgid "Nano Contract Status"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:79
+#: src/components/NanoContract/NanoContractDetailsHeader.js:79
 #: src/components/TxDetailsModal.js:120
 msgid "Nano Contract"
 msgstr ""
@@ -1284,78 +1284,82 @@ msgstr ""
 msgid "Custom network"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:41
+#: src/components/NanoContract/EditAddressModal.js:41
 msgid "New Nano Contract Address"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:49
+#: src/components/NanoContract/EditAddressModal.js:49
 msgid ""
 "This address signs any transaction you create with Nano Contracts method. "
 "Switching to a new one means"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:51
+#: src/components/NanoContract/EditAddressModal.js:51
 msgid "all future transactions will use this address."
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:57
+#: src/components/NanoContract/EditAddressModal.js:57
 msgid "Selected Information"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:67
+#: src/components/NanoContract/EditAddressModal.js:67
 msgid "Index"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:74
+#: src/components/NanoContract/EditAddressModal.js:74
 msgid "Confirm new address"
 msgstr ""
 
-#: src/components/NanoContract/EditAddressModal.component.js:78
+#: src/components/NanoContract/EditAddressModal.js:78
 msgid "Go back"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:159
+#: src/components/NanoContract/NanoContractDetails.js:174
+msgid "Load More"
+msgstr ""
+
+#: src/components/NanoContract/NanoContractDetails.js:200
 msgid "Loading Nano Contract transactions."
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetails.component.js:173
+#: src/components/NanoContract/NanoContractDetails.js:214
 msgid "Nano Contract Transactions Error"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:146
+#: src/components/NanoContract/NanoContractDetailsHeader.js:146
 #: src/components/NanoContract/NanoContractsListItem.js:59
 msgid "Blueprint Name"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:150
+#: src/components/NanoContract/NanoContractDetailsHeader.js:150
 msgid "Registered Address"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:153
+#: src/components/NanoContract/NanoContractDetailsHeader.js:153
 msgid "See status details"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractDetailsHeader.component.js:154
+#: src/components/NanoContract/NanoContractDetailsHeader.js:154
 msgid "Unregister contract"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:96
+#: src/components/NanoContract/NanoContractTransactionHeader.js:96
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 msgid "Date and Time"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:103
-#: src/components/NanoContract/NanoContractTransactionsListItem.component.js:62
+#: src/components/NanoContract/NanoContractTransactionHeader.js:103
+#: src/components/NanoContract/NanoContractTransactionsListItem.js:62
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 msgid "From this wallet"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:106
+#: src/components/NanoContract/NanoContractTransactionHeader.js:106
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 msgid "Caller"
 msgstr ""
 
-#: src/components/NanoContract/NanoContractTransactionHeader.component.js:109
+#: src/components/NanoContract/NanoContractTransactionHeader.js:109
 #.  XXX: add <ArrowUpIcon /> when shrank component can be used. 
 msgid "See transaction details"
 msgstr ""
@@ -1374,42 +1378,42 @@ msgstr ""
 msgid "Register new"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:90
+#: src/components/NanoContract/SelectAddressModal.js:90
 msgid "Choose New Wallet Address"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:97
+#: src/components/NanoContract/SelectAddressModal.js:97
 msgid "Load Addresses Error"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:106
+#: src/components/NanoContract/SelectAddressModal.js:106
 msgid "Loading wallet addresses."
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:114
+#: src/components/NanoContract/SelectAddressModal.js:114
 msgid "Current Information"
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:115
+#: src/components/NanoContract/SelectAddressModal.js:115
 msgid "To change, select other address on the list below."
 msgstr ""
 
-#: src/components/NanoContract/SelectAddressModal.component.js:178
+#: src/components/NanoContract/SelectAddressModal.js:178
 msgid "index"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:39
+#: src/components/NanoContract/UnregisterNanoContractModal.js:39
 msgid "Unregister Nano Contract"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:41
+#: src/components/NanoContract/UnregisterNanoContractModal.js:41
 msgid "Are you sure you want to unregister this Nano Contract?"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:44
+#: src/components/NanoContract/UnregisterNanoContractModal.js:44
 msgid "Yes, unregister contract"
 msgstr ""
 
-#: src/components/NanoContract/UnregisterNanoContractModal.component.js:50
+#: src/components/NanoContract/UnregisterNanoContractModal.js:50
 msgid "No, go back"
 msgstr ""

--- a/src/components/NanoContract/NanoContractDetails.js
+++ b/src/components/NanoContract/NanoContractDetails.js
@@ -23,6 +23,7 @@ import Spinner from '../Spinner';
 import errorIcon from '../../assets/images/icErrorBig.png';
 import SimpleButton from '../SimpleButton';
 import { FeedbackContent } from '../FeedbackContent';
+import NewHathorButton from '../NewHathorButton';
 
 /**
  * Retrieves Nano Contract details from Redux.
@@ -98,7 +99,7 @@ export const NanoContractDetails = ({ nc }) => {
   /**
    * Triggered when a user makes the pull gesture on the transaction history content.
    */
-  const handleNewTransactions = () => {
+  const handleNewerTransactions = () => {
     dispatch(nanoContractHistoryRequest({ ncId: nc.ncId, before: txHistory[0].txId }));
   };
 
@@ -136,11 +137,48 @@ export const NanoContractDetails = ({ nc }) => {
             )}
             keyExtractor={(item) => item.txId}
             refreshing={isLoading}
-            onRefresh={handleNewTransactions} // pull gesture
+            onRefresh={handleNewerTransactions} // pull gesture
+            ListFooterComponent={<LoadMoreButton lastTx={txHistory.slice(-1,).pop()} />}
+            extraData={[isLoading, error]}
           />
         )}
     </Wrapper>
   );
+};
+
+/**
+ * It show a button to 'Load More' transactions after the last one.
+ * It hides the button when the last transaction is the initialize.
+ *
+ * @param {Object} prop Properties object
+ * @param {{
+ *   ncId: string;
+ *   txId: string;
+ * }} prop.lastTx A transaction item from transaction history
+ */
+const LoadMoreButton = ({ lastTx }) => {
+  const dispatch = useDispatch();
+  const isInitializeTx = lastTx.ncMethod === 'initialize';
+
+  /**
+   * This handling will dispatch an action to request for
+   * older transactions after a txId.
+   */
+  const handleLoadMore = () => dispatch(nanoContractHistoryRequest({
+    ncId: lastTx.ncId,
+    after: lastTx.txId,
+  }));
+
+  return !isInitializeTx && (
+    <NewHathorButton
+      title={t`Load More`}
+      onPress={handleLoadMore}
+      discrete
+      wrapperStyle={{
+        marginTop: 16,
+      }}
+    />
+  )
 };
 
 /**


### PR DESCRIPTION
### Acceptance Criteria
- Add 'Load More' in the footer of transactions list, which triggers the request for older transactions when pressed
- Hides the 'Load More' button when the last transaction of the list is the 'initialize'

#### Loading older transactions


https://github.com/user-attachments/assets/68f99f4e-b8be-4cf2-a02f-63f1268bfa18

The video above shows a list of transactions initialized in the newest transaction only. When the button 'Load More' is pressed a list of older transactions is loaded. The button 'Load More' didn't show after load because the list has reached its end.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
