### PR TITLE
feat: Bumps Android target SDK to 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         kotlin_version = "1.7.20"
         minSdkVersion = 23
         compileSdkVersion = 33
-        targetSdkVersion = 33
+        targetSdkVersion = 34
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"


### PR DESCRIPTION
### Acceptance Criteria
- The application build process should target Android SDK 34

### Notes about build environment
The application build was run on Ubuntu 22, with the following devices working successfully
- Emulator running Android 13
- Motorola G52 physical device running Android 13
- Emulator running Android 15

To ensure the build was being executed in an environment as reproducible as possible, the following cache clearing script was used:
```sh
#!/bin/bash

# Clear global android cache of NDK's
rm -rf /home/my_user/Android/Sdk/ndk/*

# Clear all builds within the project
rm -rf /home/my_user/mobile-wallet/android/.gradle
rm -rf /home/my_user/mobile-wallet/android/build
rm -rf /home/my_user/mobile-wallet/android/app/build

# Clear all leaking gradle processes
cd ~/mobile-wallet/android
./gradlew --stop
pkill -9 -f gradle
cd ~/
```

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
