### PR TITLE
fix: fetch metadata fail

### DIFF
--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -20,7 +20,7 @@ import { t } from 'ttag';
 import { metadataApi } from '@hathor/wallet-lib';
 import { channel } from 'redux-saga';
 import { get } from 'lodash';
-import { specificTypeAndPayload, dispatchAndWait, getRegisteredTokenUids } from './helpers';
+import { specificTypeAndPayload, dispatchAndWait, getRegisteredTokenUids, getNetworkSettings } from './helpers';
 import { mapToTxHistory, splitInGroups } from '../utils';
 import {
   types,
@@ -241,7 +241,7 @@ function* fetchTokenMetadataConsumer(fetchTokenMetadataChannel) {
  * @inner
  */
 export function* fetchTokenMetadata({ tokenId }) {
-  const { network } = yield select((state) => state.serverInfo);
+  const { network } = yield select((state) => getNetworkSettings(state));
 
   try {
     // Retry mechanism


### PR DESCRIPTION
### Acceptance Criteria
- Fetch token metadata is failing because we don't have `serverInfo` when on the wallet-service facade
- We should use the network from networkSettings

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
