### PR TITLE
chore: Cleanup scripts

### DIFF
--- a/pre_release.sh
+++ b/pre_release.sh
@@ -12,19 +12,24 @@ set -v # Verbose mode for better debugging
 
 git log -n1
 
-rm -rf node_modules/
-rm -rf ios/Pods/
+echo "🧹 Major cache and dependency cleanup..."
+./scripts/cleanup.sh --ios --android
 
+echo "🧹 Cleaning old GoogleService files..."
 rm -f ./android/app/google-services.json
 rm -f ./android/app/GoogleService-Info.plist
 rm -f ./notifications/GoogleService-Info.plist
 
+echo "📦 Reinstalling dependencies for release..."
 npm run setup:release
 
+echo "📦 Reinstalling pods..."
 (cd ios/ && pod install)
 
+echo "📝 Updating i18n..."
 make i18n
 
+echo "⬇️ Retrieving latest GoogleService files..."
 source ./env
 mkdir -p ./notifications
 aws s3 cp ${HATHOR_WALLET_MOBILE_S3_PATH}/google-services.json ./android/app

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -30,7 +30,7 @@ done
 
 # Check if is in root folder by verifying the presence of the package.json file
 if [ ! -f "package.json" ]; then
-  echo "❌ Error: 'node_modules' folder not found in the current directory. Are you in the project root?"
+  echo "❌ Error: 'package.json' file not found in the current directory. Are you in the project root?"
   exit 1
 fi
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# This script cleans every possible cache related to the project dependencies
+# This is especially helpful during major dependency upgrades or to generate clean builds
+# It must be run from the root folder of the project
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Parse parameters
+CLEAN_IOS=false
+CLEAN_ANDROID=false
+REINSTALL=false
+
+for arg in "$@"; do
+  case $arg in
+    --ios)
+      CLEAN_IOS=true
+      ;;
+    --android)
+      CLEAN_ANDROID=true
+      ;;
+    --reinstall)
+      REINSTALL=true
+      ;;
+    *)
+      echo "❌ Error: Unknown parameter '$arg'"
+      exit 1
+      ;;
+  esac
+done
+
+# Check if the node_modules folder exists
+if [ ! -d "node_modules" ]; then
+  echo "❌ Error: 'node_modules' folder not found in the current directory. Are you in the project root?"
+  exit 1
+fi
+
+echo "🧹 Cleaning node_modules..."
+rm -rf node_modules
+
+# Execute cleanup_ios.sh if --ios was provided
+if $CLEAN_IOS; then
+  echo "🧹 Cleaning iOS build artifacts..."
+  ./scripts/cleanup_ios.sh
+fi
+
+# Execute cleanup_android.sh if --android was provided
+if $CLEAN_ANDROID; then
+  echo "🧹 Cleaning Android build artifacts..."
+  ./scripts/cleanup_android.sh
+fi
+
+# Reinstall dependencies if --reinstall was provided
+if $REINSTALL; then
+  echo "📦 Reinstalling dependencies..."
+  npm run setup
+
+  if $CLEAN_IOS; then
+    echo "🛠️ Rebuilding iOS artifacts..."
+    cd ios
+    pod install
+    cd ..
+  fi
+fi
+

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -28,8 +28,8 @@ for arg in "$@"; do
   esac
 done
 
-# Check if the node_modules folder exists
-if [ ! -d "node_modules" ]; then
+# Check if is in root folder by verifying the presence of the package.json file
+if [ ! -f "package.json" ]; then
   echo "❌ Error: 'node_modules' folder not found in the current directory. Are you in the project root?"
   exit 1
 fi

