### PR TITLE
fix: Payment request bigint issues

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
             ruby
             gnumake
             gettext
+          ] ++ lib.optionals stdenv.isDarwin [
             cocoapods
           ];
         };

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -919,12 +919,24 @@ const onSetTokens = (state, { payload }) => {
     // We have unregistered this token
     selectedToken = DEFAULT_TOKEN;
   }
+
+  // Only allow name, uid and symbol keys for each token
+  const sanitizedTokens = Object.entries(payload).reduce((acc, [uid, token]) => {
+    acc[uid] = {
+      name: token?.name,
+      uid,
+      symbol: token?.symbol,
+    };
+    return acc;
+  }, {});
+
   return {
     ...state,
-    tokens: { ...payload },
+    tokens: sanitizedTokens,
     selectedToken,
   };
 };
+
 /**
  * Set loadHistoryStatus
  */

--- a/src/screens/PaymentRequestDetail.js
+++ b/src/screens/PaymentRequestDetail.js
@@ -15,7 +15,6 @@ import { get } from 'lodash';
 
 import QRCode from 'react-native-qrcode-svg';
 
-import { JSONBigInt } from '@hathor/wallet-lib/lib/utils/bigint';
 import HathorHeader from '../components/HathorHeader';
 import ModalConfirmation from '../components/ModalConfirmation';
 import OfflineBar from '../components/OfflineBar';
@@ -98,31 +97,6 @@ class PaymentRequestDetail extends React.Component {
       />
     );
 
-    /**
-     * Processes inputs and generates the values to be used in the QR code.
-     * @returns {string}
-     */
-    const generateQrCodeValue = () => {
-      let qrCodeValue = 'invalid-qr-code';
-      try {
-        // Removing the unnecessary "balance" from the token object, as it contains bigint values
-        const treatedToken = this.props.token;
-        delete treatedToken.balance;
-
-        qrCodeValue = JSONBigInt.stringify({
-          address: `hathor:${this.props.address}`,
-          // amount is a bigint, so we need to stringify it as
-          // it is not serializable
-          amount: this.props.amount.toString(),
-          token: treatedToken
-        });
-      } catch (e) {
-        console.warn('Error generating QR code value:', e);
-        throw e;
-      }
-      return qrCodeValue;
-    }
-
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         {renderPaymentConfirm()}
@@ -140,7 +114,13 @@ class PaymentRequestDetail extends React.Component {
           }}
           >
             <QRCode
-              value={generateQrCodeValue()}
+              value={JSON.stringify({
+                address: `hathor:${this.props.address}`,
+                // amount is a bigint, so we need to stringify it as
+                // it is not serializable
+                amount: this.props.amount.toString(),
+                token: this.props.token
+              })}
               size={200}
             />
           </View>

--- a/src/screens/PaymentRequestDetail.js
+++ b/src/screens/PaymentRequestDetail.js
@@ -99,12 +99,13 @@ class PaymentRequestDetail extends React.Component {
     );
 
     /**
-     * Fetches and treats the value to be used in the QR code.
+     * Processes inputs and generates the values to be used in the QR code.
      * @returns {string}
      */
-    const fetchQrCodeValue = () => {
+    const generateQrCodeValue = () => {
       let qrCodeValue = 'invalid-qr-code';
       try {
+        // Removing the unnecessary "balance" from the token object, as it contains bigint values
         const treatedToken = this.props.token;
         delete treatedToken.balance;
 
@@ -139,7 +140,7 @@ class PaymentRequestDetail extends React.Component {
           }}
           >
             <QRCode
-              value={fetchQrCodeValue()}
+              value={generateQrCodeValue()}
               size={200}
             />
           </View>

--- a/src/screens/PaymentRequestDetail.js
+++ b/src/screens/PaymentRequestDetail.js
@@ -98,28 +98,27 @@ class PaymentRequestDetail extends React.Component {
       />
     );
 
+    /**
+     * Fetches and treats the value to be used in the QR code.
+     * @returns {string}
+     */
     const fetchQrCodeValue = () => {
       let qrCodeValue = 'invalid-qr-code';
       try {
-        console.log(`Generating QR code value for props:`, {
-          address: this.props.address,
-          amount: this.props.amount,
-          token: this.props.token
-        });
-        console.log(`Is there a good environment?`, { json: JSON, isRawJson: JSON.isRawJson, jsonRaw: JSON.rawJSON });
+        const treatedToken = this.props.token;
+        delete treatedToken.balance;
 
         qrCodeValue = JSONBigInt.stringify({
           address: `hathor:${this.props.address}`,
           // amount is a bigint, so we need to stringify it as
           // it is not serializable
-          amount: this.props.amount,
-          token: this.props.token
+          amount: this.props.amount.toString(),
+          token: treatedToken
         });
       } catch (e) {
         console.warn('Error generating QR code value:', e);
         throw e;
       }
-      console.log(`QR code value generated: ${qrCodeValue}`);
       return qrCodeValue;
     }
 

--- a/src/screens/PaymentRequestDetail.js
+++ b/src/screens/PaymentRequestDetail.js
@@ -15,6 +15,7 @@ import { get } from 'lodash';
 
 import QRCode from 'react-native-qrcode-svg';
 
+import { JSONBigInt } from '@hathor/wallet-lib/lib/utils/bigint';
 import HathorHeader from '../components/HathorHeader';
 import ModalConfirmation from '../components/ModalConfirmation';
 import OfflineBar from '../components/OfflineBar';
@@ -97,6 +98,31 @@ class PaymentRequestDetail extends React.Component {
       />
     );
 
+    const fetchQrCodeValue = () => {
+      let qrCodeValue = 'invalid-qr-code';
+      try {
+        console.log(`Generating QR code value for props:`, {
+          address: this.props.address,
+          amount: this.props.amount,
+          token: this.props.token
+        });
+        console.log(`Is there a good environment?`, { json: JSON, isRawJson: JSON.isRawJson, jsonRaw: JSON.rawJSON });
+
+        qrCodeValue = JSONBigInt.stringify({
+          address: `hathor:${this.props.address}`,
+          // amount is a bigint, so we need to stringify it as
+          // it is not serializable
+          amount: this.props.amount,
+          token: this.props.token
+        });
+      } catch (e) {
+        console.warn('Error generating QR code value:', e);
+        throw e;
+      }
+      console.log(`QR code value generated: ${qrCodeValue}`);
+      return qrCodeValue;
+    }
+
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         {renderPaymentConfirm()}
@@ -114,13 +140,7 @@ class PaymentRequestDetail extends React.Component {
           }}
           >
             <QRCode
-              value={JSON.stringify({
-                address: `hathor:${this.props.address}`,
-                // amount is a bigint, so we need to stringify it as
-                // it is not serializable
-                amount: this.props.amount.toString(),
-                token: this.props.token
-              })}
+              value={fetchQrCodeValue()}
               size={200}
             />
           </View>


### PR DESCRIPTION
### Motivation
In some hard-to-define cases the Payment Request QR Code was crashing the app. This happened because the `token` object passed as parameter had the `balances` populated in it, containing bigint values.

Since those values are not necessary for the QR generation, they were simply removed from redux through the reducer.

### Acceptance Criteria
- Fixes a BigInt issue happening when a Payment Request QR Code was being built
- Adjusts the Flake nix file to also work in Linux distros

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
