### PR TITLE
fix: token swap screen fixes

### DIFF
--- a/src/components/AmountInputAccessory.js
+++ b/src/components/AmountInputAccessory.js
@@ -7,31 +7,35 @@
 
 import React from 'react';
 import {
-  InputAccessoryView,
   View,
   Text,
   TouchableOpacity,
   StyleSheet,
-  Platform,
   Keyboard,
 } from 'react-native';
 import { t } from 'ttag';
 import { COLORS } from '../styles/themes';
 
 /**
- * Quick action buttons for amount input (25%, 50%, Max, Done).
- * Uses InputAccessoryView on iOS for native keyboard integration.
- * On Android, renders as a regular component that should be positioned above the keyboard.
+ * Quick-action buttons for an amount input (25%, 50%, Max, Done).
+ * Renders as a regular component; the parent is responsible for
+ * positioning it above the keyboard (e.g. via an absolutely-positioned
+ * overlay tied to keyboard events).
+ *
+ * Previously this component used iOS's `<InputAccessoryView>` to attach
+ * itself to the keyboard window. That caused iOS to keep the accessory
+ * height associated with the keyboard frame across screen unmounts —
+ * the next screen with `<KeyboardAvoidingView>` then over-padded by the
+ * accessory's height (~92 px). Rendering as a plain view instead, and
+ * letting the parent place it, removes that leak entirely.
  *
  * @param {Object} props
- * @param {string} props.nativeID - Unique ID for InputAccessoryView (iOS only)
- * @param {bigint} props.availableBalance - The available balance to calculate percentages
- * @param {Function} props.onPercentagePress - Callback when percentage button is pressed
- * @param {Function} props.onDonePress - Callback when Done button is pressed
- * @param {boolean} [props.visible] - Whether to show the accessory (Android only)
+ * @param {bigint} props.availableBalance - Used to compute percentages
+ * @param {Function} props.onPercentagePress - Called with 25 | 50 | 100
+ * @param {Function} [props.onDonePress] - Optional extra Done handler
+ * @param {boolean} [props.visible=true] - Skip rendering when false
  */
 const AmountInputAccessory = ({
-  nativeID,
   availableBalance,
   onPercentagePress,
   onDonePress,
@@ -103,15 +107,6 @@ const AmountInputAccessory = ({
     </View>
   );
 
-  if (Platform.OS === 'ios') {
-    return (
-      <InputAccessoryView nativeID={nativeID}>
-        {buttons}
-      </InputAccessoryView>
-    );
-  }
-
-  // Android: render as a regular component (parent should position it)
   if (!visible) {
     return null;
   }

--- a/src/components/AmountTextInput.js
+++ b/src/components/AmountTextInput.js
@@ -6,15 +6,24 @@
  */
 
 import React, { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
-import { StyleSheet, Text, TextInput } from 'react-native';
+import { StyleSheet, TextInput } from 'react-native';
 import { getAmountParsed, getIntegerAmount } from '../utils';
 import { COLORS } from '../styles/themes';
 
-// When the rendered text would overflow the input width, we scale
-// the font size down by this factor at minimum (relative to the base
-// font size). 0.5 keeps very large amounts readable without
-// shrinking past a usable size.
+// Auto-shrink lower bound: never scale the font below this fraction of
+// the base size, so very long amounts stay readable even when scaled.
 const MIN_FONT_SCALE = 0.5;
+
+// Average glyph width as a fraction of fontSize for the bold sans-serif
+// AmountTextInput uses. We don't measure rendered text (an earlier
+// implementation that did caused a Folly F14Set assertion crash on
+// iOS 26.1 + Fabric due to the extra hidden <Text> re-rendering on
+// every keystroke), so we estimate width as
+// `length * fontSize * GLYPH_RATIO`. Slightly conservative for digits
+// and slightly generous for `,` / `.` — net effect is the font shrinks
+// a hair sooner than strictly necessary, which is preferable to letting
+// the value clip behind the token selector.
+const GLYPH_RATIO = 0.55;
 
 /**
  * Text input component specifically for handling token amounts with BigInt validation.
@@ -38,14 +47,12 @@ const AmountTextInput = forwardRef((props, ref) => {
   const { decimalPlaces } = props;
 
   // Auto-shrink-to-fit: amounts can grow long enough to overflow the
-  // input's column (e.g. `957,791,973.79`). React Native's TextInput
-  // doesn't support `adjustsFontSizeToFit` directly, so we measure the
-  // text via a hidden <Text> sibling rendered at the base font size
-  // and scale the input's fontSize down when the measured width
-  // exceeds the input's container width. When the user shortens the
-  // value, measuredTextWidth shrinks and the font scales back up.
+  // input's column (e.g. `957,791,973.79`). We capture the column
+  // width once via the TextInput's `onLayout` and scale `fontSize` down
+  // when the estimated text width (length × fontSize × GLYPH_RATIO)
+  // exceeds it. When the user shortens the value, the estimate drops
+  // and the font scales back up to the base size.
   const [containerWidth, setContainerWidth] = useState(0);
-  const [measuredTextWidth, setMeasuredTextWidth] = useState(0);
 
   // Expose the focus method to parent components
   useImperativeHandle(ref, () => ({
@@ -123,50 +130,34 @@ const AmountTextInput = forwardRef((props, ref) => {
 
   // Resolve the base (unscaled) font size from the merged style chain
   // so callers that override fontSize via `customStyle` still get
-  // correct measurement + scaling math.
+  // correct scaling math.
   const flatStyle = StyleSheet.flatten([style.input, customStyle]) || {};
   const baseFontSize = flatStyle.fontSize ?? 32;
   const minFontSize = Math.max(14, Math.floor(baseFontSize * MIN_FONT_SCALE));
-  const scaledFontSize = (containerWidth > 0 && measuredTextWidth > containerWidth)
+  const displayed = text || placeholder;
+  const estimatedWidth = displayed.length * baseFontSize * GLYPH_RATIO;
+  const scaledFontSize = (containerWidth > 0 && estimatedWidth > containerWidth)
     ? Math.max(
       minFontSize,
-      Math.floor(baseFontSize * (containerWidth / measuredTextWidth)),
+      Math.floor(baseFontSize * (containerWidth / estimatedWidth)),
     )
     : baseFontSize;
 
   return (
-    <>
-      {/* Hidden measurement layer — same styles as the TextInput, but
-          positioned absolutely offscreen so it doesn't participate in
-          layout. We render at `baseFontSize` (not the scaled size) so
-          its onLayout width tells us the natural width of the text and
-          we can decide whether scaling is needed at all. */}
-      <Text
-        style={[
-          style.input,
-          customStyle,
-          style.measureLayer,
-          { fontSize: baseFontSize },
-        ]}
-        onLayout={(e) => setMeasuredTextWidth(e.nativeEvent.layout.width)}
-      >
-        {text || placeholder}
-      </Text>
-      <TextInput
-        ref={inputRef}
-        style={[style.input, customStyle, { fontSize: scaledFontSize }]}
-        onChangeText={onChangeText}
-        value={text}
-        textAlign={textAlign || 'center'}
-        textAlignVertical='bottom'
-        keyboardAppearance='dark'
-        keyboardType='numeric'
-        placeholder={placeholder}
-        placeholderTextColor={COLORS.midContrastDetail}
-        onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
-        {...restProps}
-      />
-    </>
+    <TextInput
+      ref={inputRef}
+      style={[style.input, customStyle, { fontSize: scaledFontSize }]}
+      onChangeText={onChangeText}
+      value={text}
+      textAlign={textAlign || 'center'}
+      textAlignVertical='bottom'
+      keyboardAppearance='dark'
+      keyboardType='numeric'
+      placeholder={placeholder}
+      placeholderTextColor={COLORS.midContrastDetail}
+      onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
+      {...restProps}
+    />
   );
 });
 
