### PR TITLE
fix(send): stop iOS camera after send-tx flow

### DIFF
--- a/QA/QA.md
+++ b/QA/QA.md
@@ -60,6 +60,7 @@ The main test sequence should be executed on the `testnet` network by default, u
 1. Type 2 HTR, click Next, and check the send summary.
 1. Click on Send and type a wrong PIN Code.
 1. Finally, type a correct PIN Code and check the confirmation.
+1. When back on the Dashboard screen, check the camera is turned off. Point it to a valid QR Code and it should not trigger a "Send Transaction" flow.
 
 ### Transaction History Tests
 1. Verify Dashboard displays HTR token by default
@@ -300,7 +301,7 @@ To change between the Fullnode and Wallet Service facades, choose one option and
 #### Fullnode
 Here we will remove the URLs in Custom Network
 - Follow the `Changing Networks` workflow above and select "Customize".
-- Empty the `Wallet Service URL` and `Wallet Service WS URL` fields 
+- Empty the `Wallet Service URL` and `Wallet Service WS URL` fields
 - Click "SEND" and now the application will be connected through the Fullnode on the current network
 
 Another option for a developer would be to navigate to `Unleash` and deactivate the `wallet-service-mobile.rollout`
@@ -316,13 +317,13 @@ error handling flag (`IGNORE_WS_TOGGLE_FLAG`) will prevent the app from trying t
 If you need to interact with the wallet service within this time window you'll need to resort to the operational system
 to clear this flag along with the entire application data.
 - Android: clear the application cache, start the app again and import/create your wallet
-- iOS: Uninstall the app, install it again, start the app again and import/create your wallet 
+- iOS: Uninstall the app, install it again, start the app again and import/create your wallet
 
 ### Setting flags on Unleash
 Some of the tests involve changing Unleash flags for the application. This requires access to Hathor Network's Unleash
 and proper permissions to do so. Ask the Code Owner of this repository for the access URL and credentials to do so.
 
