### PR TITLE
fix: Bump script rc regex

### DIFF
--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -36,7 +36,7 @@ function updateAndroidBuildVersion() {
  * @returns {{rcVersion: number, updatedVersionString: string, mainVersionString: string}}
  */
 function calculateNewVersion(_updateType, currentVersionString) {
-  const versionNameRegex = /(\d+)\.(\d+)\.(\d+)(-rc)?(\d+)?/;
+  const versionNameRegex = /(\d+)\.(\d+)\.(\d+)(-rc\.)?(\d+)?/;
   const versionNameMatch = currentVersionString.match(versionNameRegex);
   let major = parseInt(versionNameMatch[1], 10);
   let minor = parseInt(versionNameMatch[2], 10);
@@ -75,7 +75,7 @@ function calculateNewVersion(_updateType, currentVersionString) {
 
   const mainVersionString = `${major}.${minor}.${patch}`;
   const rcVersion = rc;
-  const updatedVersionString = `${mainVersionString}${rc ? `-rc${rc}` : ''}`;
+  const updatedVersionString = `${mainVersionString}${rc ? `-rc.${rc}` : ''}`;
   return {
     mainVersionString,
     rcVersion,


### PR DESCRIPTION
The `bump-version` script was not updated after the latest change in our official versioning syntax.

### Acceptance Criteria
- Fixes the release candidate increment on the bump version script
- The resulting version should be compliant with the change from #406 

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