--- a/scripts/cleanup_android.sh
+++ b/scripts/cleanup_android.sh
@@ -24,7 +24,7 @@ echo "🧹 Cleaning and forcing re-download of global SDK/NDK caches..."
 rm -rf ~/Android/Sdk/ndk/*
 
 # Clear all leaking gradle processes
-# ⚠️ Warning! This will stop any ongoing Gradle processes! Use only if you aren't using any!
+# ⚠️ Warning! This will stop any ongoing Gradle processes! Run only if you aren't using any!
 echo "🧹 Killing all Gradle processes to avoid leaks..."
 ./gradlew --stop
 pkill -9 -f gradle

--- a/scripts/cleanup_android.sh
+++ b/scripts/cleanup_android.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This script cleans every possible cache related to the Android project.
+# This is especially helpful during major dependency upgrades or to generate clean builds
+# It must be run from the root folder of the project
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Check if the ios folder exists
+if [ ! -d "android" ]; then
+  echo "❌ Error: 'android' folder not found in the current directory. Are you in the project root?"
+  exit 1
+fi
+
+# Clear all builds within the project
+echo "🧹 Cleaning Application build caches..."
+cd android || exit
+rm -rf .gradle
+rm -rf build
+rm -rf app/build
+
+# Clear global android cache of NDK's
+# This will force a re-download of every NDK version
+echo "🧹 Cleaning and forcing re-download of global SDK/NDK caches..."
+rm -rf ~/Android/Sdk/ndk/*
+
+# Clear all leaking gradle processes
+# ⚠️ Warning! This will stop any ongoing Gradle processes! Use only if you aren't using any!
+echo "🧹 Killing all Gradle processes to avoid leaks..."
+./gradlew --stop
+pkill -9 -f gradle

--- a/scripts/cleanup_ios.sh
+++ b/scripts/cleanup_ios.sh
@@ -27,6 +27,8 @@ echo "🧹 Cleaning Xcode DerivedData..."
 rm -rf ~/Library/Developer/Xcode/DerivedData/*
 rm -rf ~/Library/Developer/Xcode/Archives/*
 
+# Deintegrating CocoaPods. This will cause all pods to be re-downloaded upon the next install
+# which will take a lot of bandwidth and processing time
 echo "🧹 Deintegrating and cleaning CocoaPods..."
 pod deintegrate
 

--- a/scripts/cleanup_ios.sh
+++ b/scripts/cleanup_ios.sh
@@ -24,8 +24,11 @@ rm -rf ~/Library/Caches/CocoaPods
 
 
 echo "🧹 Cleaning Xcode DerivedData..."
-rm -rf ~/Library/Developer/Xcode/DerivedData/*
-rm -rf ~/Library/Developer/Xcode/Archives/*
+# Retrieve the project name by listing the *.xcodeproj directory, removing the extension,
+# and handling errors if no match is found. That way, only the folders related to this project are cleaned up.
+PROJECT_NAME=$(ls -d *.xcodeproj 2>/dev/null | sed 's/\.xcodeproj$//')
+rm -rf ~/Library/Developer/Xcode/DerivedData/"$PROJECT_NAME"-*
+rm -rf ~/Library/Developer/Xcode/Archives/"$PROJECT_NAME"-*
 
 # Deintegrating CocoaPods. This will cause all pods to be re-downloaded upon the next install
 # which will take a lot of bandwidth and processing time

--- a/scripts/cleanup_ios.sh
+++ b/scripts/cleanup_ios.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script cleans every possible cache related to the iOS project.
+# This is especially helpful during major dependency upgrades or to generate clean builds
+# It must be run from the root folder of the project
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# Check if the ios folder exists
+if [ ! -d "ios" ]; then
+  echo "❌ Error: 'ios' folder not found in the current directory. Are you in the project root?"
+  exit 1
+fi
+
+# Navigate to the iOS directory
+cd ios || exit
+
+echo "🧹 Cleaning XCode caches..."
+rm -rf build
+xcodebuild clean
+
+echo "🧹 Cleaning CocoaPods caches..."
+rm -rf Pods
+rm -rf ~/Library/Caches/CocoaPods
+
+
+echo "🧹 Cleaning Xcode DerivedData..."
+rm -rf ~/Library/Developer/Xcode/DerivedData/*
+rm -rf ~/Library/Developer/Xcode/Archives/*
+
+echo "🧹 Deintegrating and cleaning CocoaPods..."
+pod deintegrate
+
+
+echo "✅ iOS project cleanup complete!"


### PR DESCRIPTION
### Motivation
When upgrading React Native versions, it's imperative to clean not only the local development folder but also the global caches for both Android and iOS at the operational system level. Failing to do so causes bugs with misleading messages that are hard to solve otherwise.

These scripts aim to facilitate this cleanup, providing the developer with a more reliable state upon which to start working.

Also, it's helpful to have this script run at pre-release, as it ensures the environment is as close as possible to that of the developer.

### Acceptance Criteria
- Adds new cleanup scripts that also wipe global caches
- Incorporates those new scripts into the `pre_release.sh` script

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