-Once logged in, the following feature toggles can be changed. ( Note: This list is for quick reference, but can be 
+Once logged in, the following feature toggles can be changed. ( Note: This list is for quick reference, but can be
 obsolete. Refer to `src/constants.js` for the up-to-date list of feature toggle names ).
 - `wallet-service-mobile.rollout`
 - `push-notification.rollout`

--- a/src/components/QRCodeReader.js
+++ b/src/components/QRCodeReader.js
@@ -10,12 +10,12 @@ import * as React from 'react';
 import { AppState, StyleSheet, Text, View } from 'react-native';
 import { Camera, CameraType } from 'react-native-camera-kit';
 import { useEffect, useState } from 'react';
+import { useIsFocused } from '@react-navigation/native';
 import { COLORS } from '../styles/themes';
 
 const APP_ACTIVE_STATE = 'active';
 
 export default ({
-  navigation,
   onSuccess,
   focusHeight = 250,
   focusWidth = 250,
@@ -23,53 +23,18 @@ export default ({
 }) => {
   // States related to Camera rendering logic
   const [currentAppState, setCurrentAppState] = useState(AppState.currentState);
-  const [isFocusedScreen, setIsFocusedScreen] = useState(false);
+  const isFocused = useIsFocused();
 
   // States related to the custom marker
   const [canvasHeight, setCanvasHeight] = useState(0);
   const [canvasWidth, setCanvasWidth] = useState(0);
 
-  // Initialization and event listeners
+  // Track app foreground/background. Pairing this with useIsFocused below in
+  // the render predicate is what stops iOS AVCaptureSession from running when
+  // the screen is alive but not actually visible (e.g. mounted in a blurred tab).
   useEffect(() => {
-    /*
-     * We need to focus/unfocus the QRCode scanner, so that it doesn't freeze
-     * - When the navigation focuses this screen or app becomes active, we set it to `true`
-     * - When the navigation moves away or app becomes inactive, we set it to `false`
-     */
-    let appStateEvent;
-    const focusEvent = navigation.addListener('focus', () => {
-      setIsFocusedScreen(true);
-      appStateEvent = AppState.addEventListener('change', (nextAppState) => {
-        if (
-          currentAppState === APP_ACTIVE_STATE
-          && nextAppState !== APP_ACTIVE_STATE) {
-          // It's changing and won't be active anymore
-          setIsFocusedScreen(false);
-        } else if (
-          nextAppState === APP_ACTIVE_STATE
-          && currentAppState !== APP_ACTIVE_STATE) {
-          // Will become active now
-          setIsFocusedScreen(true);
-        }
-
-        setCurrentAppState(nextAppState);
-      });
-    });
-    const blurEvent = navigation.addListener('blur', () => {
-      setIsFocusedScreen(false);
-    });
-
-    // After all the listeners are in place, allow the Camera component to be rendered
-    setIsFocusedScreen(true);
-
-    return () => {
-      focusEvent();
-      blurEvent();
-      if (appStateEvent) { // This listener may have never been initialized
-        appStateEvent.remove();
-        appStateEvent = null;
-      }
-    };
+    const sub = AppState.addEventListener('change', setCurrentAppState);
+    return () => sub.remove();
   }, []);
 
   /**
@@ -154,7 +119,7 @@ export default ({
       onLayout={onViewLayoutHandler}
     >
       <>
-        {isFocusedScreen && (
+        {isFocused && currentAppState === APP_ACTIVE_STATE && (
           <Camera
             cameraType={CameraType.Back}
             flashMode='off'

--- a/src/screens/NanoContractRegisterQrCodeScreen.js
+++ b/src/screens/NanoContractRegisterQrCodeScreen.js
@@ -58,7 +58,6 @@ export const NanoContractRegisterQrCodeScreen = ({ navigation }) => {
         }}
         >
           <QRCodeReader
-            navigation={navigation}
             onSuccess={onSuccess}
             bottomText={t`Scan the nano contract ID QR code`}
           />

--- a/src/screens/RegisterToken.js
+++ b/src/screens/RegisterToken.js
@@ -48,7 +48,6 @@ class RegisterToken extends React.Component {
           }}
           >
             <QRCodeReader
-              navigation={this.props.navigation}
               onSuccess={this.onSuccess}
               bottomText={t`Scan the token QR code`}
             />

--- a/src/screens/Reown/ReownScan.js
+++ b/src/screens/Reown/ReownScan.js
@@ -47,7 +47,6 @@ export default function ReownScan({ navigation }) {
         <QRCodeReader
           onSuccess={onSuccess}
           bottomText={t`Scan the QR code`}
-          navigation={navigation}
         />
       </View>
       <OfflineBar />

--- a/src/screens/SendScanQRCode.js
+++ b/src/screens/SendScanQRCode.js
@@ -83,7 +83,6 @@ class SendScanQRCode extends React.Component {
         />
         <View style={{ flex: 1, margin: 16, alignSelf: 'stretch' }}>
           <QRCodeReader
-            navigation={this.props.navigation}
             onSuccess={this.onSuccess}
             bottomText={t`Scan the QR code`}
           />

--- a/src/screens/UnifiedQRScanner.js
+++ b/src/screens/UnifiedQRScanner.js
@@ -94,7 +94,6 @@ const UnifiedQRScanner = ({ navigation }) => {
         <QRCodeReader
           onSuccess={onSuccess}
           bottomText={t`Scan the QR code`}
-          navigation={navigation}
         />
       </View>
       <OfflineBar />


### PR DESCRIPTION
## Motivation
After successfully sending a transaction the application returned to the "Dashboard" screen, however with the camera and QR Code scanner still open.

This was a quirk of the navigation components and could only be reproduced on iOS on a physical device. 

## Summary of changes
Replaced our manually crafted focus tracker with the canonical hook from React Native, which has fixed this bug already and will always be maintained properly.

- Replace `QRCodeReader`'s manual `focus` / `blur` navigation listeners with `useIsFocused()` from `@react-navigation/native`. The hook reads focus state from the actual nav tree, so it returns the correct value even when the screen is mounted into an already-blurred stack — which is what happens after `SendConfirmScreen.exitScreen()` issues a `navigation.reset()`. Result: the iOS camera now stops as expected after a completed send-tx flow.

- Drop the now-unused `navigation` prop from `QRCodeReader` and its 5 callsites (`Send`, `RegisterToken`, `NanoContractRegister`, `ReownScan`, `UnifiedQRScanner`).

- **Incidental fix**: the original `AppState` handler had a stale-closure bug — `currentAppState` was permanently captured at its initial value because the `useEffect` deps array was `[]`. Replacing the manual focus tracking removes that effect entirely, so the bug goes away.

- **Adds QA Test**: avoids a regression in the future


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved QR code scanner camera behavior to properly respond to app foreground/background state changes and screen navigation transitions, enhancing app performance and power efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-wallet-mobile/pull/869)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->