### PR TITLE
fix: reject on wallet not ready

### DIFF
--- a/src/sagas/reown.js
+++ b/src/sagas/reown.js
@@ -873,6 +873,7 @@ export function* handleDAppRequest(payload, modalType, options = {}) {
 
   if (!wallet.isReady()) {
     log.error('Got a session request but wallet is not ready.');
+    denyCb();
     return;
   }
 


### PR DESCRIPTION
### Acceptance Criteria
- We should reject requests if the wallet is not ready instead of just returning (which causes the app to never react to new requests)

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
