### PR TITLE
fix: 16KB page alignment for legacy

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,11 +89,12 @@ android {
         missingDimensionStrategy "react-native-camera", "general"
     }
 
-    // Prevents compression of native libraries (.so files) to preserve 16KB page alignment
-    // from NDK r29. Compression would break the alignment even if NDK compiles it correctly.
+    // Enable legacy packaging to keep native libraries (.so files) compressed in the APK.
+    // This preserves 16KB page alignment required by Google Play for Android 15+ devices.
+    // NDK r29 compiles with proper alignment, and this packaging option maintains it.
     packagingOptions {
         jniLibs {
-            useLegacyPackaging = false
+            useLegacyPackaging = true
         }
     }
     signingConfigs {


### PR DESCRIPTION
### Motivation
We could not fix the 16kb page issue with #757 and we're trying a new approach to solve it.

### Acceptance Criteria
- The app complies with the Google Play requirement for apps to support 16KB memory page sizes on Android

### Notes
An obsevation on why the previous approach didn't work and what could be done if this current attempt is not enough:
> The previous value (false) was contradicting the goal. With NDK r29 and AGP 8.7.2, setting `useLegacyPackaging = true` ensures that native libraries maintain their 16KB alignment during the packaging process, which is what Google Play requires for Android 15+ devices.
> 
> If this doesn't resolve the issue after testing, the next steps would be to update `react-native-reanimated` to `3.18.0+` and `@sentry/react-native` from `6.10.0+` or `7.x`.
> 
> Another alternative would be to remove the entire packagingOptions block from `android/app/build.gradle` (lines 92-98) and add `android:extractNativeLibs="false"` to the `<application>` tag in `AndroidManifest.xml` 


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
