### PR TITLE
fix: request first address on wallet start success

### DIFF
--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -73,6 +73,7 @@ import {
   firstAddressSuccess,
   setUseSafeBiometryMode,
   lockScreen,
+  firstAddressRequest,
 } from '../actions';
 import { fetchTokenData } from './tokens';
 import {
@@ -313,7 +314,7 @@ export function* startWallet(action) {
   }
 
   yield put(walletRefreshSharedAddress());
-
+  yield put(firstAddressRequest());
   yield put(startWalletSuccess());
 
   // The way the redux-saga fork model works is that if a saga has `forked`


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/6d6c3b47-542f-4cf7-bbc1-3226af254b1b)


### Acceptance Criteria
- `firstAddress` is fetched from the state and it never gets updated when changing networks.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
