### PR TITLE
fix: we must update unleash client in the first load if we have a custom network settings

### DIFF
--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -31,7 +31,6 @@ import {
 } from './helpers';
 import { STORE } from '../store';
 import { isWalletServiceEnabled } from './wallet';
-import { monitorFeatureFlags } from './featureToggle';
 import { logger } from '../logger';
 
 const log = logger('network-settings-saga');
@@ -288,10 +287,6 @@ export function* persistNetworkSettings(action) {
 
   // Reset network name when changing networks
   yield put(setFullNodeNetworkName(''));
-
-  // After we persist the network settings, we must create a new unleash
-  // client because the network/stage might have changed
-  yield call(monitorFeatureFlags, 0, false);
 
   // Dispatch network changed so listeners can use it in other sagas
   // e.g. the Reown saga uses this to clear sessions

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -84,6 +84,7 @@ import {
   getRegisteredTokenUids,
   progressiveRetryRequest,
 } from './helpers';
+import { monitorFeatureFlags } from './featureToggle';
 import {
   getAllAddresses,
   getFirstAddress,
@@ -182,6 +183,9 @@ export function* startWallet(action) {
     // If the wallet is initialized from quit state it must
     // update the network settings on redux state
     yield put(networkSettingsUpdateState(networkSettings));
+
+    // and we also must update the unleash client for the custom network settings
+    yield call(monitorFeatureFlags, 0, false);
   } else {
     networkSettings = yield select(getNetworkSettings);
   }


### PR DESCRIPTION
### Motivation

The first load of the wallet with a custom network settings was not creating an unleash client with the correct parameters.

Note: maybe we should refactor the feature toggle saga to only start the client on wallet load but spawn the routine to update flags only once. I decided not to do it to fix the bug first but a refactor might be discussed for the future.

### Acceptance Criteria
- Update the unleash client in the wallet load (to include the first load case)

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
