### PR TITLE
chore: Add `pt-br` as a mandatory language on CI

### DIFF
--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -961,7 +961,7 @@ msgstr "Digitar"
 
 #: src/screens/Reown/ReownManual.js:45
 msgid "Reown URI"
-msgstr ""
+msgstr "URI do Reown"
 
 #: src/screens/Reown/ReownManual.js:57 src/screens/Reown/ReownScan.js:34
 msgid "Connect"
@@ -1038,19 +1038,19 @@ msgstr ""
 
 #: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:232
 msgid "Node URL"
-msgstr ""
+msgstr "URL do Fullnode"
 
 #: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:242
 msgid "Explorer URL"
-msgstr ""
+msgstr "URL do Explorer"
 
 #: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:251
 msgid "Explorer Service URL"
-msgstr ""
+msgstr "URL do Explorer Service"
 
 #: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:260
 msgid "Transaction Mining Service URL"
-msgstr ""
+msgstr "URL do Transaction Mining Service"
 
 #: src/screens/NetworkSettings/CustomNetworkSettingsScreen.js:271
 msgid "Wallet Service URL (optional)"
@@ -1610,7 +1610,7 @@ msgstr "Dados do Oracle para assinar"
 
 #: src/components/Reown/SignOracleDataRequest.js:42
 msgid "Oracle"
-msgstr ""
+msgstr "Oracle"
 
 #: src/components/Reown/WarnDisclaimer.js:27
 msgid ""

--- a/scripts/update_translations.js
+++ b/scripts/update_translations.js
@@ -31,6 +31,13 @@ const { tmpdir } = require('node:os');
  * - Lastly, checking for filesystem changes using `git status` for easier debugging, if needed
  */
 
+/*
+ * Usage:
+ * node scripts/update_translations.js
+ * node scripts/update_translations.js --ci-validation
+ * node scripts/update_translations.js --ci-validation --strict-languages=pt-br,ru-ru
+ */
+
 /**
  * All translations that should exist in the `locale` folder. Some of those may be incomplete.
  * @type {string[]}

--- a/scripts/update_translations.js
+++ b/scripts/update_translations.js
@@ -261,9 +261,27 @@ function getCliParameters() {
     parameters[key.replace('--', '')] = value || true;
   });
 
+  // Sanitize ci validation input
+  const ciValidationParam = parameters['ci-validation'];
+  if (ciValidationParam && (typeof ciValidationParam !== 'boolean')) {
+    console.warn(`❌ Must not offer any value for --ci-validation.`);
+    process.exit(1);
+  }
+
+  // Sanitize languages input, removing empty strings and using the default value if none provided
+  const strictLanguagesParam = parameters['strict-languages'];
+  if (strictLanguagesParam && (typeof strictLanguagesParam !== 'string')) {
+    console.warn(`❌ Invalid value for --strict-languages. Usage: node update_translations.js --ci-validation --strict-languages=ru-ru,da`);
+    process.exit(1);
+  }
+  const sanitizedLanguagesInput = strictLanguagesParam?.split(',').filter((lang) => lang) || [];
+  const treatedLanguagesParam = sanitizedLanguagesInput?.length
+    ? sanitizedLanguagesInput
+    : mandatoryTranslations;
+
   return {
-    isCiValidationRun: parameters['ci-validation'] || false,
-    strictLanguages: parameters['strict-languages']?.split(',') || mandatoryTranslations,
+    isCiValidationRun: ciValidationParam || false,
+    strictLanguages: treatedLanguagesParam,
   }
 }
 

--- a/scripts/update_translations.js
+++ b/scripts/update_translations.js
@@ -25,6 +25,7 @@ const { tmpdir } = require('node:os');
  * - Running all the translation steps as described above
  * - Checking if the `.pot` file is outdated
  * - Checking if all `.po` files have all messages from the `.pot` file
+ * - Checking if the mandatory languages have all translations in place in their `.po` files
  * - Checking for any fuzzy tags in the `.po` files
  * - Exiting with code 1 and failing if any of the above checks fail
  * - Lastly, checking for filesystem changes using `git status` for easier debugging, if needed


### PR DESCRIPTION
### Acceptance Criteria
- The language `pt-br` must have all translations completed to pass the CI validation
- There should be a way for the developer to set arbitrary languages to this validation locally in dev environment

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
