### PR TITLE
chore: update rpc lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/free-regular-svg-icons": "6.7.2",
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-native-fontawesome": "0.3.2",
-        "@hathor/hathor-rpc-handler": "2.1.0",
+        "@hathor/hathor-rpc-handler": "2.2.0",
         "@hathor/unleash-client": "0.1.0",
         "@hathor/wallet-lib": "2.6.0",
         "@json-rpc-tools/utils": "1.7.6",
@@ -3271,9 +3271,9 @@
       }
     },
     "node_modules/@hathor/hathor-rpc-handler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hathor/hathor-rpc-handler/-/hathor-rpc-handler-2.1.0.tgz",
-      "integrity": "sha512-Nrm4bh9Cdbj7ym+dwxNCwyXRZXoMXJT7MGki8booK2zOkWlF+lEaEVS3OOSiVKmccXzvTnxVBqzZpgJ701L8tQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@hathor/hathor-rpc-handler/-/hathor-rpc-handler-2.2.0.tgz",
+      "integrity": "sha512-3wNGqWQQdTWogJCnrhok7+6vL/FMVc2C8T4SfRJIyd/qeeG2ezaPRhONLwpUwuSyprn+jaCIwgyP5p6x4YvvmA==",
       "license": "MIT",
       "dependencies": {
         "@hathor/wallet-lib": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fortawesome/free-regular-svg-icons": "6.7.2",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@fortawesome/react-native-fontawesome": "0.3.2",
-    "@hathor/hathor-rpc-handler": "2.1.0",
+    "@hathor/hathor-rpc-handler": "2.2.0",
     "@hathor/unleash-client": "0.1.0",
     "@hathor/wallet-lib": "2.6.0",
     "@json-rpc-tools/utils": "1.7.6",


### PR DESCRIPTION
### Acceptance Criteria
- We must update `hathor-rpc-handler` to `2.2.0`

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
