### PR TITLE
chore: Upgrades android target SDK to 35

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
         compileSdkVersion = 35
-        targetSdkVersion = 34
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
         kotlin_version = kotlinVersion // Used by react-native-camera-kit


### PR DESCRIPTION
### Acceptance Criteria
- The application build process should target Android SDK 34

Reference of the latest iteration: 
- #582

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
