### PR TITLE
fix: race with the correct actions in create transaction saga

### DIFF
--- a/src/sagas/reown.js
+++ b/src/sagas/reown.js
@@ -455,8 +455,8 @@ export function* processRequest(action) {
 
         const retry = yield call(
           retryHandler,
-          types.REOWN_CREATE_TOKEN_RETRY,
-          types.REOWN_CREATE_TOKEN_RETRY_DISMISS,
+          types.REOWN_NEW_NANOCONTRACT_RETRY,
+          types.REOWN_NEW_NANOCONTRACT_RETRY_DISMISS,
         );
 
         if (retry) {


### PR DESCRIPTION
### Acceptance Criteria
- Reown would freeze after a failure in create nano contract RPC request because it was expecting an action that was never fired

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
