### PR TITLE
fix: fetch all addresses should be called only once for the send nano reown screen

### DIFF
--- a/src/components/BackdropModal.js
+++ b/src/components/BackdropModal.js
@@ -308,6 +308,7 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.backgroundColor,
     borderRadius: 8,
     padding: 16,
+    alignSelf: 'stretch',
   },
 });
 

--- a/src/components/NanoContract/NanoContractDetails.js
+++ b/src/components/NanoContract/NanoContractDetails.js
@@ -17,7 +17,11 @@ import { t } from 'ttag';
 import { NanoContractDetailsHeader } from './NanoContractDetailsHeader';
 import { NanoContractTransactionsListItem } from './NanoContractTransactionsListItem';
 import { COLORS } from '../../styles/themes';
-import { nanoContractAddressChangeRequest, nanoContractHistoryRequest } from '../../actions';
+import {
+  nanoContractAddressChangeRequest,
+  nanoContractHistoryRequest,
+  selectAddressAddressesRequest,
+} from '../../actions';
 import { HathorFlatList } from '../HathorFlatList';
 import Spinner from '../Spinner';
 import errorIcon from '../../assets/images/icErrorBig.png';
@@ -79,6 +83,11 @@ export const NanoContractDetails = ({ nc }) => {
   const navigatesToNanoContractTransaction = (tx) => {
     navigation.navigate('NanoContractTransactionScreen', { tx });
   };
+
+  // Request addresses for selection in list when component mounts
+  useEffect(() => {
+    dispatch(selectAddressAddressesRequest());
+  }, []);
 
   // This effect runs only once when the component is first built.
   useEffect(() => {

--- a/src/components/NanoContract/SelectAddressModal.js
+++ b/src/components/NanoContract/SelectAddressModal.js
@@ -71,10 +71,6 @@ export const SelectAddressModal = ({
     onEditAddress(item);
   };
 
-  useEffect(() => {
-    dispatch(selectAddressAddressesRequest());
-  }, []);
-
   const hasFailed = () => error;
   const isLoading = () => !error && addresses.length === 0;
   const hasLoaded = () => !error && addresses.length > 0;

--- a/src/components/NanoContract/SelectAddressModal.js
+++ b/src/components/NanoContract/SelectAddressModal.js
@@ -23,6 +23,7 @@ import { TextLabel } from '../TextLabel';
 import { EditAddressModal } from './EditAddressModal';
 import { FeedbackContent } from '../FeedbackContent';
 import SimpleButton from '../SimpleButton';
+import Spinner from '../Spinner';
 import errorIcon from '../../assets/images/icErrorBig.png';
 import { selectAddressAddressesRequest } from '../../actions';
 
@@ -114,6 +115,7 @@ export const SelectAddressModal = ({
           {isLoading()
             && (
               <FeedbackContent
+                icon={(<Spinner size={48} />)}
                 title={t`Loading`}
                 message={t`Loading wallet addresses.`}
                 offcard

--- a/src/components/NanoContract/SelectAddressModal.js
+++ b/src/components/NanoContract/SelectAddressModal.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   StyleSheet,
   View,

--- a/src/components/NanoContract/SelectAddressModal.js
+++ b/src/components/NanoContract/SelectAddressModal.js
@@ -22,6 +22,7 @@ import { TextValue } from '../TextValue';
 import { TextLabel } from '../TextLabel';
 import { EditAddressModal } from './EditAddressModal';
 import { FeedbackContent } from '../FeedbackContent';
+import SimpleButton from '../SimpleButton';
 import errorIcon from '../../assets/images/icErrorBig.png';
 import { selectAddressAddressesRequest } from '../../actions';
 
@@ -67,6 +68,10 @@ export const SelectAddressModal = ({
   const dispatch = useDispatch();
   const { addresses, error } = useSelector((state) => state.selectAddressModal);
 
+  const onRetryLoadAddresses = () => {
+    dispatch(selectAddressAddressesRequest());
+  }
+
   const onSelectItem = (item) => {
     onEditAddress(item);
   };
@@ -102,6 +107,7 @@ export const SelectAddressModal = ({
                 icon={(<Image source={errorIcon} style={styles.feedbackContentIcon} resizeMode='contain' />)}
                 title={t`Load Addresses Error`}
                 message={error}
+                action={(<SimpleButton title={t`Retry`} onPress={onRetryLoadAddresses} />)}
                 offcard
               />
             )}

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -812,8 +812,6 @@ export function* fetchAllWalletAddresses() {
     const feedbackErrorMsg = t`Wallet is not ready to load addresses.`;
     // This will show the message in the feedback content at SelectAddressModal
     yield put(selectAddressAddressesFailure({ error: feedbackErrorMsg }));
-    // This will show user an error modal with the option to send the error to sentry.
-    yield put(onExceptionCaptured(new Error(errorMsg), false));
     return;
   }
 


### PR DESCRIPTION
### Motivation

https://github.com/HathorNetwork/hathor-wallet-mobile/issues/727

The `SelectAddressModal` screen was calling `selectAddressAddressesRequest` in a `useEffect` and this component was used by the `BaseNanoContractRequest`, which is also calling `selectAddressAddressesRequest`. This by itself was a bug, we were calling the same method twice.

However, the `BaseNanoContractRequest` re-renders changing its content after the user types the PIN, so the screen can show a loading while the transaction is mined and sent to the network. After the loading, we show a `SuccessFeedbackScreen` and call `dispatch(statusConfig.setReadyAction());` which once again re-renders the   `BaseNanoContractRequest` component and makes `SelectAddressModal` component to mount again and call `selectAddressAddressesRequest` once more. So the method `selectAddressAddressesRequest` was being called three times when a screen to send nano tx using Reown was shown.

The last time was right after the tx was pushed to the network, and in the wallet lib we have this piece of code in the `onNewTx` method:

```ts
    // set state to processing and save current state.
    const previousState = this.state;
    this.state = HathorWallet.PROCESSING;
    if (isNewTx) {
      // Process this single transaction.
      // Handling new metadatas and deleting utxos that are not available anymore
      await this.storage.processNewTx(newTx);
    } else if (storageTx.is_voided !== newTx.is_voided) {
      // This is a voided transaction update event.
      // voided transactions require a full history reprocess.
      await this.storage.processHistory();
    } else {
      // Process other types of metadata updates.
      await processMetadataChanged(this.storage, newTx);
    }
    // restore previous state
    this.state = previousState;
```

We change the wallet state to `PROCESSING` for some time, and the `fetchAllWalletAddresses` saga (which is called by the action `selectAddressAddressesRequest`) has a check of wallet state (`if (!wallet.isReady()) {`). In this async call, we might get to this method while in the middle of a PROCESSING state.

I think we should discuss better these state changes and maybe improve the `wallet.isReady` condition but for the meantime, this change fixes the error modal that is appearing sometimes when sending a nano tx.

### Acceptance Criteria

- Screens that execute fetch all addresses action should have this call only once.
- Add retry button to the SelectAddressModal screen
- Stop showing error modal if fetchAllAddresses fail



https://github.com/user-attachments/assets/5c50bc90-4079-41b0-be6b-2776d69b14a9


