### PR TITLE
fix: handling object types in RPC requests

### DIFF
--- a/src/components/Reown/NanoContract/NanoContractMethodArgs.js
+++ b/src/components/Reown/NanoContract/NanoContractMethodArgs.js
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import { t } from 'ttag';
-import { Network } from '@hathor/wallet-lib';
+import { Network, bigIntUtils } from '@hathor/wallet-lib';
 import { COLORS } from '../../../styles/themes';
 import { commonStyles } from '../theme';
 import { DEFAULT_TOKEN } from '../../../constants';
@@ -133,6 +133,9 @@ const ArgValueRenderer = ({ type, value, network, tokens }) => {
     } else if (value in tokens) {
       displayValue = `${tokens[value].symbol} (${value})`;
     }
+  } else if (typeof value === 'object' && value !== null) {
+    // Handle objects and arrays by converting to JSON string with BigInt support
+    displayValue = bigIntUtils.JSONBigInt.stringify(value, 2);
   }
 
   return (


### PR DESCRIPTION
Fixes crash when nano contract arguments contain objects/structs. React Native cannot render objects directly in Text components, causing "Objects are not valid as a React child" error.

## Problem

When `validateAndParseBlueprintMethodArgs` parses struct-type arguments, `field.toUser()` returns objects as-is. The `ArgValueRenderer` component attempted to render these objects directly in a `<Text>` component, causing crashes.

Example failing RPC:

```json
{
  "network": "testnet",
  "nc_id": "858f4fdfc943e36bed0d56e5210f30a9fb79a65bdd7225c0d82807f5639eb480",
  "method": "send_attack",
  "args": [
    0,
    1,
    {
      "swordsman": 1,
      "archer": 1
    },
    "conquest"
  ],
  "actions": [],
  "push_tx": true
}
```

## Acceptance Criteria

- Nano contract transactions with object arguments display without crashing
- Object arguments render as formatted JSON strings
- BigInt values in objects maintain precision
- Arrays in arguments display correctly


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
