### PR TITLE
fix: show error modal if it fails to register nano

### DIFF
--- a/src/components/Reown/NanoContract/BaseNanoContractRequest.js
+++ b/src/components/Reown/NanoContract/BaseNanoContractRequest.js
@@ -424,14 +424,12 @@ export const BaseNanoContractRequest = ({
 
   if (notRegistered && hasNcRegisterFailed) {
     return (
-      <>
-        <FeedbackModal
-          icon={(<Image source={errorIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
-          text={t`Error while registering Nano Contract.`}
-          onDismiss={onDeclineConfirmation}
-          action={(<NewHathorButton discrete title={t`Decline Transaction`} onPress={onDeclineConfirmation} />)}
-        />
-      </>
+      <FeedbackModal
+        icon={(<Image source={errorIcon} style={styles.feedbackModalIcon} resizeMode='contain' />)}
+        text={t`Error while registering Nano Contract.`}
+        onDismiss={onDeclineConfirmation}
+        action={(<NewHathorButton discrete title={t`Decline Transaction`} onPress={onDeclineConfirmation} />)}
+      />
     );
   }
 


### PR DESCRIPTION
### Acceptance Criteria
- Show error modal if it fails to register nano in the Reown modal screen


https://github.com/user-attachments/assets/bec37ae3-9237-4bc3-a7f5-d4560c308e40


Previously (with the bug)


https://github.com/user-attachments/assets/bd6feacd-8d52-408a-a97e-68ab3a659fe4



### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
