### PR TITLE
chore: bump to v0.30.1-rc.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,8 +79,8 @@ android {
         applicationId "network.hathor.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 84
-        versionName "0.30.0"
+        versionCode 85
+        versionName "0.30.1-rc.1"
         missingDimensionStrategy "react-native-camera", "general"
     }
     signingConfigs {

--- a/ios/HathorMobile.xcodeproj/project.pbxproj
+++ b/ios/HathorMobile.xcodeproj/project.pbxproj
@@ -476,7 +476,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = HathorMobile/HathorMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = 0.1.0;
 				DEVELOPMENT_TEAM = 55SHY647CG;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = HathorMobile/Info.plist;
@@ -485,7 +485,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.30.0;
+				MARKETING_VERSION = 0.30.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -506,7 +506,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = HathorMobile/HathorMobile.entitlements;
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = 0.1.0;
 				DEVELOPMENT_TEAM = 55SHY647CG;
 				INFOPLIST_FILE = HathorMobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -514,7 +514,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.30.0;
+				MARKETING_VERSION = 0.30.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "HathorMobile",
-  "version": "0.30.0",
+  "version": "0.30.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "HathorMobile",
-      "version": "0.30.0",
+      "version": "0.30.1-rc.1",
       "dependencies": {
         "@ethersproject/shims": "5.7.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HathorMobile",
-  "version": "0.30.0",
+  "version": "0.30.1-rc.1",
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=9.0.0"


### PR DESCRIPTION
### Acceptance Criteria
- Bump to v0.30.1-rc.1

### Checklist
- [X] Make sure you updated the `CURRENT_PROJECT_VERSION` with the appropriate release-candidate version in `ios/HathorMobile.xcodeproj/project.pbxproj`
- [X] Make sure you updated the `MARKETING_VERSION` with the appropriate version in `ios/HathorMobile.xcodeproj/project.pbxproj`
- [X] Make sure you updated the version attribute in `package.json`
- [X] Make sure you updated the version attribute in `package-lock.json`
- [X] Make sure you incremented the `versionCode` attribute in `android/app/build.gradle`
- [X] Make sure you updated the `versionName` with the appropriate version, including the release candidate number in `android/app/build.gradle`
