### PR TITLE
refactor: skip directly to the ChoosePinScreen

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -46,7 +46,7 @@ export const _DEFAULT_TOKEN = {
  * Whether we should skip the words confirmation screen during
  * new wallet creation
  */
-export const SKIP_SEED_CONFIRMATION = false;
+export const SKIP_SEED_CONFIRMATION = true;
 
 /**
  * App's primary color (Hathor purple)

--- a/src/config.js
+++ b/src/config.js
@@ -43,6 +43,12 @@ export const _DEFAULT_TOKEN = {
 };
 
 /**
+ * Whether we should skip the words confirmation screen during
+ * new wallet creation
+ */
+export const SKIP_SEED_CONFIRMATION = false;
+
+/**
  * App's primary color (Hathor purple)
  */
 export const _PRIMARY_COLOR = '#8C46FF';

--- a/src/screens/InitWallet.js
+++ b/src/screens/InitWallet.js
@@ -216,7 +216,7 @@ class NewWordsScreen extends React.Component {
           {renderWords()}
           <View style={this.style.buttonView}>
             <NewHathorButton
-              onPress={() => this.props.navigation.navigate('BackupWords', { words: this.state.words })}
+              onPress={() => this.props.navigation.navigate('ChoosePinScreen', { words: this.state.words })}
               title={t`Next`}
             />
           </View>

--- a/src/screens/InitWallet.js
+++ b/src/screens/InitWallet.js
@@ -32,6 +32,7 @@ import { Link, str2jsx } from '../utils';
 
 import { TERMS_OF_SERVICE_URL, PRIVACY_POLICY_URL } from '../constants';
 import { COLORS } from '../styles/themes';
+import { SKIP_SEED_CONFIRMATION } from '../config';
 
 class WelcomeScreen extends React.Component {
   state = { switchValue: false };
@@ -166,6 +167,14 @@ class NewWordsScreen extends React.Component {
     const wordsArr = this.state.words ? this.state.words.split(' ') : [];
     const wordsPerRow = 2;
 
+    const navigateToNextStep = () => {
+      const nextStep = SKIP_SEED_CONFIRMATION ? 'ChoosePinScreen' : 'BackupWords';
+
+      this.props.navigation.navigate(nextStep, {
+        words: this.state.words,
+      })
+    };
+
     const renderWords = () => {
       const data = [];
 
@@ -216,7 +225,7 @@ class NewWordsScreen extends React.Component {
           {renderWords()}
           <View style={this.style.buttonView}>
             <NewHathorButton
-              onPress={() => this.props.navigation.navigate('ChoosePinScreen', { words: this.state.words })}
+              onPress={navigateToNextStep}
               title={t`Next`}
             />
           </View>


### PR DESCRIPTION
### Acceptance Criteria
- We should skip the seed confirmation depending on a constant file in config

### Future possibilities

I think this could go to `master` (changing the default to `true`), as it is a nice option to have on whitelabel apps, but we would have to add a mechanism for display the seed after it's loaded

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
