### PR TITLE
chore: update react native sentry to v6.10.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -35,44 +35,44 @@ PODS:
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - GoogleUtilities (8.0.2):
-    - GoogleUtilities/AppDelegateSwizzler (= 8.0.2)
-    - GoogleUtilities/Environment (= 8.0.2)
-    - GoogleUtilities/Logger (= 8.0.2)
-    - GoogleUtilities/MethodSwizzler (= 8.0.2)
-    - GoogleUtilities/Network (= 8.0.2)
-    - "GoogleUtilities/NSData+zlib (= 8.0.2)"
-    - GoogleUtilities/Privacy (= 8.0.2)
-    - GoogleUtilities/Reachability (= 8.0.2)
-    - GoogleUtilities/SwizzlerTestHelpers (= 8.0.2)
-    - GoogleUtilities/UserDefaults (= 8.0.2)
-  - GoogleUtilities/AppDelegateSwizzler (8.0.2):
+  - GoogleUtilities (8.1.0):
+    - GoogleUtilities/AppDelegateSwizzler (= 8.1.0)
+    - GoogleUtilities/Environment (= 8.1.0)
+    - GoogleUtilities/Logger (= 8.1.0)
+    - GoogleUtilities/MethodSwizzler (= 8.1.0)
+    - GoogleUtilities/Network (= 8.1.0)
+    - "GoogleUtilities/NSData+zlib (= 8.1.0)"
+    - GoogleUtilities/Privacy (= 8.1.0)
+    - GoogleUtilities/Reachability (= 8.1.0)
+    - GoogleUtilities/SwizzlerTestHelpers (= 8.1.0)
+    - GoogleUtilities/UserDefaults (= 8.1.0)
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (8.0.2):
+  - GoogleUtilities/Environment (8.1.0):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.0.2):
+  - GoogleUtilities/Logger (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/MethodSwizzler (8.0.2):
+  - GoogleUtilities/MethodSwizzler (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (8.0.2):
+  - GoogleUtilities/Network (8.1.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (8.0.2)":
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.0.2)
-  - GoogleUtilities/Reachability (8.0.2):
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/SwizzlerTestHelpers (8.0.2):
+  - GoogleUtilities/SwizzlerTestHelpers (8.1.0):
     - GoogleUtilities/MethodSwizzler
-  - GoogleUtilities/UserDefaults (8.0.2):
+  - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - nanopb (3.30910.0):
@@ -1927,7 +1927,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSentry (5.31.0):
+  - RNSentry (6.10.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.11.18.00)
@@ -1947,7 +1947,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Sentry/HybridSDK (= 8.36.0)
+    - Sentry/HybridSDK (= 8.48.0)
     - Yoga
   - RNSVG (15.11.2):
     - DoubleConversion
@@ -1994,7 +1994,7 @@ PODS:
     - Yoga
   - RNVectorIcons (9.2.0):
     - React-Core
-  - Sentry/HybridSDK (8.36.0)
+  - Sentry/HybridSDK (8.48.0)
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2302,95 +2302,95 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
-  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 85b72250b63cfb54f29ca96ceb108cb9ef3c2079
   RCTRequired: 567cb8f5d42b990331bfd93faad1d8999b1c1736
   RCTTypeSafety: 5e57924492a5e0a762654f814dd018953274eca9
   React: 53c9bd6f974c5dd019ee466e46477eb679149c38
   React-callinvoker: d6484472c1c742917b51338525336d6a74ab8a9f
-  React-Core: 8009e7e4d638af9b6c9d67d423117e66246cfb2f
-  React-CoreModules: 0a31ca662ac169edd0c210efd324e19b3012d7ed
-  React-cxxreact: 001d9a5211e1c863c9410040be3407fd569094b9
+  React-Core: 612c34cb6d1f38412d36da151a422346f7696f0e
+  React-CoreModules: abe0b2089368e420b7beaa5e140771181e2f6edb
+  React-cxxreact: bd1950310faaf5905df711dd7c48c264be36e01c
   React-debug: af25f71a2ea800559f591ef9e9e6495a206c4f7c
-  React-defaultsnativemodule: cb8233682afae2d59839dcbb80f37a936a201750
-  React-domnativemodule: 0d53406b3a442e0411592028f6ee5a3d0f3d1e0d
-  React-Fabric: 0f86f0f3ff59b831c2daf9be2bb73b280993a59c
-  React-FabricComponents: 32a54e385fb416dd9f31596f979ee02aa0c663dd
-  React-FabricImage: 9d8d270429b2780067978054d467efd472db3d6a
+  React-defaultsnativemodule: 421bff085280ecb9a1e93cccd138c6bdaf900be4
+  React-domnativemodule: 12e520db1f78f41258ced39adafa177a6a989798
+  React-Fabric: aeb1a15d9ac5cad481009b5294b9e2b8dc128db9
+  React-FabricComponents: 82bc0da2d627a53fcc09c4e6fa5687da8ac69db9
+  React-FabricImage: b7c0a2a254cf3c61eaaef6dd01374518d117a911
   React-featureflags: 05545ed41078babfec20095fd7825f029709cde6
-  React-featureflagsnativemodule: 475df149f76ee65733766b37aab731f1409542bf
-  React-graphics: a59f1b9378ed14476288352d50bb68e251c2340e
-  React-idlecallbacksnativemodule: ab7ac7616979ee5b2675e4072257838683bbd5be
-  React-ImageManager: cbc7991281d0b6921a3456ef3de70876c89546cf
+  React-featureflagsnativemodule: 6b0452c031269f33131a36212dc71540145311e7
+  React-graphics: e33b1bff03c62a7293991bcc28ceb946740bae0f
+  React-idlecallbacksnativemodule: b064a214a661c0d80b470a55f89630ebbb84bc0e
+  React-ImageManager: ca548168b2efedd1e017dc6d715f5e0028eb446a
   React-jsc: 6dda524fbf683ef91d21444c48360808f0d4a637
-  React-jserrorhandler: e249d8460765f6f03e01734e522f604052b37353
-  React-jsi: 7dea3f0a38ea004011b0ba52e5e6a0040d71e16b
-  React-jsiexecutor: 26ced15fa076270af4e0c172ca2bb660b9f30073
-  React-jsinspector: b1896b38797c81b0d3e5081b673c0863778aa64f
-  React-jsitracing: 3d0518503be9950bfb2d32af73221a35ac174707
-  React-logger: 592d84bed2e04db64c0b3725f9970b437473f3d3
-  React-Mapbuffer: 0341d6efffcd02a6cd981bd254216adebb41ffb2
-  React-microtasksnativemodule: 6629d41bd1be3f5e76df92aba26dc5b890699b7d
-  react-native-compat: 2b3e16d46648bba5128288b77dc214b5a29c95c7
-  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
-  react-native-mmkv: 000fb73b8f468a2ede9c90c3ef631c37f5841d94
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: 9d6e3a98dc5a85490eb7b424e22dba38fb09493f
-  react-native-randombytes: 3c8f3e89d12487fd03a2f966c288d495415fc116
-  react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863
-  react-native-safe-area-context: aa83adb930d87ff2b482accd0254295a42a0c02b
-  react-native-version-number: 3d74b5224ca4e1032b1593937d86d3f3c94bf95c
+  React-jserrorhandler: 3afff8f504b60f6781cd2fbc2d8ac983b3c5f9b7
+  React-jsi: 3ba8050e245e61d7ad745f1efda77c04e452519c
+  React-jsiexecutor: 801fdffdd59043c3f8449d3293c83178850d9770
+  React-jsinspector: 4890eae75d046e0c49c74170deec25bad68d50ce
+  React-jsitracing: a417d71b554e891ccab72510f9482e6c53d0b09a
+  React-logger: 5320a2acb25baa566cda59b611231929dd3ed7fc
+  React-Mapbuffer: 9af3695e354816d30d4429992714e0c8cefac25f
+  React-microtasksnativemodule: 191151e7675778f802dce7fa52773bb9b4d3fda6
+  react-native-compat: cee64be5635b60e3742a44ca19a74d32fc34e259
+  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
+  react-native-mmkv: 326739e7f6cdba138d4164a9e2846c8bd888efca
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 1630db382e41ee172ebce675820e0bfe0564635a
+  react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
+  react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
+  react-native-safe-area-context: 00675a8f76ce84db84e579f8270d0c7175a2c1f4
+  react-native-version-number: b415bbec6a13f2df62bf978e85bc0d699462f37f
   React-nativeconfig: 75658bde8f977492f668e94ae8eb9c0dfef7ed94
-  React-NativeModulesApple: fbf514529a9e6f0c784399fb97be0eb865738a34
-  React-perflogger: 1111b5feb064c4cc83df88fb403efda54b387951
-  React-performancetimeline: 0f4f0f6ca1c46ac917e48c54007db30d8c2ce31e
+  React-NativeModulesApple: 0007e24f14df7e842ff098249a0c65aea66eb077
+  React-perflogger: a0f49e229d1252d683102df60d2392229ece5837
+  React-performancetimeline: d0fb47dfc5d55ec6b7c4a79c83912ff59bb8df51
   React-RCTActionSheet: 150cfe1df4275db2251a2a4a1b22be3294e94ef7
-  React-RCTAnimation: 1de976f7a660429c39e20a81a728eb0102226f9b
-  React-RCTAppDelegate: 4109e479dd590a298df157d64a108838bbe7934d
-  React-RCTBlob: 8e8cfeaa827eb22261d5b8ade01367da4c73db16
-  React-RCTFabric: 395ca2a0e78ac8242b81f988074a3bc81baae2ab
-  React-RCTFBReactNativeSpec: 7aaac0f00cccdbb7342cbcc2cec42d9fbccfb280
-  React-RCTImage: 148afd89e4de0c36b87df0d1e8c0007fa89fb055
-  React-RCTLinking: 389458d08b891fa0a03e4c2cee545ebff341d06f
-  React-RCTNetwork: a78572948341ef0f9438b2d1cd685be564256518
-  React-RCTSettings: 484e4ec805ff8ab6c0af21fe90f415a8fae89f43
-  React-RCTText: 0d6fbf6ebe6eaa749bc7d672ba01a3e96553e941
-  React-RCTVibration: 4baa58b79be7062096e0f0b7575d4f0507952449
+  React-RCTAnimation: 67a303df28e0981f58a26968b3c15252a6b277b8
+  React-RCTAppDelegate: 802a3d800f403a92981ee39c9e57864e4c5a98fa
+  React-RCTBlob: 133da40b3f1579d9e4f026177900bc52ccc725ca
+  React-RCTFabric: 081af1b470d84c6c483d0ee62102bb4e1a70bb26
+  React-RCTFBReactNativeSpec: 3a9159a6a36578d8502d54b6b51f81384904ea73
+  React-RCTImage: f235db428b4c98cbb1ad6304f826695f19e82c57
+  React-RCTLinking: 523a01769de55660743d6332157dfb4dbad817b8
+  React-RCTNetwork: d99ee5bf1f15ad8521d30c9da477906d7fb00110
+  React-RCTSettings: 4165a44c6f51787980634bd522f3b379ee8531a6
+  React-RCTText: 462ab8d4f2f180be83e3983307ce5ef5fa58210e
+  React-RCTVibration: ca784cb7e30c21852d4b78b1621bfa11940ab061
   React-rendererconsistency: 28f87593201bca785e0bbdc94bff4d92ee2d32ee
-  React-rendererdebug: 8b06c1e79936abf465dbd903cd621e93c61a67c4
+  React-rendererdebug: c3121b6c4f0873ad2cf1bb63947c0a8a0ae8a1ab
   React-rncore: df9c0360d3f28371a103921890e20c309c906407
-  React-RuntimeApple: 5f4e288b03c1bb278c67aa378227970fd0dbd110
-  React-RuntimeCore: f383ce1dc1a2d77d03fc21ed9857bc8c0c6007f2
+  React-RuntimeApple: 9bc0127e9c8a138c17ef17629336fa03cb4921db
+  React-RuntimeCore: 3d225cfb6bb1a83008cc74fd37c42151dd64abc9
   React-runtimeexecutor: e6e7af01f9989f931289250ee9060604bc0f0144
-  React-runtimescheduler: a2b7c564b1ebc0cbc304132d63b424354b1b7c64
+  React-runtimescheduler: df86f05e772a528b483c273bc38d10ecc9c3e73a
   React-timing: dfac299d2afa69272d469c8e5fd4d4328fe41d1e
-  React-utils: 18289f625947da6fb29079dc03e56116a7b72c69
-  ReactAppDependencyProvider: f334cebc0beed0a72490492e978007082c03d533
-  ReactCodegen: 61a05405803e0739e86f180af0a15783cbfded15
-  ReactCommon: c7015b7a01aa9d92794bbfbc513c7e726bef6e49
-  ReactNativeCameraKit: aadaf796360a424596444eda4d2eec1ed960205b
-  ReactNativeExceptionHandler: a23922ca00122b050ae9412f960061791c232c47
-  RNCAsyncStorage: 02516518831d323a25a24300b37a429ff98552b6
-  RNDeviceInfo: d3e91ffb33ee97a7982108476edb68cb3672efa6
-  RNFBApp: 40dddac677bdc020c7669ffc52ed849930b8c694
-  RNFBMessaging: f0760e86d85a314e39281301b4ea3e337ef12d96
-  RNGestureHandler: 25e1da256231856e84fa152639b6b5423bda945d
-  RNKeychain: 3a8b12f0fdd0b967811a48d9e83d582fc2e483eb
-  RNLocalize: 8bf466de4c92d4721b254aabe1ff0a1456e7b9f4
-  RNNotifee: 5e3b271e8ea7456a36eec994085543c9adca9168
-  RNPermissions: 6c9e5f32f6bb4e2102aac9cbab649ddcc58996b6
-  RNReanimated: a5ef17bf8b97678a24158a65703ccd784d558c66
-  RNScreens: cb8aaea32de90c6e43530966cb5b13b76af44b34
-  RNSentry: 04585078c7854f0826b784883d6845d3e2afe865
-  RNSVG: 3430a8d8657420cc09e4e9145e7de99b397fab63
-  RNVectorIcons: 5784330be9dddb5474e8b378d5f6947996c84e55
-  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
+  React-utils: e2960cfd9a7add7a8662a431723b2ca95f5b7a6e
+  ReactAppDependencyProvider: 8955603808eb24bbfde3511d2bcc8362d1d5860e
+  ReactCodegen: ed16d2cfd7bb09a04fbb1d823a349b7730f16ab1
+  ReactCommon: dbf107ea305227130cedc2edfdb5e9d0dabd569b
+  ReactNativeCameraKit: f3283f10137c74883ff41358da403f4e98834e44
+  ReactNativeExceptionHandler: b11ff67c78802b2f62eed0e10e75cb1ef7947c60
+  RNCAsyncStorage: bb040e4d81456fd2f7de5e88b94f0f2fe5a5ce7b
+  RNDeviceInfo: aad3c663b25752a52bf8fce93f2354001dd185aa
+  RNFBApp: 57aef1ee0e7195a8728f8923bfbc2916298ccb3d
+  RNFBMessaging: 51ca431c76f028c1bc84d889cbe8680133d5e429
+  RNGestureHandler: 314905d74b04a5119ebb111de628f3023d6662ca
+  RNKeychain: ff836453cba46938e0e9e4c22e43d43fa2c90333
+  RNLocalize: d4b8af4e442d4bcca54e68fc687a2129b4d71a81
+  RNNotifee: 4a6ee5c7deaf00e005050052d73ee6315dff7ec9
+  RNPermissions: 4afefd69b8d79c6362584699b348709d5ccad0f7
+  RNReanimated: b14414db476f7eb6cd63928a2adb8cc0b21fe76c
+  RNScreens: ef00e90b5ce3f7df17925c4a008dac4da7920b83
+  RNSentry: 9142512356537e39a951e5a9beaae97f3b91c82b
+  RNSVG: fbb121a922cd3aa38454b0cacc7ecfc8476fcf73
+  RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
+  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: fdc0542faa3ba87e56f2030b3f3f2e21bc3ba01c
 
 PODFILE CHECKSUM: 7389f16a87857304211bb25e1b753e4dbb613719
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@react-navigation/native": "7.1.11",
         "@react-navigation/stack": "7.3.4",
         "@reown/walletkit": "1.1.0",
-        "@sentry/react-native": "5.31.0",
+        "@sentry/react-native": "6.10.0",
         "@walletconnect/core": "2.17.0",
         "@walletconnect/react-native-compat": "2.17.0",
         "assert": "2.0.0",
@@ -5357,83 +5357,80 @@
         "@walletconnect/utils": "2.17.0"
       }
     },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.0.tgz",
