### PR TITLE
feat: Android target 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         kotlin_version = "1.7.20"
         minSdkVersion = 23
         compileSdkVersion = 33
-        targetSdkVersion = 33
+        targetSdkVersion = 34
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"


### PR DESCRIPTION
### Acceptance Criteria
- Implements a cherry pick of the same feature available on the Hathor Play branch: #562 
- The application build process should target Android SDK 34
- This is a part of the `0.28.0` Release Candidate


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
