### PR TITLE
refactor: fetchHistory on sagas/nanoContract to avoid iteration suspension

### DIFF
--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -37,7 +37,7 @@ import {
 } from '../actions';
 import { logger } from '../logger';
 import { NANO_CONTRACT_TX_HISTORY_SIZE } from '../constants';
-import { getNanoContractFeatureToggle, isAddressMine } from '../utils';
+import { getNanoContractFeatureToggle } from '../utils';
 
 const log = logger('nano-contract-saga');
 
@@ -52,6 +52,25 @@ export const failureMessage = {
   blueprintInfoFailure: t`Couldn't get Blueprint info.`,
   notRegistered: t`Nano Contract not registered.`,
   nanoContractHistoryFailure: t`Error while trying to download Nano Contract transactions history.`,
+};
+
+/**
+ * Call the async wallet method `isAddressMine` considering the type of wallet.
+ *
+ * @param {Object} wallet A wallet instance
+ * @param {string} address A wallet address to check
+ * @param {boolean} useWalletService A flag that determines if wallet service is in use
+ */
+export const isAddressMine = async (wallet, address, useWalletService) => {
+  // XXX: Wallet Service doesn't implement isAddressMine.
+  // See issue: https://github.com/HathorNetwork/hathor-wallet-lib/issues/732
+  // Default to `false` if using Wallet Service.
+  if (useWalletService) {
+    return false;
+  }
+
+  const isMine = await wallet.isAddressMine(address);
+  return isMine;
 };
 
 export function* init() {

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -251,7 +251,7 @@ export async function fetchHistory(req) {
   const network = wallet.getNetworkObject();
   // Translate rawNcTxHistory to NcTxHistory
   // Prouce a list ordered from newest to oldest
-  const historyTransformer = rawHistory.map(async (rawTx) => {
+  const transformedTxHistory = rawHistory.map(async (rawTx) => {
     const caller = addressUtils.getAddressFromPubkey(rawTx.nc_pubkey, network).base58;
     const actions = rawTx.nc_context.actions.map((each) => ({
       type: each.type, // 'deposit' or 'withdrawal'
@@ -276,7 +276,7 @@ export async function fetchHistory(req) {
     return tx;
   });
 
-  return { history: await Promise.all(historyTransformer) };
+  return { history: await Promise.all(transformedTxHistory) };
 }
 
 /**

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -249,8 +249,8 @@ export async function fetchHistory(req) {
   }
 
   const network = wallet.getNetworkObject();
-  // As isAddressMine call is async we collect the tasks to avoid
-  // suspend the iteration with an await.
+  // As isAddressMine call is async, we should collect the tasks to avoid
+  // suspending the iteration with an await.
   const isMineTasks = [];
   // Translate rawNcTxHistory to NcTxHistory and collect isAddressMine tasks
   const historyNewestToOldest = rawHistory.map((rawTx) => {

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -215,6 +215,7 @@ function* registerNanoContractOnError(error) {
  * @param {string} req.before Transaction hash to start to get newer items
  * @param {string} req.after Transaction hash to start to get older items
  * @param {Object} req.wallet Wallet instance from redux state
+ * @param {boolean} req.useWalletService A flag that determines if wallet service is in use
  *
  * @returns {{
  *   history: NcTxHistory;

--- a/src/utils.js
+++ b/src/utils.js
@@ -429,18 +429,6 @@ export const getNanoContractFeatureToggle = (state) => (
 export const getTimestampFormat = (timestamp) => moment.unix(timestamp).format(t`DD MMM YYYY [•] HH:mm`)
 
 /**
- * Extract the result of a generator function when it is done.
- */
-export const consumeGenerator = (generator) => {
-  for (;;) {
-    const { value, done } = generator.next();
-    if (done) {
-      return value;
-    }
-  }
-}
-
-/**
  * Extract all the items of an async iterator/generator.
  *
  * @returns {Promise<unknown[]>} A promise of an array of unkown object.


### PR DESCRIPTION
### Motivation

This PR closes https://github.com/HathorNetwork/hathor-wallet-mobile/issues/514 to add concurrency on isAddressMine calls without mess with history ordering.

### Acceptance Criteria
- Refactor fetchHistory to avoid iteration suspension while hydrating the NcTxHistory item with isMine flag
- As the isAddressMine is an O(1) call and don't require a http request, we can use a plain Promise.all to collect the tasks

#### fetchHistory still working properly

https://github.com/user-attachments/assets/fdd10982-f498-45d6-b4d5-f7c0215a526a


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
