### PR TITLE
fix: token details does not have value.id

### DIFF
--- a/src/sagas/reown.js
+++ b/src/sagas/reown.js
@@ -153,7 +153,7 @@ function convertAndStoreTokenDetails(tokenDetailsMap, dispatch) {
     Array.from(tokenDetailsMap.entries()).map(([key, value]) => [
       key,
       {
-        uid: value.tokenInfo.id,
+        uid: key,
         name: value.tokenInfo.name,
         symbol: value.tokenInfo.symbol,
       },


### PR DESCRIPTION
### Context

The wallet service facade was returning `id` in the TokenInfo object and the old facade wasn't. I'm fixing it directly here, and will create a PR in the wallet lib as well to fix it.

### Acceptance Criteria
- Set token details uid correctly for RPC lib requests

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
