### PR TITLE
chore: update sentry version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@react-navigation/bottom-tabs": "6.5.8",
         "@react-navigation/native": "6.1.7",
         "@react-navigation/stack": "6.3.17",
-        "@sentry/react-native": "5.6.0",
+        "@sentry/react-native": "5.31.0",
         "assert": "2.0.0",
         "buffer": "4.9.2",
         "console-browserify": "1.2.0",
@@ -6427,41 +6427,83 @@
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.2.1.tgz",
       "integrity": "sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA=="
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.54.0.tgz",
-      "integrity": "sha512-JsyhZ0wWZ+VqbHJg+azqRGdYJDkcI5R9+pnkO6SzbzxrRewqMAIwzkpPee3oI7vG99uhMEkOkMjHu0nQGwkOQw==",
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.0.tgz",
+      "integrity": "sha512-om8TkAU5CQGO8nkmr7qsSBVkP+/vfeS4JgtW3sjoTK0fhj26+DljR6RlfCGWtYQdPSP6XV7atcPTjbSnsmG9FQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.54.0",
-        "@sentry/types": "7.54.0",
-        "@sentry/utils": "7.54.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.0.tgz",
+      "integrity": "sha512-NL02VQx6ekPxtVRcsdp1bp5Tb5w6vnfBKSIfMKuDRBy5A10Uc3GSoy/c3mPyHjOxB84452A+xZSx6bliEzAnuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.119.0",
+        "@sentry/replay": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.0.tgz",
+      "integrity": "sha512-oKdFJnn+56f0DHUADlL8o9l8jTib3VDLbWQBVkjD9EprxfaCwt2m8L5ACRBdQ8hmpxCEo4I8/6traZ7qAdBUqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.20.1.tgz",
+      "integrity": "sha512-4mhEwYTK00bIb5Y9UWIELVUfru587Vaeg0DQGswv4aIRHIiMKLyNqCEejaaybQ/fNChIZOKmvyqXk430YVd7Qg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@sentry/browser": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.54.0.tgz",
-      "integrity": "sha512-EvLAw03N9WE2m1CMl2/1YMeIs1icw9IEOVJhWmf3uJEysNJOFWXu6ZzdtHEz1E6DiJYhc1HzDya0ExZeJxNARA==",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.0.tgz",
+      "integrity": "sha512-WwmW1Y4D764kVGeKmdsNvQESZiAn9t8LmCWO0ucBksrjL2zw9gBPtOpRcO6l064sCLeSxxzCN+kIxhRm1gDFEA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.54.0",
-        "@sentry/core": "7.54.0",
-        "@sentry/replay": "7.54.0",
-        "@sentry/types": "7.54.0",
-        "@sentry/utils": "7.54.0",
-        "tslib": "^1.9.3"
+        "@sentry-internal/feedback": "7.119.0",
+        "@sentry-internal/replay-canvas": "7.119.0",
+        "@sentry-internal/tracing": "7.119.0",
+        "@sentry/core": "7.119.0",
+        "@sentry/integrations": "7.119.0",
+        "@sentry/replay": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.18.1.tgz",
-      "integrity": "sha512-lc/dX/cvcmznWNbLzDbzxn224vwY5zLIDBe3yOO6Usg3CDgkZZ3xfjN4AIUZwkiTEPIOELodrOfdoMxqpXyYDw==",
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.31.2.tgz",
+      "integrity": "sha512-2aKyUx6La2P+pplL8+2vO67qJ+c1C79KYWAyQBE0JIT5kvKK9JpwtdNoK1F0/2mRpwhhYPADCz3sVIRqmL8cQQ==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.7",
@@ -6474,59 +6516,185 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.31.2",
+        "@sentry/cli-linux-arm": "2.31.2",
+        "@sentry/cli-linux-arm64": "2.31.2",
+        "@sentry/cli-linux-i686": "2.31.2",
+        "@sentry/cli-linux-x64": "2.31.2",
+        "@sentry/cli-win32-i686": "2.31.2",
+        "@sentry/cli-win32-x64": "2.31.2"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.31.2.tgz",
+      "integrity": "sha512-BHA/JJXj1dlnoZQdK4efRCtHRnbBfzbIZUKAze7oRR1RfNqERI84BVUQeKateD3jWSJXQfEuclIShc61KOpbKw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.31.2.tgz",
+      "integrity": "sha512-W8k5mGYYZz/I/OxZH65YAK7dCkQAl+wbuoASGOQjUy5VDgqH0QJ8kGJufXvFPM+f3ZQGcKAnVsZ6tFqZXETBAw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.31.2.tgz",
+      "integrity": "sha512-FLVKkJ/rWvPy/ka7OrUdRW63a/z8HYI1Gt8Pr6rWs50hb7YJja8lM8IO10tYmcFE/tODICsnHO9HTeUg2g2d1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.31.2.tgz",
+      "integrity": "sha512-A64QtzaPi3MYFpZ+Fwmi0mrSyXgeLJ0cWr4jdeTGrzNpeowSteKgd6tRKU+LVq0k5shKE7wdnHk+jXnoajulMA==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.31.2.tgz",
+      "integrity": "sha512-YL/r+15R4mOEiU3mzn7iFQOeFEUB6KxeKGTTrtpeOGynVUGIdq4nV5rHow5JDbIzOuBS3SpOmcIMluvo1NCh0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.31.2.tgz",
+      "integrity": "sha512-Az/2bmW+TFI059RE0mSBIxTBcoShIclz7BDebmIoCkZ+retrwAzpmBnBCDAHow+Yi43utOow+3/4idGa2OxcLw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.31.2.tgz",
+      "integrity": "sha512-XIzyRnJu539NhpFa+JYkotzVwv3NrZ/4GfHB/JWA2zReRvsk39jJG8D5HOmm0B9JA63QQT7Dt39RW8g3lkmb6w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.54.0.tgz",
-      "integrity": "sha512-MAn0E2EwgNn1pFQn4qxhU+1kz6edullWg6VE5wCmtpXWOVw6sILBUsQpeIG5djBKMcneJCdOlz5jeqcKPrLvZQ==",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.0.tgz",
+      "integrity": "sha512-CS2kUv9rAJJEjiRat6wle3JATHypB0SyD7pt4cpX5y0dN5dZ1JrF57oLHRMnga9fxRivydHz7tMTuBhSSwhzjw==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.54.0",
-        "@sentry/utils": "7.54.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.54.0.tgz",
-      "integrity": "sha512-GePswxz0rzSaCGB0QR2FgH7Hht9SfxsVyX271FtPH3V5hUIZOHlftXggqmNy5XyyiGf27zsWM+DYgQUFJwMcjQ==",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.119.0.tgz",
+      "integrity": "sha512-183h5B/rZosLxpB+ZYOvFdHk0rwZbKskxqKFtcyPbDAfpCUgCass41UTqyxF6aH1qLgCRxX8GcLRF7frIa/SOg==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.54.0",
-        "@sentry/types": "7.54.0",
-        "@sentry/utils": "7.54.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.54.0.tgz",
-      "integrity": "sha512-RolGsQzJChJzjHTJcCKSZ1HanmY33floc5o13WgU9NoDqJbLGLNcOIrAu+WynqPe8P5VTVrVb8NiwhLqWrKp4g==",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.0.tgz",
+      "integrity": "sha512-OHShvtsRW0A+ZL/ZbMnMqDEtJddPasndjq+1aQXw40mN+zeP7At/V1yPZyFaURy86iX7Ucxw5BtmzuNy7hLyTA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.54.0",
-        "@sentry/utils": "7.54.0",
-        "localforage": "^1.8.1",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.54.0.tgz",
-      "integrity": "sha512-qUbwmRRpTh05m2rbC8A2zAFQYsoHhwIpxT5UXxh0P64ZlA3cSg1/DmTTgwnd1l+7gzKrc31UikXQ4y0YDbMNKg==",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.119.0.tgz",
+      "integrity": "sha512-cf8Cei+qdSA26gx+IMAuc/k44PeBImNzIpXi3930SLhUe44ypT5OZ/44L6xTODHZzTIyMSJPduf59vT2+eW9yg==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "7.54.0",
-        "@sentry/types": "7.54.0",
-        "@sentry/utils": "7.54.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
+        "@sentry/browser": "7.119.0",
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0",
+        "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -6536,52 +6704,66 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.6.0.tgz",
-      "integrity": "sha512-qmu1WzgairYNE/dlGQrjWAZA0OcTv/31yaPUDhX0Yrf1GT+KSerSlimiHGqvle81NJcpSi/K1+7EBfPiK57GmA==",
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.31.0.tgz",
+      "integrity": "sha512-iflj+SfH2k/vSybC5APTjwdBuW53rQtitD99vRbsMgMTnhcvWMy+ASTf6Shr9czv9uzlYrS83iF/COSyDNwiPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "7.54.0",
-        "@sentry/cli": "2.18.1",
-        "@sentry/core": "7.54.0",
-        "@sentry/hub": "7.54.0",
-        "@sentry/integrations": "7.54.0",
-        "@sentry/react": "7.54.0",
-        "@sentry/types": "7.54.0",
-        "@sentry/utils": "7.54.0"
+        "@sentry/babel-plugin-component-annotate": "2.20.1",
+        "@sentry/browser": "7.119.0",
+        "@sentry/cli": "2.31.2",
+        "@sentry/core": "7.119.0",
+        "@sentry/hub": "7.119.0",
+        "@sentry/integrations": "7.119.0",
+        "@sentry/react": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
       },
       "peerDependencies": {
+        "expo": ">=49.0.0",
         "react": ">=17.0.0",
         "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.54.0.tgz",
-      "integrity": "sha512-C0F0568ybphzGmKGe23duB6n5wJcgM7WLYhoeqW3o2bHeqpj1dGPSka/K3s9KzGaAgzn1zeOUYXJsOs+T/XdsA==",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.0.tgz",
+      "integrity": "sha512-BnNsYL+X5I4WCH6wOpY6HQtp4MgVt0NVlhLUsEyrvMUiTs0bPkDBrulsgZQBUKJsbOr3l9nHrFoNVB/0i6WNLA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.54.0",
-        "@sentry/types": "7.54.0",
-        "@sentry/utils": "7.54.0"
+        "@sentry-internal/tracing": "7.119.0",
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.54.0.tgz",
-      "integrity": "sha512-D+i9xogBeawvQi2r0NOrM7zYcUaPuijeME4O9eOTrDF20tj71hWtJLilK+KTGLYFtpGg1h+9bPaz7OHEIyVopg==",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.0.tgz",
+      "integrity": "sha512-27qQbutDBPKGbuJHROxhIWc1i0HJaGLA90tjMu11wt0E4UNxXRX+UQl4Twu68v4EV3CPvQcEpQfgsViYcXmq+w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.54.0.tgz",
-      "integrity": "sha512-3Yf5KlKjIcYLddOexSt2ovu2TWlR4Fi7M+aCK8yUTzwNzf/xwFSWOstHlD/WiDy9HvfhWAOB/ukNTuAeJmtasw==",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.0.tgz",
+      "integrity": "sha512-ZwyXexWn2ZIe2bBoYnXJVPc2esCSbKpdc6+0WJa8eutXfHq3FRKg4ohkfCBpfxljQGEfP1+kfin945lA21Ka+A==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.54.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.119.0"
       },
       "engines": {
         "node": ">=8"
@@ -7160,6 +7342,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
       "dependencies": {
         "debug": "4"
       },
@@ -11295,6 +11478,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -11379,7 +11563,8 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -15273,6 +15458,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
       "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -15287,6 +15473,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
       "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -17563,6 +17750,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -19707,7 +19895,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@react-navigation/bottom-tabs": "6.5.8",
     "@react-navigation/native": "6.1.7",
     "@react-navigation/stack": "6.3.17",
-    "@sentry/react-native": "5.6.0",
+    "@sentry/react-native": "5.31.0",
     "assert": "2.0.0",
     "buffer": "4.9.2",
     "console-browserify": "1.2.0",


### PR DESCRIPTION
### Motivation

The previous version is breaking the build process.

### Acceptance Criteria
- It must have the version 5.31.0 of @sentry/react-native pinned

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
