### PR TITLE
fix(ios): patch fmt consteval build error on Xcode 26+

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -99,5 +99,20 @@ target 'HathorMobile' do
         end
       end
     end
+
+    # Fix fmt 11.x consteval build error on Xcode 26+.
+    # Apple clang claims consteval support but fmt's usage is incompatible.
+    fmt_base = File.join(installer.sandbox.root, 'fmt', 'include', 'fmt', 'base.h')
+    if File.exist?(fmt_base)
+      content = File.read(fmt_base)
+      patched = content.gsub(
+        /defined\(__apple_build_version__\) && __apple_build_version__ < \d+L/,
+        'defined(__apple_build_version__)'
+      )
+      if content != patched
+        File.write(fmt_base, patched)
+        Pod::UI.puts "Patched fmt/base.h to disable consteval on Apple clang"
+      end
+    end
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -102,16 +102,21 @@ target 'HathorMobile' do
 
     # Fix fmt 11.x consteval build error on Xcode 26+.
     # Apple clang claims consteval support but fmt's usage is incompatible.
+    # We disable consteval for ALL Apple clang versions as a safe fallback.
     fmt_base = File.join(installer.sandbox.root, 'fmt', 'include', 'fmt', 'base.h')
     if File.exist?(fmt_base)
-      content = File.read(fmt_base)
-      patched = content.gsub(
-        /defined\(__apple_build_version__\) && __apple_build_version__ < \d+L/,
-        'defined(__apple_build_version__)'
-      )
-      if content != patched
-        File.write(fmt_base, patched)
-        Pod::UI.puts "Patched fmt/base.h to disable consteval on Apple clang"
+      begin
+        content = File.read(fmt_base)
+        patched = content.gsub(
+          /defined\(__apple_build_version__\) && __apple_build_version__ < \d+L/,
+          'defined(__apple_build_version__)'
+        )
+        if content != patched
+          File.write(fmt_base, patched)
+          Pod::UI.puts "Patched fmt/base.h to disable consteval on Apple clang"
+        end
+      rescue => e
+        Pod::UI.warn "Failed to patch fmt/base.h: #{e.message}"
       end
     end
   end


### PR DESCRIPTION
### Motivation

fmt 11.x fails to build on Xcode 26+ because Apple clang defines `__cpp_consteval` but its consteval implementation is incompatible with fmt's usage, producing hard errors in `base.h` and `format-inl.h`.

This is a known React Native issue: https://github.com/facebook/react-native/issues/55601

The upstream fix (fmt bumped to 12.1.0) landed on RN `main` but won't be backported to 0.77.x. This workaround patches fmt's `base.h` after `pod install` to disable consteval on Apple clang.

### Acceptance Criteria

- [ ] iOS build succeeds on Xcode 26+
- [ ] Patch is applied automatically on `pod install`
- [ ] No impact on older Xcode versions

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.