### PR TITLE
fix: multiple modal nc address seletor

### DIFF
--- a/src/components/NanoContract/EditAddressModal.js
+++ b/src/components/NanoContract/EditAddressModal.js
@@ -40,10 +40,6 @@ export const EditAddressModal = ({ item, show, onAddressChange, onDismiss }) => 
   <ModalBase
     show={show}
     onDismiss={onDismiss}
-    styleModal={{
-      zIndex: 1000,
-      elevation: 1000
-    }}
   >
     <ModalBase.Title>{t`New Nano Contract Address`}</ModalBase.Title>
     <ModalBase.Body style={styles.body}>

--- a/src/components/NanoContract/EditAddressModal.js
+++ b/src/components/NanoContract/EditAddressModal.js
@@ -37,7 +37,14 @@ import { TextValue } from '../TextValue';
  * />
  */
 export const EditAddressModal = ({ item, show, onAddressChange, onDismiss }) => (
-  <ModalBase show={show} onDismiss={onDismiss}>
+  <ModalBase
+    show={show}
+    onDismiss={onDismiss}
+    styleModal={{
+      zIndex: 1000,
+      elevation: 1000
+    }}
+  >
     <ModalBase.Title>{t`New Nano Contract Address`}</ModalBase.Title>
     <ModalBase.Body style={styles.body}>
       <View style={styles.infoContainer}>

--- a/src/components/NanoContract/NanoContractDetailsHeader.js
+++ b/src/components/NanoContract/NanoContractDetailsHeader.js
@@ -26,6 +26,7 @@ import { TextValue } from '../TextValue';
 import { TextLabel } from '../TextLabel';
 import { EditInfoContainer } from '../EditInfoContainer';
 import { SelectAddressModal } from './SelectAddressModal';
+import { EditAddressModal } from './EditAddressModal';
 import { UnregisterNanoContractModal } from './UnregisterNanoContractModal';
 
 /**
@@ -44,16 +45,24 @@ export const NanoContractDetailsHeader = ({ nc, address, onAddressChange }) => {
   const [isShrank, toggleShrank] = useState(true);
   const [selectedAddress, setSelectedAddress] = useState(address);
   const [showSelectAddressModal, setShowSelectAddressModal] = useState(false);
+  const [showEditAddressModal, setShowEditAddressModal] = useState(false);
+  const [selectedItem, setSelectedItem] = useState({ address });
   const [showUnregisterNanoContractModal, setShowUnregisterNanoContractModal] = useState(false);
+  const [modalStep, setModalStep] = useState('select');
 
   const isExpanded = () => !isShrank;
 
   const onEditAddress = () => {
+    setModalStep('select');
     setShowSelectAddressModal(true);
   };
 
   const toggleSelectAddressModal = () => {
     setShowSelectAddressModal(!showSelectAddressModal);
+  };
+
+  const toggleEditAddressModal = () => {
+    setShowEditAddressModal(!showEditAddressModal);
   };
 
   const onUnregisterNanoContract = () => {
@@ -64,10 +73,26 @@ export const NanoContractDetailsHeader = ({ nc, address, onAddressChange }) => {
     setShowUnregisterNanoContractModal(!showUnregisterNanoContractModal);
   };
 
+  const handleEditAddress = (item) => {
+    setSelectedItem(item);
+    setModalStep('edit');
+  };
+
+  const onDismissEditAddressModal = () => {
+    setSelectedItem({ address });
+    setModalStep('select');
+  };
+
   const handleSelectAddress = (pickedAddress) => {
     setSelectedAddress(pickedAddress);
     toggleSelectAddressModal();
     onAddressChange(pickedAddress);
+  };
+
+  const hookAddressChange = (selectedAddress) => {
+    setShowSelectAddressModal(false);
+    setModalStep('select');
+    handleSelectAddress(selectedAddress);
   };
 
   return (
@@ -95,6 +120,11 @@ export const NanoContractDetailsHeader = ({ nc, address, onAddressChange }) => {
           show={showSelectAddressModal}
           onDismiss={toggleSelectAddressModal}
           onSelectAddress={handleSelectAddress}
+          onEditAddress={handleEditAddress}
+          modalStep={modalStep}
+          selectedItem={selectedItem}
+          onDismissEdit={onDismissEditAddressModal}
+          onAddressChange={hookAddressChange}
         />
         <UnregisterNanoContractModal
           ncId={nc.ncId}

--- a/src/components/NanoContract/NanoContractDetailsHeader.js
+++ b/src/components/NanoContract/NanoContractDetailsHeader.js
@@ -26,7 +26,6 @@ import { TextValue } from '../TextValue';
 import { TextLabel } from '../TextLabel';
 import { EditInfoContainer } from '../EditInfoContainer';
 import { SelectAddressModal } from './SelectAddressModal';
-import { EditAddressModal } from './EditAddressModal';
 import { UnregisterNanoContractModal } from './UnregisterNanoContractModal';
 
 /**
@@ -45,7 +44,6 @@ export const NanoContractDetailsHeader = ({ nc, address, onAddressChange }) => {
   const [isShrank, toggleShrank] = useState(true);
   const [selectedAddress, setSelectedAddress] = useState(address);
   const [showSelectAddressModal, setShowSelectAddressModal] = useState(false);
-  const [showEditAddressModal, setShowEditAddressModal] = useState(false);
   const [selectedItem, setSelectedItem] = useState({ address });
   const [showUnregisterNanoContractModal, setShowUnregisterNanoContractModal] = useState(false);
   const [modalStep, setModalStep] = useState('select');
@@ -59,10 +57,6 @@ export const NanoContractDetailsHeader = ({ nc, address, onAddressChange }) => {
 
   const toggleSelectAddressModal = () => {
     setShowSelectAddressModal(!showSelectAddressModal);
-  };
-
-  const toggleEditAddressModal = () => {
-    setShowEditAddressModal(!showEditAddressModal);
   };
 
   const onUnregisterNanoContract = () => {
@@ -89,10 +83,10 @@ export const NanoContractDetailsHeader = ({ nc, address, onAddressChange }) => {
     onAddressChange(pickedAddress);
   };
 
-  const hookAddressChange = (selectedAddress) => {
+  const hookAddressChange = (newSelectedAddress) => {
     setShowSelectAddressModal(false);
     setModalStep('select');
-    handleSelectAddress(selectedAddress);
+    handleSelectAddress(newSelectedAddress);
   };
 
   return (
@@ -106,12 +100,12 @@ export const NanoContractDetailsHeader = ({ nc, address, onAddressChange }) => {
               && <HeaderShrank />}
             {isExpanded()
               && (
-              <HeaderExpanded
-                nc={nc}
-                address={address}
-                onEditAddress={onEditAddress}
-                onUnregisterNanoContract={onUnregisterNanoContract}
-              />
+                <HeaderExpanded
+                  nc={nc}
+                  address={address}
+                  onEditAddress={onEditAddress}
+                  onUnregisterNanoContract={onUnregisterNanoContract}
+                />
               )}
           </View>
         </TouchableWithoutFeedback>

--- a/src/components/NanoContract/NanoContractDetailsHeader.js
+++ b/src/components/NanoContract/NanoContractDetailsHeader.js
@@ -73,6 +73,7 @@ export const NanoContractDetailsHeader = ({ nc, address, onAddressChange }) => {
   };
 
   const onDismissEditAddressModal = () => {
+    // Reset to original address when dismissing edit modal
     setSelectedItem({ address });
     setModalStep('select');
   };

--- a/src/components/NanoContract/SelectAddressModal.js
+++ b/src/components/NanoContract/SelectAddressModal.js
@@ -26,25 +26,30 @@ import errorIcon from '../../assets/images/icErrorBig.png';
 import { selectAddressAddressesRequest } from '../../actions';
 
 /**
- * Use this modal to select an address from the wallet.
+ * A modal component that handles address selection and editing in two steps:
+ * 1. Address selection view - displays list of wallet addresses
+ * 2. Address edit view - shows confirmation screen for selected address
  *
  * @param {Object} props
- * @param {string} props.address It refers to the address selected
- * @param {boolean} props.show It determines if modal must show or hide
- * @param {(address:string) => {}} props.onSelectAddress
- * Callback function called when an address is selected
- * @param {() => {}} props.onDismiss
- * Callback function called to dismiss the modal
- * @param {(item: Object) => {}} props.onEditAddress
- * Callback function called when an address item is selected for editing
+ * @param {string} props.address Current selected address
+ * @param {boolean} props.show Whether the modal is visible
+ * @param {() => void} props.onDismiss Function called to dismiss the modal
+ * @param {(item: Object) => void} props.onEditAddress Function called when an address is selected for editing
+ * @param {string} props.modalStep Current step ('select' or 'edit')
+ * @param {Object} props.selectedItem Currently selected address item
+ * @param {() => void} props.onDismissEdit Function called to dismiss the edit view
+ * @param {(address: string) => void} props.onAddressChange Function called when address change is confirmed
  *
  * @example
  * <SelectAddressModal
  *   address={selectedAddress}
  *   show={showSelectAddressModal}
  *   onDismiss={toggleSelectAddressModal}
- *   onSelectAddress={handleSelectAddress}
  *   onEditAddress={handleEditAddress}
+ *   modalStep={modalStep}
+ *   selectedItem={selectedItem}
+ *   onDismissEdit={onDismissEditAddressModal}
+ *   onAddressChange={hookAddressChange}
  * />
  */
 export const SelectAddressModal = ({
@@ -137,16 +142,15 @@ export const SelectAddressModal = ({
 };
 
 /**
- * It renders and address as an item of the list, also it indicates a match
- * between the current address and the item's address.
+ * Renders an individual address item in the address list.
+ * Highlights the currently selected address and handles item selection.
  *
  * @param {Object} props
- * @param {string} props.currentAddress It refers to the address selected
- * @param {Object} props.item Address of the item
- * @param {string} props.item.address
- * @param {number} props.item.index
- * @param {(address:string) => void} props.onSelectItem
- * Callback function called when an address is selected
+ * @param {string} props.currentAddress Currently selected address
+ * @param {Object} props.item Address item data
+ * @param {string} props.item.address The wallet address
+ * @param {number} props.item.index The address index in the wallet
+ * @param {(item: Object) => void} props.onSelectItem Function called when item is selected
  */
 const AddressItem = ({ currentAddress, item, onSelectItem }) => {
   const onPress = () => {

--- a/src/components/NanoContract/SelectAddressModal.js
+++ b/src/components/NanoContract/SelectAddressModal.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import {
   StyleSheet,
   View,

--- a/src/components/NanoContract/SelectAddressModal.js
+++ b/src/components/NanoContract/SelectAddressModal.js
@@ -123,6 +123,7 @@ export const SelectAddressModal = ({
                   <Text style={styles.infoText}>{t`To change, select other address on the list below.`}</Text>
                   <Text>
                     <TextValue bold>{t`Address`}</TextValue>
+                    {/* the unicode character u00A0 means no-break space. */}
                     <TextValue>{`:${'\u00A0'}${address}`}</TextValue>
                   </Text>
                 </View>

--- a/src/components/NanoContract/SelectAddressModal.js
+++ b/src/components/NanoContract/SelectAddressModal.js
@@ -34,11 +34,13 @@ import { selectAddressAddressesRequest } from '../../actions';
  * @param {string} props.address Current selected address
  * @param {boolean} props.show Whether the modal is visible
  * @param {() => void} props.onDismiss Function called to dismiss the modal
- * @param {(item: Object) => void} props.onEditAddress Function called when an address is selected for editing
+ * @param {(item: Object) => void} props.onEditAddress Function called when and
+ * is selected for editing
  * @param {string} props.modalStep Current step ('select' or 'edit')
  * @param {Object} props.selectedItem Currently selected address item
  * @param {() => void} props.onDismissEdit Function called to dismiss the edit view
- * @param {(address: string) => void} props.onAddressChange Function called when address change is confirmed
+ * @param {(address: string) => void} props.onAddressChange Function called when
+ * address change is confirmed
  *
  * @example
  * <SelectAddressModal


### PR DESCRIPTION


https://github.com/user-attachments/assets/2cca18db-8760-4c12-9131-a2f7be45b722



### Acceptance Criteria
- We should remove the delay before showing children in the BackdropModal as it was not benefiting us in any way and was causing the `SelectAddressModal` to display a small modal before rendering the full content.
- We should change the `SelectAddressModal` modal in NanoContractDetail screen to only show one modal at a time, preventing nested modals which were causing react-native to break
- We should increase the SelectAddressModal size so it's the same size of all other modals

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
