### PR TITLE
feat: add register nano contract buttom if nc not registered on new nc transaction

### DIFF
--- a/src/components/NewHathorButton.js
+++ b/src/components/NewHathorButton.js
@@ -77,6 +77,7 @@ const style = StyleSheet.create({
     borderRadius: 8,
     backgroundColor: COLORS.textColor,
     alignSelf: 'stretch',
+    padding: 16,
   },
   wrapperDisabled: {
     backgroundColor: COLORS.textColorShadowOpacity005,

--- a/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
+++ b/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
@@ -100,8 +100,6 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
   const onAcceptTransaction = () => {
     // Update the caller with the address selected by the user.
     const acceptedNc = { ...nc, caller: ncAddress };
-    // Restore ready status to Nano Contract registration state
-    dispatch(nanoContractRegisterReady());
     // Signal the user has accepted the current request and pass the accepted data.
     dispatch(walletConnectAccept(acceptedNc));
   };
@@ -118,9 +116,6 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
   };
   const onDeclineConfirmation = () => {
     setShowDeclineModal(false);
-    // Restore ready status to Nano Contract registration state if
-    // we have had a registration while handling a new transaction request
-    dispatch(nanoContractRegisterReady());
     dispatch(walletConnectReject());
     navigation.goBack();
   };
@@ -138,6 +133,16 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
   ), [notInitialize, registeredNc]); 
   // It results in true for registered nc and initialize request
   const showRequest = !notRegistered;
+
+  // Mount: do nothing
+  useEffect(() => {
+    // Unmount
+    return () => {
+      // Restore ready status to Nano Contract registration state if
+      // we have had a registration while handling a new transaction request
+      dispatch(nanoContractRegisterReady());
+    }
+  }, []);
 
   // This effect should run at most twice:
   // 1. when in the construct phase

--- a/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
+++ b/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
@@ -141,7 +141,7 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
       // Restore ready status to Nano Contract registration state if
       // we have had a registration while handling a new transaction request
       dispatch(nanoContractRegisterReady());
-    }
+    };
   }, []);
 
   // This effect should run at most twice:

--- a/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
+++ b/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
@@ -100,6 +100,8 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
   const onAcceptTransaction = () => {
     // Update the caller with the address selected by the user.
     const acceptedNc = { ...nc, caller: ncAddress };
+    // Restore ready status to Nano Contract registration state
+    dispatch(nanoContractRegisterReady());
     // Signal the user has accepted the current request and pass the accepted data.
     dispatch(walletConnectAccept(acceptedNc));
   };


### PR DESCRIPTION
### Acceptance Criteria
- Allow the user to register the nano contract when a RPC request from a unregistered nano contract arrives

#### Transaction request for unregistered Nano Contract

https://github.com/user-attachments/assets/d5336a8f-96ba-4fcc-863f-cb068e14b3b0

It allows user to register and after it the transaction request is loaded.

#### Nano Contract registration fails during transaction handling

https://github.com/user-attachments/assets/c15742b6-b475-47e3-ba97-7026bd6754c3

It allows user only to decline the transaction and go back as a feedback action.

>[!NOTE]
>This is a good candidate to go to production.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
