### PR TITLE
fix: serialize bigint AsyncStorage writes on Hermes/SES (network token snapshot)

### DIFF
--- a/patches/@hathor+wallet-lib+3.1.1.patch
+++ b/patches/@hathor+wallet-lib+3.1.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@hathor/wallet-lib/lib/utils/bigint.js b/node_modules/@hathor/wallet-lib/lib/utils/bigint.js
-index 312d9fb..2b3f211 100644
+index 312d9fb..38840c2 100644
 --- a/node_modules/@hathor/wallet-lib/lib/utils/bigint.js
 +++ b/node_modules/@hathor/wallet-lib/lib/utils/bigint.js
-@@ -9,6 +9,13 @@ exports.parseSchema = parseSchema;
+@@ -9,6 +9,21 @@ exports.parseSchema = parseSchema;
  exports.transformJsonBigIntResponse = transformJsonBigIntResponse;
  var _zod = require("zod");
  var _types = require("../types");
@@ -13,10 +13,18 @@ index 312d9fb..2b3f211 100644
 +// react-native doesn't have it neither in Hermes or in JavascriptCore
 +const corejsParser = require('core-js-pure/actual/json/parse');
 +
++// `JSON.rawJSON` (used to emit BigInts as raw, unquoted JSON numbers) is a
++// Node v22 / V8 API unavailable in react-native engines, and the core-js-pure
++// stringify/rawJSON ponyfills break under this app's SES hardening ("Cannot
++// assign to read-only property"). Instead we serialize BigInts to a sentinel
++// string with the native JSON.stringify and then unquote them into raw numbers.
++const BIGINT_SENTINEL = String.fromCharCode(0) + 'bigint:';
++const BIGINT_SENTINEL_RE = /"\\u0000bigint:(-?\d+)"/g;
++
  /**
   * Copyright (c) Hathor Labs and its affiliates.
   *
-@@ -27,7 +34,7 @@ const JSONBigInt = exports.JSONBigInt = {
+@@ -27,16 +42,22 @@ const JSONBigInt = exports.JSONBigInt = {
    /* eslint-disable @typescript-eslint/no-explicit-any */
    parse(text) {
      // @ts-expect-error TypeScript hasn't been updated with the `context` argument from Node v22.
@@ -24,8 +32,13 @@ index 312d9fb..2b3f211 100644
 +    return corejsParser(text, this.bigIntReviver);
    },
    stringify(value, space) {
-     return JSON.stringify(value, this.bigIntReplacer, space);
-@@ -37,6 +44,10 @@ const JSONBigInt = exports.JSONBigInt = {
+-    return JSON.stringify(value, this.bigIntReplacer, space);
++    // Native JSON.stringify is SES-safe; bigIntReplacer tags BigInts with a
++    // sentinel string which we then unquote into raw JSON numbers.
++    return JSON.stringify(value, this.bigIntReplacer, space).replace(BIGINT_SENTINEL_RE, '$1');
+   },
+   bigIntReviver(_key, value, context) {
+     if (typeof value !== 'number') {
        // No special handling needed for non-number values.
        return value;
      }
@@ -36,7 +49,7 @@ index 312d9fb..2b3f211 100644
      try {
        const bigIntValue = BigInt(context.source);
        if (bigIntValue < Number.MIN_SAFE_INTEGER || bigIntValue > Number.MAX_SAFE_INTEGER) {
-@@ -47,7 +58,10 @@ const JSONBigInt = exports.JSONBigInt = {
+@@ -47,7 +68,10 @@ const JSONBigInt = exports.JSONBigInt = {
        // Otherwise, we can keep it as a Number.
        return value;
      } catch (e) {
@@ -48,3 +61,16 @@ index 312d9fb..2b3f211 100644
          // When this error happens, it means the number cannot be converted to a BigInt,
          // so it's a double, for example '123.456' or '1e2'.
          return value;
+@@ -59,9 +83,9 @@ const JSONBigInt = exports.JSONBigInt = {
+     }
+   },
+   bigIntReplacer(_key, value_) {
+-    // If the value is a BigInt, we simply return its string representation.
+-    // @ts-expect-error TypeScript hasn't been updated with the `rawJSON` function from Node v22.
+-    return typeof value_ === 'bigint' ? JSON.rawJSON(value_.toString(10)) : value_;
++    // Tag BigInts with a sentinel string; stringify() unquotes them into raw
++    // JSON numbers so they round-trip back to a BigInt through bigIntReviver.
++    return typeof value_ === 'bigint' ? `${BIGINT_SENTINEL}${value_.toString(10)}` : value_;
+   }
+   /* eslint-enable @typescript-eslint/no-explicit-any */
+ };


### PR DESCRIPTION
### Motivation

In the `0.39.0` RC cycle the wallet started crashing when persisting `bigint` token data to AsyncStorage. `store.js` `setItem` serializes through `@hathor/wallet-lib`'s `JSONBigInt.stringify`, which relies on **`JSON.rawJSON`** — a Node 22 / V8-only API that **does not exist on Hermes** — so any write of a value containing a `bigint` (e.g. the per-network token snapshot) threw `TypeError: JSON.rawJSON is not a function`. The error is caught by the saga, so the **token snapshot is silently never saved** (custom tokens are not restored when switching networks).

This PR extends the existing `patch-package` patch for `@hathor/wallet-lib` so `JSONBigInt.stringify` works on Hermes **and** under this app's SES hardening, without `JSON.rawJSON` and without pulling `core-js` stringify (which breaks SES).

### Acceptance Criteria

- Persisting registered tokens per network (`updateNetworkTokenSnapshot` → `STORE.saveTokensForNetwork` → `setItem`) no longer throws on iOS/Android.
- `bigint` values round-trip through `JSONBigInt.stringify`/`parse` (emitted as raw JSON numbers), keeping the same on-the-wire format as `JSON.rawJSON`.
- No `Console Error` / `Uncaught Error` on wallet load/sync related to JSON bigint serialization.
- No new runtime dependency is introduced.

---

## Bug fix detail (RC-4)

### Problem

`JSONBigInt` (`@hathor/wallet-lib/src/utils/bigint.ts`) depends on two APIs of the "JSON source text access" proposal — `JSON.rawJSON` (stringify) and the `JSON.parse` reviver `context` (parse) — which ship in V8 / Node v22 but are **absent in react-native engines (Hermes / JavaScriptCore)**. Persisting `bigint` token balances made `stringify` throw `TypeError: JSON.rawJSON is not a function`.

The obvious fix — ponyfilling with `core-js-pure` `stringify`/`raw-json` — does **not** work here: those modules mutate an intrinsic that is **frozen by SES**, throwing `Cannot assign to read-only property 'get'` (and a cascading `Cannot read property 'set' of undefined`). core-js **parse** is SES-safe; only stringify/rawJSON are not.

### Example

```js
// Hermes (React Native). A value containing a bigint (token balance):
const data = { balance: { tokens: { unlocked: 100000000000n, locked: 0n } } };

JSONBigInt.stringify(data);
// ❌ Before: TypeError: JSON.rawJSON is not a function (it is undefined)
// ❌ core-js attempt under SES: Cannot assign to read-only property 'get'
```

### Solution

The replacer tags each `bigint` with a **NUL-prefixed sentinel** string; the native (SES-safe) `JSON.stringify` serializes it, and a final pass unquotes the sentinels into raw JSON numbers. `parse` keeps the `core-js-pure` ponyfill.

```js
const BIGINT_SENTINEL = String.fromCharCode(0) + 'bigint:';
const BIGINT_SENTINEL_RE = /"\\u0000bigint:(-?\d+)"/g;

bigIntReplacer(_key, value) {
  return typeof value === 'bigint' ? `${BIGINT_SENTINEL}${value.toString(10)}` : value;
}
stringify(value, space) {
  return JSON.stringify(value, this.bigIntReplacer, space).replace(BIGINT_SENTINEL_RE, '$1');
}
// ✅ {"balance":{"tokens":{"unlocked":100000000000,"locked":0}}}
```

Verified end-to-end on the iOS Simulator (Hermes + SES): the snapshot persists, `asyncstorage:networkTokens` stores bigint balances as raw numbers, and the errors are gone. The upstream fix lives in `hathor-wallet-lib` PR #1104; this patch can be dropped once the lib is bumped to a version that includes it.

### When it was introduced

The crash was introduced in the `0.39.0` cycle by **#870** (`a8644ed`, 2026-05-21, `setItem` → `JSONBigInt.stringify`) together with the wallet-lib 3.x bump **#873** (`ca56b11`); first shipped in **0.39.0-rc.1**. The underlying upstream defect (`JSON.rawJSON` in `bigIntReplacer`) has existed in `@hathor/wallet-lib` since **#728** (v2.0.0, 2024-12-09) but stayed dormant until a write path serialized a `bigint` through it.

### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us. — _No new dependency: the patch uses native `JSON.stringify` + a regex; `core-js-pure` was already present (used by the existing parse patch)._
