### PR TITLE
refactor: remove address requirement from nc registering process

### DIFF
--- a/__tests__/sagas/nanoContracts/registerNanoContract.test.js
+++ b/__tests__/sagas/nanoContracts/registerNanoContract.test.js
@@ -16,7 +16,7 @@ describe('sagas/nanoContract/registerNanoContract', () => {
     const { address, ncId } = fixtures;
 
     // call effect to register nano contract
-    const gen = registerNanoContract(nanoContractRegisterRequest({ address, ncId }));
+    const gen = registerNanoContract(nanoContractRegisterRequest({ ncId }));
     // call select wallet
     gen.next();
     // feed back the selector
@@ -35,7 +35,7 @@ describe('sagas/nanoContract/registerNanoContract', () => {
     const { address, ncId } = fixtures;
 
     // call effect to register nano contract
-    const gen = registerNanoContract(nanoContractRegisterRequest({ address, ncId }));
+    const gen = registerNanoContract(nanoContractRegisterRequest({ ncId }));
     // call select wallet
     gen.next();
 
@@ -58,7 +58,7 @@ describe('sagas/nanoContract/registerNanoContract', () => {
     const { address, ncId } = fixtures;
 
     // call effect to register nano contract
-    const gen = registerNanoContract(nanoContractRegisterRequest({ address, ncId }));
+    const gen = registerNanoContract(nanoContractRegisterRequest({ ncId }));
     // call select wallet
     gen.next();
     // feed back the selector
@@ -79,7 +79,7 @@ describe('sagas/nanoContract/registerNanoContract', () => {
     const { address, ncId } = fixtures;
 
     // call effect to register nano contract
-    const gen = registerNanoContract(nanoContractRegisterRequest({ address, ncId }));
+    const gen = registerNanoContract(nanoContractRegisterRequest({ ncId }));
     // call select wallet
     gen.next();
     // feed back the selector
@@ -102,7 +102,7 @@ describe('sagas/nanoContract/registerNanoContract', () => {
     const { address, ncId } = fixtures;
 
     // call effect to register nano contract
-    const gen = registerNanoContract(nanoContractRegisterRequest({ address, ncId }));
+    const gen = registerNanoContract(nanoContractRegisterRequest({ ncId }));
     // call select wallet
     gen.next();
     // feed back the selector

--- a/src/actions.js
+++ b/src/actions.js
@@ -1071,7 +1071,6 @@ export const nanoContractInit = () => ({
 /**
  * Request a Nano Contract to be registered.
  * @param {{
- *   address: string,
  *   ncId: string,
  * }} registry Inputs to register a Nano Contract
  */

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -321,7 +321,7 @@ const initialState = {
     /**
      * registered {{
      *   [ncId: string]: {
-     *     address: string,
+     *     address?: string,
      *     ncId: string,
      *     blueprintId: string,
      *     blueprintName: string,

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -73,13 +73,12 @@ export function* init() {
  * Process Nano Contract registration request.
  * @param {{
  *   payload: {
- *     address: string,
  *     ncId: string,
  *   }
  * }} action with request payload.
  */
 export function* registerNanoContract({ payload }) {
-  const { address, ncId } = payload;
+  const { ncId } = payload;
 
   const wallet = yield select((state) => state.wallet);
   if (!wallet.isReady()) {
@@ -95,21 +94,6 @@ export function* registerNanoContract({ payload }) {
   if (isRegistered) {
     log.debug('Fail registering Nano Contract because it is already registered.');
     yield put(nanoContractRegisterFailure(failureMessage.alreadyRegistered));
-    return;
-  }
-
-  // XXX: Wallet Service doesn't implement isAddressMine.
-  // See issue: https://github.com/HathorNetwork/hathor-wallet-lib/issues/732
-  // Default to `false` if using Wallet Service.
-  let isAddressMine = false;
-  const useWalletService = yield call(isWalletServiceEnabled);
-  if (!useWalletService) {
-    isAddressMine = yield call([wallet, wallet.isAddressMine], address);
-  }
-
-  if (!isAddressMine) {
-    log.debug('Fail registering Nano Contract because address do not belongs to this wallet.');
-    yield put(nanoContractRegisterFailure(failureMessage.addressNotMine));
     return;
   }
 

--- a/src/screens/NanoContract/NanoContractRegisterScreen.js
+++ b/src/screens/NanoContract/NanoContractRegisterScreen.js
@@ -13,7 +13,6 @@ import React, {
 import {
   StyleSheet,
   View,
-  Text,
   Image,
 } from 'react-native';
 import {
@@ -22,15 +21,11 @@ import {
 } from 'react-redux';
 import { t } from 'ttag';
 import HathorHeader from '../../components/HathorHeader';
-import { CircleInfoIcon } from '../../components/Icons/CircleInfo.icon';
 import NewHathorButton from '../../components/NewHathorButton';
 import OfflineBar from '../../components/OfflineBar';
 import SimpleInput from '../../components/SimpleInput';
-import { TextLabel } from '../../components/TextLabel';
-import { TextValue } from '../../components/TextValue';
 import { COLORS } from '../../styles/themes';
 import {
-  firstAddressRequest,
   nanoContractRegisterReady,
   nanoContractRegisterRequest
 } from '../../actions';
@@ -44,7 +39,6 @@ import Spinner from '../../components/Spinner';
 import FeedbackModal from '../../components/FeedbackModal';
 import errorIcon from '../../assets/images/icErrorBig.png';
 import checkIcon from '../../assets/images/icCheckBig.png';
-import { FeedbackContent } from '../../components/FeedbackContent';
 import { hasError } from '../../utils';
 
 /**
@@ -65,7 +59,6 @@ export function NanoContractRegisterScreen({ navigation, route }) {
   const ncIdFromQrCode = route.params?.ncId;
 
   const dispatch = useDispatch();
-  const { address, error } = useSelector((state) => state.firstAddress);
   const registerState = useSelector((state) => ({
     registerStatus: state.nanoContract.registerStatus,
     registerFailureMessage: state.nanoContract.registerFailureMessage,
@@ -116,9 +109,9 @@ export function NanoContractRegisterScreen({ navigation, route }) {
       }
 
       const { ncId } = formModel;
-      dispatch(nanoContractRegisterRequest({ address, ncId }));
+      dispatch(nanoContractRegisterRequest({ ncId }));
     },
-    [formModel, address]
+    [formModel]
   );
 
   const handleFeedbackModalDismiss = () => {
@@ -135,15 +128,7 @@ export function NanoContractRegisterScreen({ navigation, route }) {
       // Set ncId in the input when given
       handleInputChange('ncId')(ncIdFromQrCode);
     }
-
-    if (!address) {
-      dispatch(firstAddressRequest());
-    }
   }, []);
-
-  const hasFirstAddressFailed = () => error;
-  const isFirstAddressLoading = () => !error && !address;
-  const hasFirstAddressLoaded = () => !error && address;
 
   return (
     <Wrapper>
@@ -169,25 +154,6 @@ export function NanoContractRegisterScreen({ navigation, route }) {
           />
         )}
 
-      {hasFirstAddressFailed()
-        && (
-        <FeedbackContent
-          icon={(<Image source={errorIcon} style={styles.feedbackContentIcon} resizeMode='contain' />)}
-          title={t`Load First Addresses Error`}
-          message={error}
-        />
-        )}
-
-      {isFirstAddressLoading()
-        && (
-        <FeedbackContent
-          title={t`Loading`}
-          message={t`Loading first wallet address.`}
-        />
-        )}
-
-      {hasFirstAddressLoaded()
-        && (
         <ContentWrapper>
           <SimpleInput
             containerStyle={styles.input}
@@ -197,25 +163,6 @@ export function NanoContractRegisterScreen({ navigation, route }) {
             error={invalidModel.ncId}
             value={formModel.ncId}
           />
-          <View style={styles.selectionContainer}>
-            <FieldContainer>
-              <TextLabel pb8 bold>{t`Wallet Address`}</TextLabel>
-              <TextValue>{address}</TextValue>
-            </FieldContainer>
-          </View>
-          <View style={styles.infoContainer}>
-            <View style={styles.infoIcon}>
-              <CircleInfoIcon size={20} color='hsla(203, 100%, 25%, 1)' />
-            </View>
-            <View style={styles.infoContent}>
-              <Text style={styles.text}>
-                {t`If you want to change the wallet address, you will be able to do`}
-                <Text style={styles.bold}>
-                  {' '}{t`after the contract is registered.`}
-                </Text>
-              </Text>
-            </View>
-          </View>
           {isLoading(registerState.registerStatus)
             && (
               <View style={styles.loadingContainer}>
@@ -234,17 +181,10 @@ export function NanoContractRegisterScreen({ navigation, route }) {
             />
           </View>
         </ContentWrapper>
-        )}
       <OfflineBar />
     </Wrapper>
   );
 }
-
-const FieldContainer = ({ last, children }) => (
-  <View style={[styles.fieldContainer, last && styles.pd0]}>
-    {children}
-  </View>
-);
 
 const NavigationHeader = ({ navigation }) => (
   <HathorHeader
@@ -279,27 +219,6 @@ const styles = StyleSheet.create({
     paddingBottom: 48,
     paddingHorizontal: 16,
   },
-  infoContainer: {
-    flexShrink: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 24,
-    borderRadius: 8,
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    backgroundColor: 'hsla(203, 100%, 93%, 1)',
-  },
-  infoContent: {
-    flex: 1,
-    paddingLeft: 8,
-  },
-  selectionContainer: {
-    marginBottom: 16,
-    borderRadius: 8,
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    backgroundColor: COLORS.freeze100,
-  },
   loadingContainer: {
     alignItems: 'center',
   },
@@ -313,22 +232,5 @@ const styles = StyleSheet.create({
   feedbackModalIcon: {
     height: 105,
     width: 105
-  },
-  feedbackContentIcon: {
-    height: 36,
-    width: 36,
-  },
-  text: {
-    fontSize: 14,
-    lineHeight: 20,
-  },
-  bold: {
-    fontWeight: 'bold',
-  },
-  pd0: {
-    paddingBottom: 0,
-  },
-  pd8: {
-    paddingBottom: 8,
   },
 });


### PR DESCRIPTION
### Motivation

Liberate a Nano Contract registration while using Wallet Service. It is not possible now because the address is checked as belonging to the wallet, but Wallet Service's wallet doesn't implement this check.

### Acceptance Criteria

- Remove address requirement to register a Nano Contract

>[!WARNING]
>It is lacking:
>- [ ] Load wallet's `firstAddress` on wallet initialization
>- [ ] Adapt NanoContractDetailsScreen to consume the `firstAddress` as the default address of signature in case of an operation
>- [ ] Adapt NanoContractDetailsScreen to show a feedback of first address request failure in case it happens

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
