### PR TITLE
fix: android uncompression config for google 16kb page size

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,8 +90,11 @@ android {
     }
 
     // Prevents compression of native libraries (.so files) to preserve 16KB page alignment
-    // from NDK r29. Compression would break the alignment even if NDK compiles it correctly.
-    packagingOptions {
+    // from NDK r29. Setting useLegacyPackaging = false (or leaving null) ensures .so files
+    // are stored UNCOMPRESSED and page-aligned, which is required for 16KB page size support.
+    // Note: "legacy" refers to pre-API23 behavior which compressed .so files.
+    // Required for Google Play 16KB page size support (mandatory from Nov 1, 2025).
+    packaging {
         jniLibs {
             useLegacyPackaging = false
         }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -40,3 +40,7 @@ hermesEnabled=true
 
 # Increase maximum size of memory allocation
 org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=512m
+
+# Enable uncompressed native libraries for 16KB page size support
+# Required for Google Play 16KB page size compatibility (mandatory from Nov 1, 2025)
+android.bundle.enableUncompressedNativeLibs=true


### PR DESCRIPTION
### Motivation

See description on https://github.com/HathorNetwork/hathor-wallet-mobile/pull/789

### Acceptance Criteria
- Changed from packagingOptions to packaging (modern AGP syntax, the other was deprecated)
- Tells the bundle tool to handle native libraries correctly for 16 KB support

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
