### PR TITLE
fix: refresh unleash context on every wallet start

### DIFF
--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -181,12 +181,15 @@ export function* startWallet(action) {
     // If the wallet is initialized from quit state it must
     // update the network settings on redux state
     yield put(networkSettingsUpdateState(networkSettings));
-
-    // and we also must update the unleash client for the custom network settings
-    yield call(monitorFeatureFlags, 0, false);
   } else {
     networkSettings = yield select(getNetworkSettings);
   }
+
+  // Refresh the unleash client context so feature toggles reflect the current
+  // network. Required after wallet reset, since onResetWalletSuccess preserves
+  // state.featureToggles to avoid re-initialization, leaving stale values from
+  // the previous network until the next polling cycle.
+  yield call(monitorFeatureFlags, 0, false);
 
   const uniqueDeviceId = getUniqueId();
   const useWalletService = yield call(isWalletServiceEnabled);


### PR DESCRIPTION
### Acceptance Criteria
- Should refetch unleash feature flags after a wallet reset

### How to reproduce the bug (the example says address mode, but could be any flag that is disabled in mainnet and enabled in testnet)
1. Start the wallet on mainnet — Address Mode option hidden
2. Switch to testnet via Settings → Network Settings → Testnet — option appears
3. Switch back to mainnet — option hides
4. Switch to testnet again — option appears
5. Reset the wallet (Settings → Reset wallet) and finish onboarding
6. Wallet reconnects to mainnet — Address Mode option still appears (bug)

### Root cause
- `onResetWalletSuccess` preserves `state.featureToggles` to skip unleash re-initialization
- `startWallet` only refreshed unleash inside the `if (customNetwork)` branch
- After reset, `cleanNetworkSettings` removes the persisted network from STORE, so `customNetwork` is `null`, the refresh is skipped, and toggles from the previous network leak into the new wallet

### Fix
- Move `monitorFeatureFlags(0, false)` out of the `if (customNetwork)` block so the unleash context is refreshed on every wallet start (cold boot, network switch, post-reset)

### Security Checklist
- [x] No new dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent feature flag refresh behavior that now updates properly across all network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->