### PR TITLE
fix: nano contract history was using nc_pubkey

### DIFF
--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -198,7 +198,7 @@ function* registerNanoContractOnError(error) {
  * @property {string} nc_blueprint_id
  * @property {string} nc_id
  * @property {string} nc_method
- * @property {string} nc_pubkey
+ * @property {string} nc_address
  * @property {number} nonce
  * @property {Object[]} parents
  * @property {number} signal_bits
@@ -267,11 +267,10 @@ export async function fetchHistory(req) {
     throw new Error('Failed to fetch nano contract history');
   }
 
-  const network = wallet.getNetworkObject();
   // Translate rawNcTxHistory to NcTxHistory
   // Prouce a list ordered from newest to oldest
   const transformedTxHistory = rawHistory.map(async (rawTx) => {
-    const caller = addressUtils.getAddressFromPubkey(rawTx.nc_pubkey, network).base58;
+    const caller = rawTx.nc_address;
     const actions = rawTx.nc_context.actions.map((each) => ({
       type: each.type, // 'deposit' or 'withdrawal'
       uid: each.token_uid,

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -7,7 +7,6 @@
 
 import {
   ncApi,
-  addressUtils,
   nanoUtils,
 } from '@hathor/wallet-lib';
 import {

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -271,7 +271,7 @@ export async function fetchHistory(req) {
   const transformedTxHistory = rawHistory.map(async (rawTx) => {
     const caller = rawTx.nc_address;
     const actions = rawTx.nc_context.actions.map((each) => ({
-      type: each.type, // 'deposit' or 'withdrawal'
+      type: each.type,
       uid: each.token_uid,
       amount: each.amount,
     }));


### PR DESCRIPTION
### Acceptance Criteria
- The nano contract history screen was crashing because it was trying to access `nc_pubkey` which doesn't exist anymore.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
