### PR TITLE
refactor: sort nano contracts by last registered first

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/free-regular-svg-icons": "6.4.0",
         "@fortawesome/free-solid-svg-icons": "6.4.0",
         "@fortawesome/react-native-fontawesome": "0.2.7",
-        "@hathor/hathor-rpc-handler": "^0.0.2-experimental-alpha",
+        "@hathor/hathor-rpc-handler": "0.0.2-experimental-alpha",
         "@hathor/unleash-client": "0.1.0",
         "@hathor/wallet-lib": "1.10.0",
         "@json-rpc-tools/utils": "^1.7.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/free-regular-svg-icons": "6.4.0",
         "@fortawesome/free-solid-svg-icons": "6.4.0",
         "@fortawesome/react-native-fontawesome": "0.2.7",
-        "@hathor/hathor-rpc-handler": "^0.0.1-experimental-alpha",
+        "@hathor/hathor-rpc-handler": "^0.0.2-experimental-alpha",
         "@hathor/unleash-client": "0.1.0",
         "@hathor/wallet-lib": "1.10.0",
         "@json-rpc-tools/utils": "^1.7.6",
@@ -2754,9 +2754,10 @@
       }
     },
     "node_modules/@hathor/hathor-rpc-handler": {
-      "version": "0.0.1-experimental-alpha",
-      "resolved": "https://registry.npmjs.org/@hathor/hathor-rpc-handler/-/hathor-rpc-handler-0.0.1-experimental-alpha.tgz",
-      "integrity": "sha512-/8zz7HUFYOYd1k0ZIyJMyNBB1mdhZ0VoU09yAVkYFtJFJlScCPD8gNvlWmtjC8CdBnQAAk7ozKW4k0UbYd6/zQ==",
+      "version": "0.0.2-experimental-alpha",
+      "resolved": "https://registry.npmjs.org/@hathor/hathor-rpc-handler/-/hathor-rpc-handler-0.0.2-experimental-alpha.tgz",
+      "integrity": "sha512-DLFokiS3E+O8kdbrL6vfnueIbB9+2bpvMPLKb7N/YVZOuJJ5clSsjmPa+JxxpnZjI+Z0SFGJf9zEBYgqMP/h4g==",
+      "license": "MIT",
       "dependencies": {
         "@hathor/wallet-lib": "1.8.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@fortawesome/free-regular-svg-icons": "6.4.0",
     "@fortawesome/free-solid-svg-icons": "6.4.0",
     "@fortawesome/react-native-fontawesome": "0.2.7",
-    "@hathor/hathor-rpc-handler": "^0.0.1-experimental-alpha",
+    "@hathor/hathor-rpc-handler": "^0.0.2-experimental-alpha",
     "@hathor/unleash-client": "0.1.0",
     "@hathor/wallet-lib": "1.10.0",
     "@json-rpc-tools/utils": "^1.7.6",

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1601,20 +1601,20 @@ export const onNanoContractRegisterSuccess = (state, { payload }) => ({
       ? NANOCONTRACT_REGISTER_STATUS.SUCCESSFUL
       : NANOCONTRACT_REGISTER_STATUS.READY,
     registered: {
-      ...state.nanoContract.registered,
       [payload.entryKey]: payload.entryValue,
+      ...state.nanoContract.registered,
     },
     history: {
-      ...state.nanoContract.history,
       [payload.entryKey]: [],
+      ...state.nanoContract.history,
     },
     historyMeta: {
-      ...state.nanoContract.historyMeta,
       [payload.entryKey]: {
         isLoading: false,
         error: null,
         after: null,
       },
+      ...state.nanoContract.historyMeta,
     },
   },
 });


### PR DESCRIPTION
### Motivation

An order from newest to oldest improves user experience.

### Acceptance Criteria
- Sort nano contracts by last registered first
- Upgrade hathor-rpc-handler lib to 0.0.2-experimental-alpha

#### Register a Nano Contract
The new registered Nano Contract is presented first in the list:

https://github.com/user-attachments/assets/1750cb75-79ef-4057-a52a-a5de08d8f2a0


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
