### PR TITLE
fix: kill the feature toggle update listener task if android

### DIFF
--- a/src/sagas/ses.js
+++ b/src/sagas/ses.js
@@ -89,6 +89,11 @@ export function* isSESEnabled() {
  * the react-native bundle if the feature was enabled and is now disabled.
  */
 export function* featureToggleUpdateListener() {
+  if (Platform.OS === 'android') {
+    log.debug('Platform is android, skipping SES');
+    return;
+  }
+
   while (true) {
     const oldSesEnabled = yield call(isSESEnabled);
     yield take('FEATURE_TOGGLE_UPDATED');


### PR DESCRIPTION
### Acceptance Criteria
- The feature toggle listener should end if the platform is android, this will prevent apps from restarting when ses is disabled.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