-      "integrity": "sha512-om8TkAU5CQGO8nkmr7qsSBVkP+/vfeS4JgtW3sjoTK0fhj26+DljR6RlfCGWtYQdPSP6XV7atcPTjbSnsmG9FQ==",
-      "license": "MIT",
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.54.0.tgz",
+      "integrity": "sha512-DKWCqb4YQosKn6aD45fhKyzhkdG7N6goGFDeyTaJFREJDFVDXiNDsYZu30nJ6BxMM7uQIaARhPAC5BXfoED3pQ==",
       "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/core": "8.54.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.54.0.tgz",
+      "integrity": "sha512-nQqRacOXoElpE0L0ADxUUII0I3A94niqG9Z4Fmsw6057QvyrV/LvTiMQBop6r5qLjwMqK+T33iR4/NQI5RhsXQ==",
+      "dependencies": {
+        "@sentry/core": "8.54.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.54.0.tgz",
+      "integrity": "sha512-8xuBe06IaYIGJec53wUC12tY2q4z2Z0RPS2s1sLtbA00EvK1YDGuXp96IDD+HB9mnDMrQ/jW5f97g9TvPsPQUg==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.54.0",
+        "@sentry/core": "8.54.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.0.tgz",
-      "integrity": "sha512-NL02VQx6ekPxtVRcsdp1bp5Tb5w6vnfBKSIfMKuDRBy5A10Uc3GSoy/c3mPyHjOxB84452A+xZSx6bliEzAnuA==",
-      "license": "MIT",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.54.0.tgz",
+      "integrity": "sha512-K/On3OAUBeq/TV2n+1EvObKC+WMV9npVXpVyJqCCyn8HYMm8FUGzuxeajzm0mlW4wDTPCQor6mK9/IgOquUzCw==",
       "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/replay": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry-internal/replay": "8.54.0",
+        "@sentry/core": "8.54.0"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.0.tgz",
-      "integrity": "sha512-oKdFJnn+56f0DHUADlL8o9l8jTib3VDLbWQBVkjD9EprxfaCwt2m8L5ACRBdQ8hmpxCEo4I8/6traZ7qAdBUqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.20.1.tgz",
-      "integrity": "sha512-4mhEwYTK00bIb5Y9UWIELVUfru587Vaeg0DQGswv4aIRHIiMKLyNqCEejaaybQ/fNChIZOKmvyqXk430YVd7Qg==",
-      "license": "MIT",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-3.2.2.tgz",
+      "integrity": "sha512-D+SKQ266ra/wo87s9+UI/rKQi3qhGPCR8eSCDe0VJudhjHsqyNU+JJ5lnIGCgmZaWFTXgdBP/gdr1Iz1zqGs4Q==",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.0.tgz",
-      "integrity": "sha512-WwmW1Y4D764kVGeKmdsNvQESZiAn9t8LmCWO0ucBksrjL2zw9gBPtOpRcO6l064sCLeSxxzCN+kIxhRm1gDFEA==",
-      "license": "MIT",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.54.0.tgz",
+      "integrity": "sha512-BgUtvxFHin0fS0CmJVKTLXXZcke0Av729IVfi+2fJ4COX8HO7/HAP02RKaSQGmL2HmvWYTfNZ7529AnUtrM4Rg==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.119.0",
-        "@sentry-internal/replay-canvas": "7.119.0",
-        "@sentry-internal/tracing": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/integrations": "7.119.0",
-        "@sentry/replay": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry-internal/browser-utils": "8.54.0",
+        "@sentry-internal/feedback": "8.54.0",
+        "@sentry-internal/replay": "8.54.0",
+        "@sentry-internal/replay-canvas": "8.54.0",
+        "@sentry/core": "8.54.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.31.2.tgz",
-      "integrity": "sha512-2aKyUx6La2P+pplL8+2vO67qJ+c1C79KYWAyQBE0JIT5kvKK9JpwtdNoK1F0/2mRpwhhYPADCz3sVIRqmL8cQQ==",
+      "version": "2.42.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.42.4.tgz",
+      "integrity": "sha512-BoSZDAWJiz/40tu6LuMDkSgwk4xTsq6zwqYoUqLU3vKBR/VsaaQGvu6EWxZXORthfZU2/5Agz0+t220cge6VQw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.7",
@@ -5448,20 +5445,19 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "2.31.2",
-        "@sentry/cli-linux-arm": "2.31.2",
-        "@sentry/cli-linux-arm64": "2.31.2",
-        "@sentry/cli-linux-i686": "2.31.2",
-        "@sentry/cli-linux-x64": "2.31.2",
-        "@sentry/cli-win32-i686": "2.31.2",
-        "@sentry/cli-win32-x64": "2.31.2"
+        "@sentry/cli-darwin": "2.42.4",
+        "@sentry/cli-linux-arm": "2.42.4",
+        "@sentry/cli-linux-arm64": "2.42.4",
+        "@sentry/cli-linux-i686": "2.42.4",
+        "@sentry/cli-linux-x64": "2.42.4",
+        "@sentry/cli-win32-i686": "2.42.4",
+        "@sentry/cli-win32-x64": "2.42.4"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.31.2.tgz",
-      "integrity": "sha512-BHA/JJXj1dlnoZQdK4efRCtHRnbBfzbIZUKAze7oRR1RfNqERI84BVUQeKateD3jWSJXQfEuclIShc61KOpbKw==",
-      "license": "BSD-3-Clause",
+      "version": "2.42.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.42.4.tgz",
+      "integrity": "sha512-PZV4Y97VDWBR4rIt0HkJfXaBXlebIN2s/FDzC3iHINZE5OG62CDFsnC4/lbGlf2/UZLDaGGIK7mYwSHhTvN+HQ==",
       "optional": true,
       "os": [
         "darwin"
@@ -5471,13 +5467,12 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.31.2.tgz",
-      "integrity": "sha512-W8k5mGYYZz/I/OxZH65YAK7dCkQAl+wbuoASGOQjUy5VDgqH0QJ8kGJufXvFPM+f3ZQGcKAnVsZ6tFqZXETBAw==",
+      "version": "2.42.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.42.4.tgz",
+      "integrity": "sha512-lBn0oeeg62h68/4Eo6zbPq99Idz5t0VRV48rEU/WKeM4MtQCvG/iGGQ3lBFW2yNiUBzXZIK9poXLEcgbwmcRVw==",
       "cpu": [
         "arm"
       ],
-      "license": "BSD-3-Clause",
       "optional": true,
       "os": [
         "linux",
@@ -5488,13 +5483,12 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.31.2.tgz",
-      "integrity": "sha512-FLVKkJ/rWvPy/ka7OrUdRW63a/z8HYI1Gt8Pr6rWs50hb7YJja8lM8IO10tYmcFE/tODICsnHO9HTeUg2g2d1w==",
+      "version": "2.42.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.42.4.tgz",
+      "integrity": "sha512-Ex8vRnryyzC/9e43daEmEqPS+9uirY/l6Hw2lAvhBblFaL7PTWNx52H+8GnYGd9Zy2H3rWNyBDYfHwnErg38zA==",
       "cpu": [
         "arm64"
       ],
-      "license": "BSD-3-Clause",
       "optional": true,
       "os": [
         "linux",
@@ -5505,14 +5499,13 @@
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.31.2.tgz",
-      "integrity": "sha512-A64QtzaPi3MYFpZ+Fwmi0mrSyXgeLJ0cWr4jdeTGrzNpeowSteKgd6tRKU+LVq0k5shKE7wdnHk+jXnoajulMA==",
+      "version": "2.42.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.42.4.tgz",
+      "integrity": "sha512-IBJg0aHjsLCL4LvcFa3cXIjA+4t5kPqBT9y+PoDu4goIFxYD8zl7mbUdGJutvJafTk8Akf4ss4JJXQBjg019zA==",
       "cpu": [
         "x86",
         "ia32"
       ],
-      "license": "BSD-3-Clause",
       "optional": true,
       "os": [
         "linux",
@@ -5523,13 +5516,12 @@
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.31.2.tgz",
-      "integrity": "sha512-YL/r+15R4mOEiU3mzn7iFQOeFEUB6KxeKGTTrtpeOGynVUGIdq4nV5rHow5JDbIzOuBS3SpOmcIMluvo1NCh0g==",
+      "version": "2.42.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.42.4.tgz",
+      "integrity": "sha512-gXI5OEiOSNiAEz7VCE6AZcAgHJ47mlgal3+NmbE8XcHmFOnyDws9FNie6PJAy8KZjXi3nqoBP9JVAbnmOix3uA==",
       "cpu": [
         "x64"
       ],
-      "license": "BSD-3-Clause",
       "optional": true,
       "os": [
         "linux",
@@ -5540,14 +5532,13 @@
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.31.2.tgz",
-      "integrity": "sha512-Az/2bmW+TFI059RE0mSBIxTBcoShIclz7BDebmIoCkZ+retrwAzpmBnBCDAHow+Yi43utOow+3/4idGa2OxcLw==",
+      "version": "2.42.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.42.4.tgz",
+      "integrity": "sha512-vZuR3UPHKqOMniyrijrrsNwn9usaRysXq78F6WV0cL0ZyPLAmY+KBnTDSFk1Oig2pURnzaTm+RtcZu2fc8mlzg==",
       "cpu": [
         "x86",
         "ia32"
       ],
-      "license": "BSD-3-Clause",
       "optional": true,
       "os": [
         "win32"
@@ -5557,13 +5548,12 @@
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.31.2.tgz",
-      "integrity": "sha512-XIzyRnJu539NhpFa+JYkotzVwv3NrZ/4GfHB/JWA2zReRvsk39jJG8D5HOmm0B9JA63QQT7Dt39RW8g3lkmb6w==",
+      "version": "2.42.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.42.4.tgz",
+      "integrity": "sha512-OIBj3uaQ6nAERSm5Dcf8UIhyElEEwMNsZEEppQpN4IKl0mrwb/57AznM23Dvpu6GR8WGbVQUSolt879YZR5E9g==",
       "cpu": [
         "x64"
       ],
-      "license": "BSD-3-Clause",
       "optional": true,
       "os": [
         "win32"
@@ -5575,14 +5565,12 @@
     "node_modules/@sentry/cli/node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/@sentry/cli/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5594,81 +5582,41 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.0.tgz",
-      "integrity": "sha512-CS2kUv9rAJJEjiRat6wle3JATHypB0SyD7pt4cpX5y0dN5dZ1JrF57oLHRMnga9fxRivydHz7tMTuBhSSwhzjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
-      },
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
+      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/hub": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.119.0.tgz",
-      "integrity": "sha512-183h5B/rZosLxpB+ZYOvFdHk0rwZbKskxqKFtcyPbDAfpCUgCass41UTqyxF6aH1qLgCRxX8GcLRF7frIa/SOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.0.tgz",
-      "integrity": "sha512-OHShvtsRW0A+ZL/ZbMnMqDEtJddPasndjq+1aQXw40mN+zeP7At/V1yPZyFaURy86iX7Ucxw5BtmzuNy7hLyTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0",
-        "localforage": "^1.8.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.119.0.tgz",
-      "integrity": "sha512-cf8Cei+qdSA26gx+IMAuc/k44PeBImNzIpXi3930SLhUe44ypT5OZ/44L6xTODHZzTIyMSJPduf59vT2+eW9yg==",
-      "license": "MIT",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.54.0.tgz",
+      "integrity": "sha512-42T/fp8snYN19Fy/2P0Mwotu4gcdy+1Lx+uYCNcYP1o7wNGigJ7qb27sW7W34GyCCHjoCCfQgeOqDQsyY8LC9w==",
       "dependencies": {
-        "@sentry/browser": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0",
+        "@sentry/browser": "8.54.0",
+        "@sentry/core": "8.54.0",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       },
       "peerDependencies": {
-        "react": "15.x || 16.x || 17.x || 18.x"
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.31.0.tgz",
-      "integrity": "sha512-iflj+SfH2k/vSybC5APTjwdBuW53rQtitD99vRbsMgMTnhcvWMy+ASTf6Shr9czv9uzlYrS83iF/COSyDNwiPQ==",
-      "license": "MIT",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-6.10.0.tgz",
+      "integrity": "sha512-B56vc+pnFHMiu3cabFb454v4qD0zObW6JVzJ5Gb6fIMdt93AFIJg10ZErzC+ump7xM4BOEROFFRuLiyvadvlPA==",
       "dependencies": {
-        "@sentry/babel-plugin-component-annotate": "2.20.1",
-        "@sentry/browser": "7.119.0",
-        "@sentry/cli": "2.31.2",
-        "@sentry/core": "7.119.0",
-        "@sentry/hub": "7.119.0",
-        "@sentry/integrations": "7.119.0",
-        "@sentry/react": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/babel-plugin-component-annotate": "3.2.2",
+        "@sentry/browser": "8.54.0",
+        "@sentry/cli": "2.42.4",
+        "@sentry/core": "8.54.0",
+        "@sentry/react": "8.54.0",
+        "@sentry/types": "8.54.0",
+        "@sentry/utils": "8.54.0"
       },
       "bin": {
         "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
@@ -5684,40 +5632,26 @@
         }
       }
     },
-    "node_modules/@sentry/replay": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.0.tgz",
-      "integrity": "sha512-BnNsYL+X5I4WCH6wOpY6HQtp4MgVt0NVlhLUsEyrvMUiTs0bPkDBrulsgZQBUKJsbOr3l9nHrFoNVB/0i6WNLA==",
-      "license": "MIT",
+    "node_modules/@sentry/types": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.54.0.tgz",
+      "integrity": "sha512-wztdtr7dOXQKi0iRvKc8XJhJ7HaAfOv8lGu0yqFOFwBZucO/SHnu87GOPi8mvrTiy1bentQO5l+zXWAaMvG4uw==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/core": "8.54.0"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.0.tgz",
-      "integrity": "sha512-27qQbutDBPKGbuJHROxhIWc1i0HJaGLA90tjMu11wt0E4UNxXRX+UQl4Twu68v4EV3CPvQcEpQfgsViYcXmq+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.0.tgz",
-      "integrity": "sha512-ZwyXexWn2ZIe2bBoYnXJVPc2esCSbKpdc6+0WJa8eutXfHq3FRKg4ohkfCBpfxljQGEfP1+kfin945lA21Ka+A==",
-      "license": "MIT",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.54.0.tgz",
+      "integrity": "sha512-JL8UDjrsKxKclTdLXfuHfE7B3KbrAPEYP7tMyN/xiO2vsF6D84fjwYyalO0ZMtuFZE6vpSze8ZOLEh6hLnPYsw==",
       "dependencies": {
-        "@sentry/types": "7.119.0"
+        "@sentry/core": "8.54.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sideway/address": {
@@ -7095,7 +7029,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
       "dependencies": {
         "debug": "4"
       },
@@ -12137,7 +12070,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -12241,12 +12173,6 @@
       "engines": {
         "node": ">=16.x"
       }
-    },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -14599,15 +14525,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/lighthouse-logger": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
@@ -14639,15 +14556,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lie": "3.1.1"
-      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -17161,7 +17069,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@react-navigation/native": "7.1.11",
     "@react-navigation/stack": "7.3.4",
     "@reown/walletkit": "1.1.0",
-    "@sentry/react-native": "5.31.0",
+    "@sentry/react-native": "6.10.0",
     "@walletconnect/core": "2.17.0",
     "@walletconnect/react-native-compat": "2.17.0",
     "assert": "2.0.0",


### PR DESCRIPTION
### Context

When trying to build the app using the nix environment I was getting an error, which was fixed by the react native sentry upgrade (https://github.com/getsentry/sentry-react-native/issues/4715).

The nix environment is currently using pod v1.15.2, so I also updated the `Podfile.lock`.

### Acceptance Criteria
- update react native sentry to v6.10.0
- update Podfile.lock

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