@@ -178,16 +169,6 @@ const style = StyleSheet.create({
     fontWeight: 'bold',
     paddingVertical: 0,
     color: COLORS.textColor,
-  },
-  // Hidden <Text> used solely to measure the natural width of the
-  // current value at the base font size. Pinned far offscreen and
-  // rendered with opacity 0; absolute positioning removes it from
-  // the parent's flexbox layout entirely.
-  measureLayer: {
-    position: 'absolute',
-    top: -9999,
-    left: 0,
-    opacity: 0,
   },
 });
 

--- a/src/components/AmountTextInput.js
+++ b/src/components/AmountTextInput.js
@@ -6,9 +6,15 @@
  */
 
 import React, { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
-import { StyleSheet, TextInput } from 'react-native';
+import { StyleSheet, Text, TextInput } from 'react-native';
 import { getAmountParsed, getIntegerAmount } from '../utils';
 import { COLORS } from '../styles/themes';
+
+// When the rendered text would overflow the input width, we scale
+// the font size down by this factor at minimum (relative to the base
+// font size). 0.5 keeps very large amounts readable without
+// shrinking past a usable size.
+const MIN_FONT_SCALE = 0.5;
 
 /**
  * Text input component specifically for handling token amounts with BigInt validation.
@@ -30,6 +36,16 @@ const AmountTextInput = forwardRef((props, ref) => {
   const inputRef = useRef(null);
   const [text, setText] = useState(props.value || '');
   const { decimalPlaces } = props;
+
+  // Auto-shrink-to-fit: amounts can grow long enough to overflow the
+  // input's column (e.g. `957,791,973.79`). React Native's TextInput
+  // doesn't support `adjustsFontSizeToFit` directly, so we measure the
+  // text via a hidden <Text> sibling rendered at the base font size
+  // and scale the input's fontSize down when the measured width
+  // exceeds the input's container width. When the user shortens the
+  // value, measuredTextWidth shrinks and the font scales back up.
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [measuredTextWidth, setMeasuredTextWidth] = useState(0);
 
   // Expose the focus method to parent components
   useImperativeHandle(ref, () => ({
@@ -105,20 +121,52 @@ const AmountTextInput = forwardRef((props, ref) => {
 
   const { style: customStyle, textAlign, ...restProps } = props;
 
+  // Resolve the base (unscaled) font size from the merged style chain
+  // so callers that override fontSize via `customStyle` still get
+  // correct measurement + scaling math.
+  const flatStyle = StyleSheet.flatten([style.input, customStyle]) || {};
+  const baseFontSize = flatStyle.fontSize ?? 32;
+  const minFontSize = Math.max(14, Math.floor(baseFontSize * MIN_FONT_SCALE));
+  const scaledFontSize = (containerWidth > 0 && measuredTextWidth > containerWidth)
+    ? Math.max(
+      minFontSize,
+      Math.floor(baseFontSize * (containerWidth / measuredTextWidth)),
+    )
+    : baseFontSize;
+
   return (
-    <TextInput
-      ref={inputRef}
-      style={[style.input, customStyle]}
-      onChangeText={onChangeText}
-      value={text}
-      textAlign={textAlign || 'center'}
-      textAlignVertical='bottom'
-      keyboardAppearance='dark'
-      keyboardType='numeric'
-      placeholder={placeholder}
-      placeholderTextColor={COLORS.midContrastDetail}
-      {...restProps}
-    />
+    <>
+      {/* Hidden measurement layer — same styles as the TextInput, but
+          positioned absolutely offscreen so it doesn't participate in
+          layout. We render at `baseFontSize` (not the scaled size) so
+          its onLayout width tells us the natural width of the text and
+          we can decide whether scaling is needed at all. */}
+      <Text
+        style={[
+          style.input,
+          customStyle,
+          style.measureLayer,
+          { fontSize: baseFontSize },
+        ]}
+        onLayout={(e) => setMeasuredTextWidth(e.nativeEvent.layout.width)}
+      >
+        {text || placeholder}
+      </Text>
+      <TextInput
+        ref={inputRef}
+        style={[style.input, customStyle, { fontSize: scaledFontSize }]}
+        onChangeText={onChangeText}
+        value={text}
+        textAlign={textAlign || 'center'}
+        textAlignVertical='bottom'
+        keyboardAppearance='dark'
+        keyboardType='numeric'
+        placeholder={placeholder}
+        placeholderTextColor={COLORS.midContrastDetail}
+        onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
+        {...restProps}
+      />
+    </>
   );
 });
 
