### PR TITLE
fix: reown crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint .",
     "test": "jest",
     "setup": "npm install && ./node_modules/.bin/allow-scripts && rn-nodeify --install stream,process,path,events,crypto,console,buffer --hack && npx patch-package",
+    "setup:release": "npm ci && ./node_modules/.bin/allow-scripts && rn-nodeify --install stream,process,path,events,crypto,console,buffer --hack && npx patch-package",
     "locale-update-pot": "ttag extract -o ./locale/texts.pot ./src/"
   },
   "dependencies": {

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -18,7 +18,7 @@ rm -f ./android/app/google-services.json
 rm -f ./android/app/GoogleService-Info.plist
 rm -f ./notifications/GoogleService-Info.plist
 
-npm ci
+npm run setup:release
 
 (cd ios/ && pod install)
 

--- a/src/sagas/featureToggle.js
+++ b/src/sagas/featureToggle.js
@@ -37,12 +37,15 @@ import {
   SAFE_BIOMETRY_MODE_FEATURE_TOGGLE,
 } from '../constants';
 import { disableFeaturesIfNeeded } from './helpers';
+import { logger } from '../logger';
 
 const MAX_RETRIES = 5;
 
+const log = logger('featureToggle');
+
 export function* handleInitFailed(currentRetry) {
   if (currentRetry >= MAX_RETRIES) {
-    console.error('Max retries reached while trying to create the unleash-proxy client.');
+    log.error('Max retries reached while trying to create the unleash-proxy client.');
     const unleashClient = yield select((state) => state.unleashClient);
 
     if (unleashClient) {
@@ -75,7 +78,7 @@ export function* fetchTogglesRoutine() {
     } catch (e) {
       // No need to do anything here as it will try again automatically in
       // UNLEASH_POLLING_INTERVAL. Just prevent it from crashing the saga.
-      console.error('Erroed fetching feature toggles');
+      log.error('Erroed fetching feature toggles', e);
     }
   }
 }
@@ -128,6 +131,7 @@ export function* monitorFeatureFlags(currentRetry = 0) {
     yield put(setUseSafeBiometryMode(featureToggles[SAFE_BIOMETRY_MODE_FEATURE_TOGGLE]));
     yield put(featureToggleInitialized());
   } catch (e) {
+    log.error(e);
     yield put(setUnleashClient(null));
 
     // Wait 500ms before retrying

--- a/src/sagas/reown.js
+++ b/src/sagas/reown.js
@@ -899,7 +899,7 @@ export function* onSessionProposal(action) {
       }));
     } catch (e) {
       // Only if this fails, send the exception to Sentry
-      yield put(onExceptionCaptured(error));
+      yield put(onExceptionCaptured(e));
     }
   }
 }

--- a/src/sagas/reown.js
+++ b/src/sagas/reown.js
@@ -242,7 +242,7 @@ export function* checkForPendingRequests() {
   }
   const { walletKit } = reownClient;
 
-  yield call([walletKit, walletKit.getPendingAuthRequests]);
+  yield call([walletKit, walletKit.getPendingSessionProposals]);
   yield call([walletKit, walletKit.getPendingSessionRequests]);
 }
 

--- a/src/screens/PinScreen.js
+++ b/src/screens/PinScreen.js
@@ -163,9 +163,9 @@ class PinScreen extends React.Component {
         }
         this.props.unlockScreen();
       } catch (e) {
-        log.debug(e);
+        log.error(e);
         this.props.onExceptionCaptured(
-          new Error('Error during wallet initialization.'),
+          e,
           true, // Fatal since we can't start the wallet
         );
       }


### PR DESCRIPTION
### Acceptance Criteria
- We should stop crashing when coming back from an app `inactive` state
- We should send the error to Sentry when the biometry fails to migrate
- We should update the release script to use `npm run setup`
- We should add improved logs on feature toggle saga

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
