### PR TITLE
chore: bumped rpc-handler to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/free-regular-svg-icons": "6.7.2",
         "@fortawesome/free-solid-svg-icons": "6.7.2",
         "@fortawesome/react-native-fontawesome": "0.3.2",
-        "@hathor/hathor-rpc-handler": "3.4.0",
+        "@hathor/hathor-rpc-handler": "3.4.1",
         "@hathor/unleash-client": "0.1.0",
         "@hathor/wallet-lib": "2.9.0",
         "@json-rpc-tools/utils": "1.7.6",
@@ -3289,9 +3289,9 @@
       }
     },
     "node_modules/@hathor/hathor-rpc-handler": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@hathor/hathor-rpc-handler/-/hathor-rpc-handler-3.4.0.tgz",
-      "integrity": "sha512-sPH1i2CMn6ywN1Kdnr59o4WqnTXck8GlFpeaHHHhK8MzGM+DeVxv8CcV2zPeczNNp8adgs5XYOv1PltUDSL+/w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@hathor/hathor-rpc-handler/-/hathor-rpc-handler-3.4.1.tgz",
+      "integrity": "sha512-fNekSG3fCdth9tAgdJEHegxSntCJtrTgXe+jyC9vKDmvGF6ePaWDFLUnFelW5n1yPN9ENeNRv90Jz0PPQ8Kzcw==",
       "license": "MIT",
       "dependencies": {
         "@hathor/wallet-lib": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fortawesome/free-regular-svg-icons": "6.7.2",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@fortawesome/react-native-fontawesome": "0.3.2",
-    "@hathor/hathor-rpc-handler": "3.4.0",
+    "@hathor/hathor-rpc-handler": "3.4.1",
     "@hathor/unleash-client": "0.1.0",
     "@hathor/wallet-lib": "2.9.0",
     "@json-rpc-tools/utils": "1.7.6",


### PR DESCRIPTION
### Acceptance Criteria
- Updated hathor-rpc-handler to v3.4.1

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