@@ -130,6 +178,16 @@ const style = StyleSheet.create({
     fontWeight: 'bold',
     paddingVertical: 0,
     color: COLORS.textColor,
+  },
+  // Hidden <Text> used solely to measure the natural width of the
+  // current value at the base font size. Pinned far offscreen and
+  // rendered with opacity 0; absolute positioning removes it from
+  // the parent's flexbox layout entirely.
+  measureLayer: {
+    position: 'absolute',
+    top: -9999,
+    left: 0,
+    opacity: 0,
   },
 });
 

--- a/src/screens/TokenSwap.js
+++ b/src/screens/TokenSwap.js
@@ -49,9 +49,6 @@ import {
 import NavigationService from '../NavigationService';
 import { TOKEN_SWAP_SLIPPAGE } from '../constants';
 
-const INPUT_ACCESSORY_VIEW_ID = 'tokenSwapAmountInput';
-const OUTPUT_ACCESSORY_VIEW_ID = 'tokenSwapAmountOutput';
-
 function getAvailableAmount(token, tokensBalance) {
   if (!token) {
     return 0n;
@@ -85,6 +82,12 @@ const TokenSwap = () => {
 
   const [editing, setEditing] = useState(null);
 
+  // iOS-only: tracks the keyboard's reported height so we can position
+  // the quick-action accessory overlay above it. Replaces the previous
+  // `<InputAccessoryView>` integration — see the overlay block in JSX
+  // below for the rationale.
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
   // Ref to track editing timeout so we can cancel it on new focus
   const editingTimeoutRef = useRef(null);
 
@@ -105,6 +108,28 @@ const TokenSwap = () => {
     if (editingTimeoutRef.current) {
       clearTimeout(editingTimeoutRef.current);
     }
+  }, []);
+
+  // Track the iOS keyboard height so the absolutely-positioned
+  // accessory overlay can sit flush against the visual keyboard top.
+  // `endCoordinates.height` already includes the home-indicator
+  // safe-area, so the overlay's `bottom: keyboardHeight` lands exactly
+  // where the old <InputAccessoryView> rendered. Android does not need
+  // this — the overlay block itself is gated to iOS.
+  useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return undefined;
+    }
+    const showSub = Keyboard.addListener('keyboardWillShow', (e) => {
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+    const hideSub = Keyboard.addListener('keyboardWillHide', () => {
+      setKeyboardHeight(0);
+    });
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
   }, []);
 
   useEffect(() => {
@@ -326,24 +351,6 @@ const TokenSwap = () => {
 
   return (
     <View style={styles.screenContent}>
-      {/* iOS: Separate InputAccessoryViews for each TextInput
-        * TODO: Add InputAccessoryViews for Android. We had issues positioning the keyboard
-        * buttons correctly on Android screens, so this feature is iOS-only for now.
-        */}
-      {Platform.OS === 'ios' && (
-        <>
-          <AmountInputAccessory
-            nativeID={INPUT_ACCESSORY_VIEW_ID}
-            availableBalance={getAvailableAmount(inputToken, tokensBalance)}
-            onPercentagePress={onPercentagePress}
-          />
-          <AmountInputAccessory
-            nativeID={OUTPUT_ACCESSORY_VIEW_ID}
-            availableBalance={getAvailableAmount(outputToken, tokensBalance)}
-            onPercentagePress={onPercentagePress}
-          />
-        </>
-      )}
       <Pressable style={{ flex: 1 }} onPress={() => Keyboard.dismiss()}>
         <HathorHeader
           withBorder
@@ -365,7 +372,6 @@ const TokenSwap = () => {
                     style={swapDirection === 'output' ? styles.amountInputTextFaded : styles.amountInputText}
                     editable={editing !== 'output'}
                     textAlign='left'
-                    inputAccessoryViewID={INPUT_ACCESSORY_VIEW_ID}
                   />
                   <View>
                     <View style={styles.tokenSelectorWrapper}>
@@ -396,7 +402,6 @@ const TokenSwap = () => {
                     style={swapDirection === 'input' ? styles.amountInputTextFaded : styles.amountInputText}
                     editable={editing !== 'input'}
                     textAlign='left'
-                    inputAccessoryViewID={OUTPUT_ACCESSORY_VIEW_ID}
                   />
                   <View>
                     <View style={styles.tokenSelectorWrapper}>
@@ -456,6 +461,27 @@ const TokenSwap = () => {
           <OfflineBar style={{ position: 'relative' }} />
         </KeyboardAvoidingView>
       </Pressable>
+      {/* iOS keyboard accessory overlay (replaces <InputAccessoryView>).
+          Rendered as a sibling of the main Pressable, positioned
+          absolutely against the screen bottom so its top edge sits
+          flush with the visual keyboard top. We render it only while
+          one of the AmountTextInputs is focused (`editing` is set) and
+          the keyboard frame is known. iOS-only; Android still gets no
+          accessory, matching prior behavior. */}
+      {Platform.OS === 'ios' && editing && keyboardHeight > 0 && (
+        <View
+          pointerEvents='box-none'
+          style={[styles.kbAccessoryOverlay, { bottom: keyboardHeight }]}
+        >
+          <AmountInputAccessory
+            availableBalance={getAvailableAmount(
+              editing === 'input' ? inputToken : outputToken,
+              tokensBalance,
+            )}
+            onPercentagePress={onPercentagePress}
+          />
+        </View>
+      )}
     </View>
   );
 };
@@ -470,6 +496,12 @@ const styles = StyleSheet.create({
   screenContent: {
     flex: 1,
     backgroundColor: COLORS.backgroundColor,
+  },
+  kbAccessoryOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    zIndex: 10,
   },
   buttonContainer: {
     marginBottom: 16,


### PR DESCRIPTION
### Acceptance Criteria
- Reduce the amount font size when the size is bigger than the input
- Fix invisible margin added by the keyboard buttons in token swap

The current code adds an invisible margin when the TokenSwap screen is opened. After opening this screen, the send tx screen adds a huge margin between the keyboard and the Next button.

Bug:

https://github.com/user-attachments/assets/f6c23459-ab77-46de-9c25-4685ee630eac

Fix:


https://github.com/user-attachments/assets/f26772c4-7abc-4d6f-ab6f-90689d672c2c




### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
