### PR TITLE
feat: make requestUnregisteredTokens concurrent

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -188,8 +188,13 @@ export const types = {
   FIRSTADDRESS_FAILURE: 'FIRSTADDRESS_FAILURE',
   /* It updates the redux state of new nano contract transaction status on wallet connect register. */
   WALLETCONNECT_NEW_NANOCONTRACT_STATUS: 'WALLETCONNECT_NEW_NANOCONTRACT_STATUS',
+  /* It triggers a process to fetch token details for a list of unregistered tokens. */
   UNREGISTEREDTOKENS_REQUEST: 'UNREGISTEREDTOKENS_REQUEST',
-  UNREGISTEREDTOKENS_UPDATE: 'UNREGISTEREDTOKENS_UPDATE',
+  /* It signals the process has loaded at least one token details with success. */
+  UNREGISTEREDTOKENS_SUCCESS: 'UNREGISTEREDTOKENS_SUCCESS',
+  /* It signals the process has failed to load at least one token details. */
+  UNREGISTEREDTOKENS_FAILURE: 'UNREGISTEREDTOKENS_FAILURE',
+  /* It signals the end of the process. */
   UNREGISTEREDTOKENS_END: 'UNREGISTEREDTOKENS_END',
   WALLETCONNECT_NEW_NANOCONTRACT_RETRY: 'WALLETCONNECT_NEW_NANOCONTRACT_RETRY',
   WALLETCONNECT_NEW_NANOCONTRACT_RETRY_DISMISS: 'WALLETCONNECT_NEW_NANOCONTRACT_RETRY_DISMISS',
@@ -1401,15 +1406,25 @@ export const unregisteredTokensRequest = (payload) => ({
 });
 
 /**
- * Signals an update to unregistered tokens state.
+ * Signals the success of unregistered tokens request.
  * @param {Object} payload
  * @param {Object} payload.tokens A map of token data by its UID.
- * @param {string} payload.error The error message as feedback to user
  */
-export const unregisteredTokensUpdate = (payload) => ({
-  type: types.UNREGISTEREDTOKENS_UPDATE,
+export const unregisteredTokensSuccess = (payload) => ({
+  type: types.UNREGISTEREDTOKENS_SUCCESS,
   payload,
 });
+
+/**
+ * Signals a failure on unregistered tokens request.
+ * @param {Object} payload
+ * @param {string} payload.error The error message as feedback to user
+ */
+export const unregisteredTokensFailure = (payload) => ({
+  type: types.UNREGISTEREDTOKENS_FAILURE,
+  payload,
+});
+
 
 /**
  * Signals the unregistered tokens request has ended.

--- a/src/actions.js
+++ b/src/actions.js
@@ -1425,7 +1425,6 @@ export const unregisteredTokensFailure = (payload) => ({
   payload,
 });
 
-
 /**
  * Signals the unregistered tokens request has ended.
  */

--- a/src/actions.js
+++ b/src/actions.js
@@ -190,6 +190,7 @@ export const types = {
   WALLETCONNECT_NEW_NANOCONTRACT_STATUS: 'WALLETCONNECT_NEW_NANOCONTRACT_STATUS',
   UNREGISTEREDTOKENS_REQUEST: 'UNREGISTEREDTOKENS_REQUEST',
   UNREGISTEREDTOKENS_UPDATE: 'UNREGISTEREDTOKENS_UPDATE',
+  UNREGISTEREDTOKENS_END: 'UNREGISTEREDTOKENS_END',
   WALLETCONNECT_NEW_NANOCONTRACT_RETRY: 'WALLETCONNECT_NEW_NANOCONTRACT_RETRY',
   WALLETCONNECT_NEW_NANOCONTRACT_RETRY_DISMISS: 'WALLETCONNECT_NEW_NANOCONTRACT_RETRY_DISMISS',
   SHOW_SIGN_MESSAGE_REQUEST_MODAL: 'SHOW_SIGN_MESSAGE_REQUEST_MODAL',
@@ -1408,6 +1409,13 @@ export const unregisteredTokensRequest = (payload) => ({
 export const unregisteredTokensUpdate = (payload) => ({
   type: types.UNREGISTEREDTOKENS_UPDATE,
   payload,
+});
+
+/**
+ * Signals the unregistered tokens request has ended.
+ */
+export const unregisteredTokensEnd = () => ({
+  type: types.UNREGISTEREDTOKENS_END,
 });
 
 export const showSignMessageWithAddressModal = (accept, deny, data, dapp) => ({

--- a/src/actions.js
+++ b/src/actions.js
@@ -189,13 +189,13 @@ export const types = {
   /* It updates the redux state of new nano contract transaction status on wallet connect register. */
   WALLETCONNECT_NEW_NANOCONTRACT_STATUS: 'WALLETCONNECT_NEW_NANOCONTRACT_STATUS',
   /* It triggers a process to fetch token details for a list of unregistered tokens. */
-  UNREGISTEREDTOKENS_REQUEST: 'UNREGISTEREDTOKENS_REQUEST',
+  UNREGISTEREDTOKENS_DOWNLOAD_REQUEST: 'UNREGISTEREDTOKENS_DOWNLOAD_REQUEST',
   /* It signals the process has loaded at least one token details with success. */
-  UNREGISTEREDTOKENS_SUCCESS: 'UNREGISTEREDTOKENS_SUCCESS',
+  UNREGISTEREDTOKENS_DOWNLOAD_SUCCESS: 'UNREGISTEREDTOKENS_DOWNLOAD_SUCCESS',
   /* It signals the process has failed to load at least one token details. */
-  UNREGISTEREDTOKENS_FAILURE: 'UNREGISTEREDTOKENS_FAILURE',
+  UNREGISTEREDTOKENS_DOWNLOAD_FAILURE: 'UNREGISTEREDTOKENS_DOWNLOAD_FAILURE',
   /* It signals the end of the process. */
-  UNREGISTEREDTOKENS_END: 'UNREGISTEREDTOKENS_END',
+  UNREGISTEREDTOKENS_DOWNLOAD_END: 'UNREGISTEREDTOKENS_DOWNLOAD_END',
   WALLETCONNECT_NEW_NANOCONTRACT_RETRY: 'WALLETCONNECT_NEW_NANOCONTRACT_RETRY',
   WALLETCONNECT_NEW_NANOCONTRACT_RETRY_DISMISS: 'WALLETCONNECT_NEW_NANOCONTRACT_RETRY_DISMISS',
   SHOW_SIGN_MESSAGE_REQUEST_MODAL: 'SHOW_SIGN_MESSAGE_REQUEST_MODAL',
@@ -1400,8 +1400,8 @@ export const nanoContractBlueprintInfoSuccess = (id, blueprintInfo) => ({
  * @param {Object} payload
  * @param {string[]} payload.uids A list of token UID.
  */
-export const unregisteredTokensRequest = (payload) => ({
-  type: types.UNREGISTEREDTOKENS_REQUEST,
+export const unregisteredTokensDownloadRequest = (payload) => ({
+  type: types.UNREGISTEREDTOKENS_DOWNLOAD_REQUEST,
   payload,
 });
 
@@ -1410,8 +1410,8 @@ export const unregisteredTokensRequest = (payload) => ({
  * @param {Object} payload
  * @param {Object} payload.tokens A map of token data by its UID.
  */
-export const unregisteredTokensSuccess = (payload) => ({
-  type: types.UNREGISTEREDTOKENS_SUCCESS,
+export const unregisteredTokensDownloadSuccess = (payload) => ({
+  type: types.UNREGISTEREDTOKENS_DOWNLOAD_SUCCESS,
   payload,
 });
 
@@ -1420,16 +1420,16 @@ export const unregisteredTokensSuccess = (payload) => ({
  * @param {Object} payload
  * @param {string} payload.error The error message as feedback to user
  */
-export const unregisteredTokensFailure = (payload) => ({
-  type: types.UNREGISTEREDTOKENS_FAILURE,
+export const unregisteredTokensDownloadFailure = (payload) => ({
+  type: types.UNREGISTEREDTOKENS_DOWNLOAD_FAILURE,
   payload,
 });
 
 /**
  * Signals the unregistered tokens request has ended.
  */
-export const unregisteredTokensEnd = () => ({
-  type: types.UNREGISTEREDTOKENS_END,
+export const unregisteredTokensDownloadEnd = () => ({
+  type: types.UNREGISTEREDTOKENS_DOWNLOAD_END,
 });
 
 export const showSignMessageWithAddressModal = (accept, deny, data, dapp) => ({

--- a/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
+++ b/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
@@ -27,7 +27,7 @@ import {
   setNewNanoContractStatusReady,
   walletConnectAccept,
   walletConnectReject,
-  unregisteredTokensRequest
+  unregisteredTokensDownloadRequest
 } from '../../../actions';
 import { COLORS } from '../../../styles/themes';
 import NewHathorButton from '../../NewHathorButton';
@@ -152,7 +152,7 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
         unknownTokensUid.push(uid);
       }
     });
-    dispatch(unregisteredTokensRequest({ uids: unknownTokensUid }));
+    dispatch(unregisteredTokensDownloadRequest({ uids: unknownTokensUid }));
 
     return () => {
       dispatch(setNewNanoContractStatusReady());

--- a/src/constants.js
+++ b/src/constants.js
@@ -299,7 +299,7 @@ export const NANO_CONTRACT_ACTION = {
   deposit: 'deposit',
 };
 
-export const NODE_RATE_LIMIT_CONF  = {
+export const NODE_RATE_LIMIT_CONF = {
   thin_wallet_token: {
     perSecond: 3,
     burst: 10,

--- a/src/constants.js
+++ b/src/constants.js
@@ -298,3 +298,11 @@ export const NANO_CONTRACT_ACTION = {
   withdrawal: 'withdrawal',
   deposit: 'deposit',
 };
+
+export const NODE_RATE_LIMIT_CONF  = {
+  thin_wallet_token: {
+    perSecond: 3,
+    burst: 10,
+    delay: 3,
+  }
+};

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -703,14 +703,14 @@ export const reducer = (state = initialState, action) => {
       return onNanoContractBlueprintInfoFailure(state, action);
     case types.NANOCONTRACT_BLUEPRINTINFO_SUCCESS:
       return onNanoContractBlueprintInfoSuccess(state, action);
-    case types.UNREGISTEREDTOKENS_REQUEST:
-      return onUnregisteredTokensRequest(state);
-    case types.UNREGISTEREDTOKENS_SUCCESS:
-      return onUnregisteredTokensSuccess(state, action);
-    case types.UNREGISTEREDTOKENS_FAILURE:
-      return onUnregisteredTokensFailure(state, action);
-    case types.UNREGISTEREDTOKENS_END:
-      return onUnregisteredTokensEnd(state);
+    case types.UNREGISTEREDTOKENS_DOWNLOAD_REQUEST:
+      return onUnregisteredTokensDownloadRequest(state);
+    case types.UNREGISTEREDTOKENS_DOWNLOAD_SUCCESS:
+      return onUnregisteredTokensDownloadSuccess(state, action);
+    case types.UNREGISTEREDTOKENS_DOWNLOAD_FAILURE:
+      return onUnregisteredTokensDownloadFailure(state, action);
+    case types.UNREGISTEREDTOKENS_DOWNLOAD_END:
+      return onUnregisteredTokensDownloadEnd(state);
     case types.WALLETCONNECT_NEW_NANOCONTRACT_RETRY:
       return onNewNanoContractTransactionRetry(state);
     case types.WALLETCONNECT_NEW_NANOCONTRACT_RETRY_DISMISS:
@@ -2061,7 +2061,7 @@ export const onNanoContractBlueprintInfoSuccess = (state, { payload }) => ({
  * Remarks
  * This reducer aims to clean error feedback message before processing the request.
  */
-export const onUnregisteredTokensRequest = (state) => ({
+export const onUnregisteredTokensDownloadRequest = (state) => ({
   ...state,
   unregisteredTokens: {
     ...state.unregisteredTokens,
@@ -2078,7 +2078,7 @@ export const onUnregisteredTokensRequest = (state) => ({
  * @param {Object} action.payload
  * @param {string} action.payload.error The error message as feedback to user
  */
-export const onUnregisteredTokensSuccess = (state, { payload }) => ({
+export const onUnregisteredTokensDownloadSuccess = (state, { payload }) => ({
   ...state,
   unregisteredTokens: {
     ...state.unregisteredTokens,
@@ -2094,7 +2094,7 @@ export const onUnregisteredTokensSuccess = (state, { payload }) => ({
  * @param {Object} action.payload
  * @param {string} action.payload.error The error message as feedback to user
  */
-export const onUnregisteredTokensFailure = (state, { payload }) => ({
+export const onUnregisteredTokensDownloadFailure = (state, { payload }) => ({
   ...state,
   unregisteredTokens: {
     ...state.unregisteredTokens,
@@ -2107,7 +2107,7 @@ export const onUnregisteredTokensFailure = (state, { payload }) => ({
  *
  * @param {Object} state
  */
-export const onUnregisteredTokensEnd = (state) => ({
+export const onUnregisteredTokensDownloadEnd = (state) => ({
   ...state,
   unregisteredTokens: {
     ...state.unregisteredTokens,

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -705,8 +705,12 @@ export const reducer = (state = initialState, action) => {
       return onNanoContractBlueprintInfoSuccess(state, action);
     case types.UNREGISTEREDTOKENS_REQUEST:
       return onUnregisteredTokensRequest(state);
-    case types.UNREGISTEREDTOKENS_UPDATE:
-      return onUnregisteredTokensUpdate(state, action);
+    case types.UNREGISTEREDTOKENS_SUCCESS:
+      return onUnregisteredTokensSuccess(state, action);
+    case types.UNREGISTEREDTOKENS_FAILURE:
+      return onUnregisteredTokensFailure(state, action);
+    case types.UNREGISTEREDTOKENS_END:
+      return onUnregisteredTokensEnd(state);
     case types.WALLETCONNECT_NEW_NANOCONTRACT_RETRY:
       return onNewNanoContractTransactionRetry(state);
     case types.WALLETCONNECT_NEW_NANOCONTRACT_RETRY_DISMISS:
@@ -2067,21 +2071,46 @@ export const onUnregisteredTokensRequest = (state) => ({
 });
 
 /**
- * Update walletConnect.tokens with some tokens data needed to feed UI components
- * without the need to register them, also update an error feedback message if present.
+ * Update tokens state as the request was successful.
  *
  * @param {Object} state
  * @param {Object} action
  * @param {Object} action.payload
- * @param {Object} action.payload.tokens A map of token data by its UID.
  * @param {string} action.payload.error The error message as feedback to user
  */
-export const onUnregisteredTokensUpdate = (state, { payload }) => ({
+export const onUnregisteredTokensSuccess = (state, { payload }) => ({
   ...state,
   unregisteredTokens: {
     ...state.unregisteredTokens,
     ...payload.tokens,
-    isLoading: false,
+  },
+});
+
+/**
+ * Set error message as a user feedback.
+ *
+ * @param {Object} state
+ * @param {Object} action
+ * @param {Object} action.payload
+ * @param {string} action.payload.error The error message as feedback to user
+ */
+export const onUnregisteredTokensFailure = (state, { payload }) => ({
+  ...state,
+  unregisteredTokens: {
+    ...state.unregisteredTokens,
     error: payload.error || null,
   },
-})
+});
+
+/**
+ * Change state of isLoading to false while keeping tokens state.
+ *
+ * @param {Object} state
+ */
+export const onUnregisteredTokensEnd = (state) => ({
+  ...state,
+  unregisteredTokens: {
+    ...state.unregisteredTokens,
+    isLoading: false,
+  },
+});

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -32,6 +32,7 @@ import {
   tokenFetchHistoryFailed,
   onExceptionCaptured,
   unregisteredTokensUpdate,
+  unregisteredTokensEnd,
 } from '../actions';
 import { logger } from '../logger';
 import { NODE_RATE_LIMIT_CONF } from '../constants';
@@ -333,8 +334,8 @@ export function* requestUnregisteredTokens(action) {
   const { uids } = action.payload;
 
   if (uids.length === 0) {
-    // Do nothing.
     log.debug('No uids to request token details.');
+    yield put(unregisteredTokensEnd());
     return;
   }
 
@@ -364,6 +365,7 @@ export function* requestUnregisteredTokens(action) {
     yield delay(burstDelay * 1000);
   }
   log.log('Success getting tokens data to feed unregisteredTokens.');
+  yield put(unregisteredTokensEnd());
 }
 
 export function* saga() {

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -364,7 +364,7 @@ export function* requestUnregisteredTokensDownload(action) {
     yield join(tasks);
     // Skip delay if there is only one group or is the last group
     if (uidGroups.length === 1 || group === uidGroups.at(-1)) {
-      break;
+      continue;
     }
     // This is a quick request, we should give a break before next burst
     yield delay(burstDelay * 1000);

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -310,7 +310,7 @@ export function* fetchTokenData(tokenId, force = false) {
 export function* getTokenDetails(wallet, uid) {
   try {
     const { tokenInfo: { symbol, name } } = yield call([wallet, wallet.getTokenDetails], uid);
-    yield put(unregisteredTokensUpdate({ tokens: {[uid]: { uid, symbol, name }} }));
+    yield put(unregisteredTokensUpdate({ tokens: { [uid]: { uid, symbol, name } } }));
   } catch (e) {
     log.error(`Fail getting token data for token ${uid}.`, e);
     yield put(unregisteredTokensUpdate({ error: failureMessage.someTokensNotLoaded }));
@@ -355,12 +355,12 @@ export function* requestUnregisteredTokens(action) {
   // These are the default values configured in the nginx conf public nodes.
   const perBurst = NODE_RATE_LIMIT_CONF.thin_wallet_token.burst;
   const burstDelay = NODE_RATE_LIMIT_CONF.thin_wallet_token.delay;
-  const uidGroups = splitInGroups(uids, perBurst); 
+  const uidGroups = splitInGroups(uids, perBurst);
   for (const group of uidGroups) {
     // Fork is a non-blocking effect, it doesn't cause the caller suspension.
     const tasks = yield all(group.map((uid) => fork(getTokenDetails, wallet, uid)));
     // Awaits a group to finish before burst the next group
-    yield join(tasks); 
+    yield join(tasks);
     // Skip delay if there is only one group or is the last group
     if (uidGroups.length === 1 || group === uidGroups.at(-1)) {
       break;

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -31,8 +31,9 @@ import {
   tokenFetchHistorySuccess,
   tokenFetchHistoryFailed,
   onExceptionCaptured,
-  unregisteredTokensUpdate,
+  unregisteredTokensSuccess,
   unregisteredTokensEnd,
+  unregisteredTokensFailure,
 } from '../actions';
 import { logger } from '../logger';
 import { NODE_RATE_LIMIT_CONF } from '../constants';
@@ -310,10 +311,10 @@ export function* fetchTokenData(tokenId, force = false) {
 export function* getTokenDetails(wallet, uid) {
   try {
     const { tokenInfo: { symbol, name } } = yield call([wallet, wallet.getTokenDetails], uid);
-    yield put(unregisteredTokensUpdate({ tokens: { [uid]: { uid, symbol, name } } }));
+    yield put(unregisteredTokensSuccess({ tokens: { [uid]: { uid, symbol, name } } }));
   } catch (e) {
     log.error(`Fail getting token data for token ${uid}.`, e);
-    yield put(unregisteredTokensUpdate({ error: failureMessage.someTokensNotLoaded }));
+    yield put(unregisteredTokensFailure({ error: failureMessage.someTokensNotLoaded }));
   }
 }
 

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -31,9 +31,9 @@ import {
   tokenFetchHistorySuccess,
   tokenFetchHistoryFailed,
   onExceptionCaptured,
-  unregisteredTokensSuccess,
-  unregisteredTokensEnd,
-  unregisteredTokensFailure,
+  unregisteredTokensDownloadSuccess,
+  unregisteredTokensDownloadEnd,
+  unregisteredTokensDownloadFailure,
 } from '../actions';
 import { logger } from '../logger';
 import { NODE_RATE_LIMIT_CONF } from '../constants';
@@ -311,10 +311,10 @@ export function* fetchTokenData(tokenId, force = false) {
 export function* getTokenDetails(wallet, uid) {
   try {
     const { tokenInfo: { symbol, name } } = yield call([wallet, wallet.getTokenDetails], uid);
-    yield put(unregisteredTokensSuccess({ tokens: { [uid]: { uid, symbol, name } } }));
+    yield put(unregisteredTokensDownloadSuccess({ tokens: { [uid]: { uid, symbol, name } } }));
   } catch (e) {
     log.error(`Fail getting token data for token ${uid}.`, e);
-    yield put(unregisteredTokensFailure({ error: failureMessage.someTokensNotLoaded }));
+    yield put(unregisteredTokensDownloadFailure({ error: failureMessage.someTokensNotLoaded }));
   }
 }
 
@@ -331,12 +331,12 @@ export function* getTokenDetails(wallet, uid) {
  * @param {Object} action.payload
  * @param {string[]} action.payload.uids
  */
-export function* requestUnregisteredTokens(action) {
+export function* requestUnregisteredTokensDownload(action) {
   const { uids } = action.payload;
 
   if (uids.length === 0) {
     log.debug('No uids to request token details.');
-    yield put(unregisteredTokensEnd());
+    yield put(unregisteredTokensDownloadEnd());
     return;
   }
 
@@ -370,7 +370,7 @@ export function* requestUnregisteredTokens(action) {
     yield delay(burstDelay * 1000);
   }
   log.log('Success getting tokens data to feed unregisteredTokens.');
-  yield put(unregisteredTokensEnd());
+  yield put(unregisteredTokensDownloadEnd());
 }
 
 export function* saga() {
@@ -380,6 +380,6 @@ export function* saga() {
     takeEvery(types.TOKEN_FETCH_HISTORY_REQUESTED, fetchTokenHistory),
     takeEvery(types.NEW_TOKEN, routeTokenChange),
     takeEvery(types.SET_TOKENS, routeTokenChange),
-    takeEvery(types.UNREGISTEREDTOKENS_REQUEST, requestUnregisteredTokens),
+    takeEvery(types.UNREGISTEREDTOKENS_DOWNLOAD_REQUEST, requestUnregisteredTokensDownload),
   ]);
 }

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -361,6 +361,10 @@ export function* requestUnregisteredTokens(action) {
     const tasks = yield all(group.map((uid) => fork(getTokenDetails, wallet, uid)));
     // Awaits a group to finish before burst the next group
     yield join(tasks); 
+    // Skip delay if there is only one group or is the last group
+    if (uidGroups.length === 1 || group === uidGroups.at(-1)) {
+      break;
+    }
     // This is a quick request, we should give a break before next burst
     yield delay(burstDelay * 1000);
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -543,7 +543,7 @@ export const parseScriptData = (scriptData, network) => {
 export function splitInGroups(list, groupSize) {
   if (groupSize === 0) {
     return list;
-  };
+  }
 
   const groups = [];
   for (let i = 0; i < list.length; i += groupSize) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -527,3 +527,27 @@ export const parseScriptData = (scriptData, network) => {
     return null;
   }
 }
+
+/**
+ * Split a list in a list of groups defined by group size.
+ *
+ * @param {[]} list An array object.
+ * @param {number} groupSize The size of a group, which determines the final number of groups.
+ *
+ * @returns {[][]} Returns an array of grouped itens in array.
+ *
+ * @example
+ * splitInGroups(['a','b'], 1);
+ * // outputs: [['a'], ['b']]
+ */
+export function splitInGroups(list, groupSize) {
+  if (groupSize === 0) {
+    return list;
+  };
+
+  const groups = [];
+  for (let i = 0; i < list.length; i += groupSize) {
+    groups.push(list.slice(i, i + groupSize));
+  }
+  return groups;
+}


### PR DESCRIPTION
### Motivation

The user needs the data as quick as possible in a new nano contract request. To achieve this requirement we can make the http request concurrent, however we should respect the rate-limit rules set in public node endpoints.

### Acceptance Criteria
- Make requestUnregisteredTokens to call token details in "parallel"
- Add an action to end the request unregistered tokens process
- Add an utility function to split a list in groups

### Future possibility

We can implement a client object that implements a more sophisticated limit-rate strategy that adapts to back pressure from server. This control is interesting to pursuit in order to better rationalize the resources at app disposal and at the same time helps the server to heal in case of spike usage.

>[!NOTE]
>It closes https://github.com/HathorNetwork/hathor-wallet-mobile/issues/531.

>[!WARNING]
>To work properly it depends on the fix on promise leak, see https://github.com/HathorNetwork/hathor-wallet-lib/pull/772.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
