### PR TITLE
feat: remove nano bravo testnet from network pre settings screen

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -196,23 +196,6 @@ export const EXPLORER_TESTNET_URL = 'https://explorer.testnet.hathor.network/';
 export const EXPLORER_SERVICE_TESTNET_URL = 'https://explorer-service.testnet.hathor.network/';
 export const TX_MINING_SERVICE_TESTNET_URL = 'https://txmining.testnet.hathor.network/';
 
-// Nano testnet settings:
-export const NETWORK_NANO_TESTNET = 'testnet';
-export const FULL_NETWORK_NANO_TESTNET = 'nano-testnet-bravo';
-export const NODE_SERVER_NANO_TESTNET_URL = 'https://node1.bravo.nano-testnet.hathor.network/v1a/';
-export const EXPLORER_NANO_TESTNET_URL = 'https://explorer.bravo.nano-testnet.hathor.network/';
-export const TX_MINING_SERVICE_NANO_TESTNET_URL = 'https://txmining.bravo.nano-testnet.hathor.network/';
-
-export const PRE_SETTINGS_NANO_TESTNET = {
-  stage: STAGE_TESTNET,
-  network: NETWORK_NANO_TESTNET,
-  fullNetwork: FULL_NETWORK_NANO_TESTNET,
-  nodeUrl: NODE_SERVER_NANO_TESTNET_URL,
-  explorerUrl: EXPLORER_NANO_TESTNET_URL,
-  explorerServiceUrl: EXPLORER_SERVICE_TESTNET_URL,
-  txMiningServiceUrl: TX_MINING_SERVICE_NANO_TESTNET_URL,
-};
-
 export const PRE_SETTINGS_TESTNET = {
   stage: STAGE_TESTNET,
   network: NETWORK_TESTNET,

--- a/src/screens/NetworkSettings/NetworkPreSettingsScreen.js
+++ b/src/screens/NetworkSettings/NetworkPreSettingsScreen.js
@@ -19,7 +19,7 @@ import NewHathorButton from '../../components/NewHathorButton';
 import Spinner from '../../components/Spinner';
 import FeedbackModal from '../../components/FeedbackModal';
 import { networkSettingsPersistStore, networkSettingsUpdateReady } from '../../actions';
-import { PRE_SETTINGS_MAINNET, PRE_SETTINGS_NANO_TESTNET, PRE_SETTINGS_TESTNET } from '../../constants';
+import { PRE_SETTINGS_MAINNET, PRE_SETTINGS_TESTNET } from '../../constants';
 import { CustomNetworkSettingsNav } from './CustomNetworkSettingsScreen';
 import { feedbackSucceedText, feedbackFailedText, feedbackLoadingText, hasFailed, isLoading, hasSucceeded } from './helper';
 import errorIcon from '../../assets/images/icErrorBig.png';
@@ -81,9 +81,6 @@ export function NetworkPreSettingsScreen({ navigation }) {
   const networkSettingsStatus = useSelector((state) => state.networkSettingsStatus);
   const setMainnetNetwork = () => dispatch(networkSettingsPersistStore(PRE_SETTINGS_MAINNET));
   const setTestnetNetwork = () => dispatch(networkSettingsPersistStore(PRE_SETTINGS_TESTNET));
-  const setNanoTestnetNetwork = () => dispatch(
-    networkSettingsPersistStore(PRE_SETTINGS_NANO_TESTNET),
-  );
   const setCustomNetwork = () => {
     navigation.push(CustomNetworkSettingsNav);
   };
@@ -128,7 +125,6 @@ export function NetworkPreSettingsScreen({ navigation }) {
       <View style={styles.content}>
         <CustomNetwork title='Mainnet' url={PRE_SETTINGS_MAINNET.nodeUrl} onPress={setMainnetNetwork} />
         <CustomNetwork title='Testnet' url={PRE_SETTINGS_TESTNET.nodeUrl} onPress={setTestnetNetwork} />
-        <CustomNetwork title='Nano Testnet' url={PRE_SETTINGS_NANO_TESTNET.nodeUrl} onPress={setNanoTestnetNetwork} />
         <View style={styles.buttonContainer}>
           <NewHathorButton
             onPress={setCustomNetwork}


### PR DESCRIPTION
### Motivation

Nano testnet bravo is outdated because the latest full node version is not compatible with it. All nano tests are already happening in the hotel testnet, so we can remove it from the pre settings screen to make it cleaner.

### Acceptance Criteria
- Remove nano bravo testnet from network pre settings screen

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
