### PR TITLE
fix: empty caller after define first address

### DIFF
--- a/src/components/WalletConnect/NanoContract/NanoContractExecInfo.js
+++ b/src/components/WalletConnect/NanoContract/NanoContractExecInfo.js
@@ -102,6 +102,9 @@ export const NanoContractExecInfo = ({ nc, onSelectAddress }) => {
           {blueprintName && (
             <FrozenTextValue>{blueprintName}</FrozenTextValue>
           )}
+          {isBlueprintInfoLoading && (
+            <WarnTextValue>{t`Loading...`}</WarnTextValue>
+          )}
           {hasBlueprintInfoFailed && (
             <WarnTextValue>{blueprintInfo.error}</WarnTextValue>
           )}

--- a/src/components/WalletConnect/NanoContract/NanoContractExecInfo.js
+++ b/src/components/WalletConnect/NanoContract/NanoContractExecInfo.js
@@ -67,8 +67,7 @@ export const NanoContractExecInfo = ({ nc, onSelectAddress }) => {
                                  && blueprintInfo?.status === STATUS.FAILED;
 
   const hasCaller = nc.caller != null;
-  const hasFirstAddressFailed = !hasCaller && firstAddress.error;
-  const isFirstAddressLoading = !hasCaller && !hasFirstAddressFailed;
+  const hasFirstAddressFailed = !hasCaller || firstAddress.error;
 
   return (
     <View style={[commonStyles.card, commonStyles.cardSplit]}>
@@ -103,9 +102,6 @@ export const NanoContractExecInfo = ({ nc, onSelectAddress }) => {
           {blueprintName && (
             <FrozenTextValue>{blueprintName}</FrozenTextValue>
           )}
-          {isBlueprintInfoLoading && (
-            <WarnTextValue>{t`Loading...`}</WarnTextValue>
-          )}
           {hasBlueprintInfoFailed && (
             <WarnTextValue>{blueprintInfo.error}</WarnTextValue>
           )}
@@ -120,11 +116,6 @@ export const NanoContractExecInfo = ({ nc, onSelectAddress }) => {
             <View style={styles.contentEditableValue}>
               <TextValue label>
                 {t`Caller`}
-                {isFirstAddressLoading && (
-                  <WarnTextValue>
-                    {' '}<Spinner size={14} />
-                  </WarnTextValue>
-                )}
                 {(hasFirstAddressFailed) && (
                   <WarnTextValue>
                     {' '}<CircleError size={14} />
@@ -133,9 +124,6 @@ export const NanoContractExecInfo = ({ nc, onSelectAddress }) => {
               </TextValue>
               {hasCaller && (
                 <FrozenTextValue>{nc.caller || firstAddress.address}</FrozenTextValue>
-              )}
-              {isFirstAddressLoading && (
-                <WarnTextValue>{t`Loading...`}</WarnTextValue>
               )}
               {hasFirstAddressFailed && (
                 <WarnTextValue>{t`Couldn't determine address, select one`}</WarnTextValue>

--- a/src/components/WalletConnect/NanoContract/NanoContractExecInfo.js
+++ b/src/components/WalletConnect/NanoContract/NanoContractExecInfo.js
@@ -67,10 +67,8 @@ export const NanoContractExecInfo = ({ nc, onSelectAddress }) => {
                                  && blueprintInfo?.status === STATUS.FAILED;
 
   const hasCaller = nc.caller != null;
-  const hasFirstAddressFailed = !hasCaller && isInitialize && firstAddress.error;
-  const isFirstAddressLoading = !hasCaller
-                                && isInitialize
-                                && !hasFirstAddressFailed;
+  const hasFirstAddressFailed = !hasCaller && firstAddress.error;
+  const isFirstAddressLoading = !hasCaller && !hasFirstAddressFailed;
 
   return (
     <View style={[commonStyles.card, commonStyles.cardSplit]}>

--- a/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
+++ b/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
@@ -174,6 +174,13 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
     };
   }, []);
 
+  // When nano contract is registered it should set the caller address
+  useEffect(() => {
+    if (!ncAddress && registeredNc?.address) {
+      setNcAddress(registeredNc.address);
+    }
+  }, [registeredNc])
+
   // This effect should run at most twice:
   // 1. when in the construct phase
   // 2. after firstAddress is set on store after a request to load it
@@ -181,7 +188,7 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
   // it is requested from a child component, NanoContractExecInfo.
   useEffect(() => {
     // When initialize it doesn't have a registered address
-    if (firstAddress.address && !registeredNc?.address) {
+    if (!ncAddress && firstAddress.address) {
       setNcAddress(firstAddress.address);
     }
 

--- a/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
+++ b/src/components/WalletConnect/NanoContract/NewNanoContractTransactionRequest.js
@@ -180,7 +180,8 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
   // The mentioned load request at (2) can happen for 'initialize' transaction,
   // it is requested from a child component, NanoContractExecInfo.
   useEffect(() => {
-    if (ncToAccept.method === 'initialize' && firstAddress.address) {
+    // When initialize it doesn't have a registered address
+    if (firstAddress.address && !registeredNc?.address) {
       setNcAddress(firstAddress.address);
     }
 


### PR DESCRIPTION
### Acceptance Criteria
- Fix empty caller after register nano contract
- Fix empty caller after define first address while nano contract is not registered
- Remove dependency on `initialize` call on `NanoContractExecInfo` component
- Shows caller address not determined feedback asking user to select one when caller address is empty or first address request fails

#### Initialize working

https://github.com/user-attachments/assets/8e9798ec-ba48-47f0-bfb0-e3599ea4c13a

#### Not registered nano bet working

https://github.com/user-attachments/assets/ee0d971b-8b1d-4687-b839-ae7a59b7a12b

#### Caller empty or first address request failed

The following screenshot simulates the caller empty, it is very unlikely to happen now.

<img src="https://github.com/user-attachments/assets/b3974dca-b41e-4945-b2a9-5ef379edbb43" height="600" />


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
