### PR TITLE
fix: sequential nano contract register fails on second one

### DIFF
--- a/src/components/Reown/NanoContract/NewNanoContractTransactionRequest.js
+++ b/src/components/Reown/NanoContract/NewNanoContractTransactionRequest.js
@@ -91,10 +91,10 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
    * transaction.
    */
   const [ncAddress, setNcAddress] = useState(registeredNc?.address || firstAddress.address);
-  const ncToAccept = {
+  const ncToAccept = useMemo(() => ({
     ...nc,
     caller: ncAddress,
-  };
+  }), [ncAddress, nc]);
 
   // Check if we have enough balance for deposit actions
   const hasInsufficientBalance = useMemo(() => {

--- a/src/components/Reown/NanoContract/NewNanoContractTransactionRequest.js
+++ b/src/components/Reown/NanoContract/NewNanoContractTransactionRequest.js
@@ -91,10 +91,10 @@ export const NewNanoContractTransactionRequest = ({ ncTxRequest }) => {
    * transaction.
    */
   const [ncAddress, setNcAddress] = useState(registeredNc?.address || firstAddress.address);
-  const ncToAccept = useMemo(() => ({
+  const ncToAccept = {
     ...nc,
     caller: ncAddress,
-  }), [ncAddress])
+  };
 
   // Check if we have enough balance for deposit actions
   const hasInsufficientBalance = useMemo(() => {


### PR DESCRIPTION
After a send nano contract success, if you stay in the success screen and attempt to register a new nano contract, the register will fail until the app is restarted.

### Acceptance Criteria
- We should be able to register nano contracts after a success

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
