### PR TITLE
fix: broken modals

### DIFF
--- a/src/components/BackdropModal.js
+++ b/src/components/BackdropModal.js
@@ -254,7 +254,7 @@ const BackdropModal = ({
   return (
     <View
       style={styles.modalContainer}
-      pointerEvents="box-none" // Allow touches to pass through to backdrop/content
+      pointerEvents='box-none' // Allow touches to pass through to backdrop/content
     >
       <Animated.View
         style={[
@@ -263,7 +263,8 @@ const BackdropModal = ({
             backgroundColor: backdropColor,
             opacity: backdropOpacity,
           },
-        ]}>
+        ]}
+      >
         <View style={getContainerStyle()}>
           {/* Backdrop touch areas */}
           {enableBackdropPress && (
@@ -276,7 +277,8 @@ const BackdropModal = ({
           {visible && showChildren && (
             <Animated.View
               style={getContentStyle()}
-              {...(enableSwipeToDismiss ? panResponder.panHandlers : {})}>
+              {...(enableSwipeToDismiss ? panResponder.panHandlers : {})}
+            >
               {children}
             </Animated.View>
           )}


### PR DESCRIPTION
## Summary

Before:

https://github.com/user-attachments/assets/67b8ebf0-1010-48f5-a65d-b0b5f796bfdb


After:

https://github.com/user-attachments/assets/5acddea7-97ae-471b-a403-24144e4807cb



**The Bug:**
Native Modal component's view persisted at the native layer even after React component unmounted, causing ghost modals to flash during navigation.

**The Fix:**
Replaced react-native `Modal` with absolute-positioned View in the same React tree. When React unmounts the component, the View is guaranteed gone

| Con                            | Our Solution                                         |
|--------------------------------|------------------------------------------------------|
| No auto Android back button    | Already handled by useBackButtonHandler hook    |
| Z-index conflicts possible     | Using z-index 9999 - conflicts extremely unlikely    |
| No built-in keyboard avoidance | We already wrap content with KeyboardAvoidingView in our screens |
| Status bar stays visible       | trade-off vs ghost modal bugs             |
| Performance on complex screens | Not an issue for this app               |

### Acceptance Criteria
- We must replace the react-native `Modal` component with a simple `View` component so our modals are dealt with in the javascript layer
- All existing modals work without code changes
- No ghost modals flash during navigation
- Modal must unmount cleanly when component unmounts
- All animations must work (slide, fade, swipe-to-dismiss)
- Backdrop press and gesture dismissal must be functional

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
