### PR TITLE
feat: update feature flags on network change

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1028,6 +1028,7 @@ export const networkSettingsUpdateRequest = (customNetworkRequest) => ({
  * @param {{
  *   stage: string,
  *   network: string,
+ *   fullNetwork: string,
  *   nodeUrl: string,
  *   explorerUrl: string,
  *   txMiningServiceUrl: string,
@@ -1046,6 +1047,7 @@ export const networkSettingsUpdateState = (customNetwork) => ({
  * @param {{
  *   stage: string,
  *   network: string,
+ *   fullNetwork: string,
  *   nodeUrl: string,
  *   explorerUrl: string,
  *   explorerServiceUrl: string,

--- a/src/constants.js
+++ b/src/constants.js
@@ -188,6 +188,7 @@ export const REOWN_PROJECT_ID = '8264fff563181da658ce64ee80e80458';
 export const STAGE_DEV_PRIVNET = 'dev-privnet';
 export const STAGE_TESTNET = 'testnet';
 export const NETWORK_TESTNET = 'testnet';
+export const FULL_NETWORK_TESTNET = 'testnet';
 export const WALLET_SERVICE_TESTNET_BASE_URL = 'https://wallet-service.testnet.hathor.network/';
 export const WALLET_SERVICE_TESTNET_BASE_WS_URL = 'wss://ws.wallet-service.testnet.hathor.network/';
 export const NODE_SERVER_TESTNET_URL = 'https://node1.testnet.hathor.network/v1a/';
@@ -197,6 +198,7 @@ export const TX_MINING_SERVICE_TESTNET_URL = 'https://txmining.testnet.hathor.ne
 
 // Nano testnet settings:
 export const NETWORK_NANO_TESTNET = 'testnet';
+export const FULL_NETWORK_NANO_TESTNET = 'nano-testnet-bravo';
 export const NODE_SERVER_NANO_TESTNET_URL = 'https://node1.bravo.nano-testnet.hathor.network/v1a/';
 export const EXPLORER_NANO_TESTNET_URL = 'https://explorer.bravo.nano-testnet.hathor.network/';
 export const TX_MINING_SERVICE_NANO_TESTNET_URL = 'https://txmining.bravo.nano-testnet.hathor.network/';
@@ -204,6 +206,7 @@ export const TX_MINING_SERVICE_NANO_TESTNET_URL = 'https://txmining.bravo.nano-t
 export const PRE_SETTINGS_NANO_TESTNET = {
   stage: STAGE_TESTNET,
   network: NETWORK_NANO_TESTNET,
+  fullNetwork: FULL_NETWORK_NANO_TESTNET,
   nodeUrl: NODE_SERVER_NANO_TESTNET_URL,
   explorerUrl: EXPLORER_NANO_TESTNET_URL,
   explorerServiceUrl: EXPLORER_SERVICE_TESTNET_URL,
@@ -213,6 +216,7 @@ export const PRE_SETTINGS_NANO_TESTNET = {
 export const PRE_SETTINGS_TESTNET = {
   stage: STAGE_TESTNET,
   network: NETWORK_TESTNET,
+  fullNetwork: FULL_NETWORK_TESTNET,
   walletServiceUrl: WALLET_SERVICE_TESTNET_BASE_URL,
   walletServiceWsUrl: WALLET_SERVICE_TESTNET_BASE_WS_URL,
   nodeUrl: NODE_SERVER_TESTNET_URL,
@@ -221,6 +225,7 @@ export const PRE_SETTINGS_TESTNET = {
   txMiningServiceUrl: TX_MINING_SERVICE_TESTNET_URL,
 };
 
+export const FULL_NETWORK_MAINNET = 'mainnet';
 export const NODE_SERVER_MAINNET_URL = 'https://mobile.wallet.hathor.network/v1a/';
 export const EXPLORER_MAINNET_URL = 'https://explorer.hathor.network/';
 export const EXPLORER_SERVICE_MAINNET_URL = 'https://explorer-service.hathor.network/';
@@ -229,6 +234,7 @@ export const TX_MINING_SERVICE_MAINNET_URL = 'https://txmining.mainnet.hathor.ne
 export const PRE_SETTINGS_MAINNET = {
   stage: STAGE,
   network: NETWORK_MAINNET,
+  fullNetwork: FULL_NETWORK_MAINNET,
   walletServiceUrl: WALLET_SERVICE_MAINNET_BASE_URL,
   walletServiceWsUrl: WALLET_SERVICE_MAINNET_BASE_WS_URL,
   nodeUrl: NODE_SERVER_MAINNET_URL,

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -334,6 +334,7 @@ const initialState = {
    * @param {{
    *  stage: string;
    *  network: string;
+   *  fullNetwork: string;
    *  nodeUrl: string;
    *  explorerUrl: string;
    *  explorerServiceUrl: string;

--- a/src/sagas/featureToggle.js
+++ b/src/sagas/featureToggle.js
@@ -28,10 +28,10 @@ import {
   featureToggleInitialized,
 } from '../actions';
 import {
+  networkSettingsKeyMap,
   UNLEASH_URL,
   UNLEASH_CLIENT_KEY,
   UNLEASH_POLLING_INTERVAL,
-  STAGE,
   FEATURE_TOGGLE_DEFAULTS,
 } from '../constants';
 import { disableFeaturesIfNeeded } from './helpers';
@@ -94,14 +94,25 @@ export function* handleToggleUpdate() {
   yield put({ type: types.FEATURE_TOGGLE_UPDATED });
 }
 
-export function* monitorFeatureFlags(currentRetry = 0) {
+export function* monitorFeatureFlags(currentRetry = 0, createRoutine = true) {
+  let stage, fullNetwork;
+  // We try to get the network settings from the storage (which is updated as soon
+  // as we persist the networkSettings update) and if it's empty, we get the default state
+  const networkSettingsStorage = STORE.getItem(networkSettingsKeyMap.networkSettings);
+  if (networkSettingsStorage) {
+    ({ stage, fullNetwork } = networkSettingsStorage);
+  } else {
+    const networkSettingsState = yield select((state) => state.networkSettings);
+    ({ stage, fullNetwork } = networkSettingsState);
+  }
   const { appVersion } = VersionNumber;
 
   const options = {
     userId: getUniqueId(),
     properties: {
       platform: Platform.OS,
-      stage: STAGE,
+      stage,
+      fullNetwork,
       appVersion,
     },
   };
@@ -120,8 +131,12 @@ export function* monitorFeatureFlags(currentRetry = 0) {
 
     yield call(() => unleashClient.fetchToggles());
 
-    // Fork the routine to download toggles.
-    yield fork(fetchTogglesRoutine);
+    // We need to fork it only once, so when we call this method
+    // after a network change, we don't need to create the routine again
+    if (createRoutine) {
+      // Fork the routine to download toggles.
+      yield fork(fetchTogglesRoutine);
+    }
 
     // At this point, unleashClient.fetchToggles() already fetched the toggles
     // (this will throw if it hasn't)

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -31,6 +31,7 @@ import {
 } from './helpers';
 import { STORE } from '../store';
 import { isWalletServiceEnabled } from './wallet';
+import { monitorFeatureFlags } from './featureToggle';
 import { logger } from '../logger';
 
 const log = logger('network-settings-saga');
@@ -208,6 +209,7 @@ export function* updateNetworkSettings(action) {
   const customNetwork = {
     stage,
     network,
+    fullNetwork: potentialNetwork,
     nodeUrl,
     explorerUrl,
     explorerServiceUrl,
@@ -286,6 +288,10 @@ export function* persistNetworkSettings(action) {
 
   // Reset network name when changing networks
   yield put(setFullNodeNetworkName(''));
+
+  // After we persist the network settings, we must create a new unleash
+  // client because the network/stage might have changed
+  yield call(monitorFeatureFlags, 0, false);
 
   // Dispatch network changed so listeners can use it in other sagas
   // e.g. the Reown saga uses this to clear sessions


### PR DESCRIPTION
### Motivation

We were only fetching feature flags for mainnet stage (which was hardcoded from constants) because we were never updating the unleash client after a network settings change.

### Acceptance Criteria
- Update the unleash client on network settings change
- Use network settings stage for the unleash client
- Send to unleash a full network, so we can also create feature strategies for specific networks, e.g., `nano-bravo-testnet`, not only `testnet`.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
