### PR TITLE
fix: loading modal and token amount size

### DIFF
--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -73,7 +73,7 @@ msgstr ""
 msgid "CREATE FEE TOKEN"
 msgstr ""
 
-#: src/screens/CreateTokenAmount.js:36 src/screens/CreateTokenConfirm.js:84
+#: src/screens/CreateTokenAmount.js:36 src/screens/CreateTokenConfirm.js:91
 #: src/screens/CreateTokenDepositNotice.js:42
 #: src/screens/CreateTokenTypeNotice.js:94 src/utils.js:654
 msgid "CREATE TOKEN"
@@ -359,63 +359,69 @@ msgstr ""
 msgid "Next"
 msgstr "Næste"
 
-#: src/screens/CreateTokenConfirm.js:34
+#: src/screens/CreateTokenConfirm.js:35
 msgid ""
 "You chose to create a **Deposit-Based Token**, which requires a 1% HTR "
 "deposit."
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:36
+#: src/screens/CreateTokenConfirm.js:37
 msgid ""
 "You chose to create a **Fee-Based Token**, so a small fee will be applied to "
 "each future transaction of this token."
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:140
-msgid "Creating token"
-msgstr "Opretter token"
+#.  Show a non-dismissable spinner immediately so the user gets feedback and the
+#.  Create token button is disabled while the transaction is being prepared.
+#: src/screens/CreateTokenConfirm.js:134
+msgid "Building the transaction"
+msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:155
+#: src/screens/CreateTokenConfirm.js:184
 msgid "Enter your 6-digit pin to create your token"
 msgstr "Indtast din 6-cifrede pin for at oprette din token"
 
-#: src/screens/CreateTokenConfirm.js:156
+#: src/screens/CreateTokenConfirm.js:185
 msgid "Authorize token creation"
 msgstr "Autoriser oprettelse af token"
 
-#: src/screens/CreateTokenConfirm.js:158 src/screens/SendConfirmScreen.js:105
-#: src/screens/TokenSwapReview.js:205
+#: src/screens/CreateTokenConfirm.js:187 src/screens/SendConfirmScreen.js:105
+#: src/screens/TokenSwapReview.js:221
 msgid "Building transaction"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:216
+#: src/screens/CreateTokenConfirm.js:249
+msgid "Creating token"
+msgstr "Opretter token"
+
+#: src/screens/CreateTokenConfirm.js:252
 #, javascript-format
 msgid "**${ name }** created successfully"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:229
+#: src/screens/CreateTokenConfirm.js:264
 msgid "Amount of ${ name }"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:238
+#: src/screens/CreateTokenConfirm.js:281
 msgid "Token name"
 msgstr "Token navn"
 
-#: src/screens/CreateTokenConfirm.js:244 src/screens/CreateTokenSymbol.js:71
+#: src/screens/CreateTokenConfirm.js:287 src/screens/CreateTokenSymbol.js:71
 msgid "Token symbol"
 msgstr "Token symbol"
 
 #: src/components/Reown/CreateTokenRequest.js:87
 #: src/components/Reown/CreateTokenRequest.js:129
-#: src/screens/CreateTokenConfirm.js:251
+#: src/screens/CreateTokenConfirm.js:294
 msgid "Deposit"
 msgstr "Indsæt"
 
-#: src/screens/CreateTokenConfirm.js:259
+#: src/screens/CreateTokenConfirm.js:302
 msgid "Network fee"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:268
+#: src/screens/CreateTokenConfirm.js:311
 msgid "Create token"
 msgstr "Opret token"
 
@@ -985,22 +991,22 @@ msgstr[1] ""
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "SEND ${ tokenNameUpperCase }"
 
-#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:304
+#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:320
 msgid "No fee"
 msgstr ""
 
 #.  show loading modal
-#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:189
+#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:205
 msgid "Your transfer is being processed"
 msgstr "Din overførsel behandles"
 
 #: src/sagas/helpers.js:147 src/screens/SendConfirmScreen.js:103
-#: src/screens/TokenSwapReview.js:203
+#: src/screens/TokenSwapReview.js:219
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Indtast din 6-cifrede pin for at godkende overførslen"
 
 #: src/sagas/helpers.js:148 src/screens/SendConfirmScreen.js:104
-#: src/screens/TokenSwapReview.js:204
+#: src/screens/TokenSwapReview.js:220
 msgid "Authorize operation"
 msgstr "Autoriserer overførslen"
 
@@ -1145,25 +1151,25 @@ msgstr ""
 msgid "Loading Token Swap"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:215
+#: src/screens/TokenSwapReview.js:231
 msgid "REVIEW TOKEN SWAP"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:221
+#: src/screens/TokenSwapReview.js:237
 msgid "Building the swap transaction for your review"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:239
+#: src/screens/TokenSwapReview.js:255
 msgid "Your swap was successful"
 msgstr ""
 
 #: src/components/Reown/CreateTokenRequest.js:130
 #: src/components/Reown/TransactionFees.js:55
-#: src/screens/TokenSwapReview.js:300
+#: src/screens/TokenSwapReview.js:316
 msgid "Network Fee"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:312
+#: src/screens/TokenSwapReview.js:328
 msgid "SWAP"
 msgstr ""
 

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -73,7 +73,7 @@ msgstr "CRIAR TOKEN DE DEPÓSITO"
 msgid "CREATE FEE TOKEN"
 msgstr "CRIAR TOKEN DE TAXA"
 
-#: src/screens/CreateTokenAmount.js:36 src/screens/CreateTokenConfirm.js:84
+#: src/screens/CreateTokenAmount.js:36 src/screens/CreateTokenConfirm.js:91
 #: src/screens/CreateTokenDepositNotice.js:42
 #: src/screens/CreateTokenTypeNotice.js:94 src/utils.js:654
 msgid "CREATE TOKEN"
@@ -372,7 +372,7 @@ msgstr "Quantidade de ${ name } (${ symbol })"
 msgid "Next"
 msgstr "Próximo"
 
-#: src/screens/CreateTokenConfirm.js:34
+#: src/screens/CreateTokenConfirm.js:35
 msgid ""
 "You chose to create a **Deposit-Based Token**, which requires a 1% HTR "
 "deposit."
@@ -380,7 +380,7 @@ msgstr ""
 "Você escolheu criar um **Token Baseado em Depósito**, que requer um depósito "
 "de 1% em HTR."
 
-#: src/screens/CreateTokenConfirm.js:36
+#: src/screens/CreateTokenConfirm.js:37
 msgid ""
 "You chose to create a **Fee-Based Token**, so a small fee will be applied to "
 "each future transaction of this token."
@@ -388,51 +388,57 @@ msgstr ""
 "Você escolheu criar um **Token com Taxa**, então uma pequena taxa será "
 "aplicada a cada transação futura deste token."
 
-#: src/screens/CreateTokenConfirm.js:140
-msgid "Creating token"
-msgstr "Criando um token"
+#.  Show a non-dismissable spinner immediately so the user gets feedback and the
+#.  Create token button is disabled while the transaction is being prepared.
+#: src/screens/CreateTokenConfirm.js:134
+msgid "Building the transaction"
+msgstr "Criando a transação"
 
-#: src/screens/CreateTokenConfirm.js:155
+#: src/screens/CreateTokenConfirm.js:184
 msgid "Enter your 6-digit pin to create your token"
 msgstr "Digite seu PIN de 6 dígitos para criar o seu token"
 
-#: src/screens/CreateTokenConfirm.js:156
+#: src/screens/CreateTokenConfirm.js:185
 msgid "Authorize token creation"
 msgstr "Autorizar criação de token"
 
-#: src/screens/CreateTokenConfirm.js:158 src/screens/SendConfirmScreen.js:105
-#: src/screens/TokenSwapReview.js:205
+#: src/screens/CreateTokenConfirm.js:187 src/screens/SendConfirmScreen.js:105
+#: src/screens/TokenSwapReview.js:221
 msgid "Building transaction"
 msgstr "Criando transação"
 
-#: src/screens/CreateTokenConfirm.js:216
+#: src/screens/CreateTokenConfirm.js:249
+msgid "Creating token"
+msgstr "Criando um token"
+
+#: src/screens/CreateTokenConfirm.js:252
 #, javascript-format
 msgid "**${ name }** created successfully"
 msgstr "**${ name }** criado com sucesso"
 
-#: src/screens/CreateTokenConfirm.js:229
+#: src/screens/CreateTokenConfirm.js:264
 msgid "Amount of ${ name }"
 msgstr "Quantidade de ${ name }"
 
-#: src/screens/CreateTokenConfirm.js:238
+#: src/screens/CreateTokenConfirm.js:281
 msgid "Token name"
 msgstr "Nome do token"
 
-#: src/screens/CreateTokenConfirm.js:244 src/screens/CreateTokenSymbol.js:71
+#: src/screens/CreateTokenConfirm.js:287 src/screens/CreateTokenSymbol.js:71
 msgid "Token symbol"
 msgstr "Símbolo do token"
 
 #: src/components/Reown/CreateTokenRequest.js:87
 #: src/components/Reown/CreateTokenRequest.js:129
-#: src/screens/CreateTokenConfirm.js:251
+#: src/screens/CreateTokenConfirm.js:294
 msgid "Deposit"
 msgstr "Depósito"
 
-#: src/screens/CreateTokenConfirm.js:259
+#: src/screens/CreateTokenConfirm.js:302
 msgid "Network fee"
 msgstr "Taxa de Rede"
 
-#: src/screens/CreateTokenConfirm.js:268
+#: src/screens/CreateTokenConfirm.js:311
 msgid "Create token"
 msgstr "Criar um token"
 
@@ -1014,22 +1020,22 @@ msgstr[1] "${ amountAndToken } disponíveis"
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "ENVIAR ${ tokenNameUpperCase }"
 
-#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:304
+#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:320
 msgid "No fee"
 msgstr "Sem taxa"
 
 #.  show loading modal
-#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:189
+#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:205
 msgid "Your transfer is being processed"
 msgstr "Sua transferência está sendo processada"
 
 #: src/sagas/helpers.js:147 src/screens/SendConfirmScreen.js:103
-#: src/screens/TokenSwapReview.js:203
+#: src/screens/TokenSwapReview.js:219
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Digite seu PIN de 6 dígitos para autorizar a operação"
 
 #: src/sagas/helpers.js:148 src/screens/SendConfirmScreen.js:104
-#: src/screens/TokenSwapReview.js:204
+#: src/screens/TokenSwapReview.js:220
 msgid "Authorize operation"
 msgstr "Autorizar operação"
 
@@ -1174,25 +1180,25 @@ msgstr "Ocorreu um erro ao carregar o protocolo de troca de tokens."
 msgid "Loading Token Swap"
 msgstr "Carregando troca de tokens"
 
-#: src/screens/TokenSwapReview.js:215
+#: src/screens/TokenSwapReview.js:231
 msgid "REVIEW TOKEN SWAP"
 msgstr "REVISAR TROCA DE TOKENS"
 
-#: src/screens/TokenSwapReview.js:221
+#: src/screens/TokenSwapReview.js:237
 msgid "Building the swap transaction for your review"
 msgstr "Criando transação de swap para ser revisada"
 
-#: src/screens/TokenSwapReview.js:239
+#: src/screens/TokenSwapReview.js:255
 msgid "Your swap was successful"
 msgstr "Sua troca foi bem-sucedida"
 
 #: src/components/Reown/CreateTokenRequest.js:130
 #: src/components/Reown/TransactionFees.js:55
-#: src/screens/TokenSwapReview.js:300
+#: src/screens/TokenSwapReview.js:316
 msgid "Network Fee"
 msgstr "Taxa de Rede"
 
-#: src/screens/TokenSwapReview.js:312
+#: src/screens/TokenSwapReview.js:328
 msgid "SWAP"
 msgstr "TROCAR"
 

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -74,7 +74,7 @@ msgstr ""
 msgid "CREATE FEE TOKEN"
 msgstr ""
 
-#: src/screens/CreateTokenAmount.js:36 src/screens/CreateTokenConfirm.js:84
+#: src/screens/CreateTokenAmount.js:36 src/screens/CreateTokenConfirm.js:91
 #: src/screens/CreateTokenDepositNotice.js:42
 #: src/screens/CreateTokenTypeNotice.js:94 src/utils.js:654
 msgid "CREATE TOKEN"
@@ -360,63 +360,69 @@ msgstr ""
 msgid "Next"
 msgstr "Далее"
 
-#: src/screens/CreateTokenConfirm.js:34
+#: src/screens/CreateTokenConfirm.js:35
 msgid ""
 "You chose to create a **Deposit-Based Token**, which requires a 1% HTR "
 "deposit."
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:36
+#: src/screens/CreateTokenConfirm.js:37
 msgid ""
 "You chose to create a **Fee-Based Token**, so a small fee will be applied to "
 "each future transaction of this token."
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:140
-msgid "Creating token"
-msgstr "Создать токен"
+#.  Show a non-dismissable spinner immediately so the user gets feedback and the
+#.  Create token button is disabled while the transaction is being prepared.
+#: src/screens/CreateTokenConfirm.js:134
+msgid "Building the transaction"
+msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:155
+#: src/screens/CreateTokenConfirm.js:184
 msgid "Enter your 6-digit pin to create your token"
 msgstr "Введите 6-значный PIN-код для создания токена"
 
-#: src/screens/CreateTokenConfirm.js:156
+#: src/screens/CreateTokenConfirm.js:185
 msgid "Authorize token creation"
 msgstr "Авторизовать создание токена"
 
-#: src/screens/CreateTokenConfirm.js:158 src/screens/SendConfirmScreen.js:105
-#: src/screens/TokenSwapReview.js:205
+#: src/screens/CreateTokenConfirm.js:187 src/screens/SendConfirmScreen.js:105
+#: src/screens/TokenSwapReview.js:221
 msgid "Building transaction"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:216
+#: src/screens/CreateTokenConfirm.js:249
+msgid "Creating token"
+msgstr "Создать токен"
+
+#: src/screens/CreateTokenConfirm.js:252
 #, javascript-format
 msgid "**${ name }** created successfully"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:229
+#: src/screens/CreateTokenConfirm.js:264
 msgid "Amount of ${ name }"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:238
+#: src/screens/CreateTokenConfirm.js:281
 msgid "Token name"
 msgstr "Имя токена"
 
-#: src/screens/CreateTokenConfirm.js:244 src/screens/CreateTokenSymbol.js:71
+#: src/screens/CreateTokenConfirm.js:287 src/screens/CreateTokenSymbol.js:71
 msgid "Token symbol"
 msgstr "Символ токена"
 
 #: src/components/Reown/CreateTokenRequest.js:87
 #: src/components/Reown/CreateTokenRequest.js:129
-#: src/screens/CreateTokenConfirm.js:251
+#: src/screens/CreateTokenConfirm.js:294
 msgid "Deposit"
 msgstr "Депозит"
 
-#: src/screens/CreateTokenConfirm.js:259
+#: src/screens/CreateTokenConfirm.js:302
 msgid "Network fee"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:268
+#: src/screens/CreateTokenConfirm.js:311
 msgid "Create token"
 msgstr "Создать токен"
 
@@ -987,22 +993,22 @@ msgstr[2] ""
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "ОТПРАВИТЬ ${ tokenNameUpperCase }"
 
-#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:304
+#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:320
 msgid "No fee"
 msgstr ""
 
 #.  show loading modal
-#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:189
+#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:205
 msgid "Your transfer is being processed"
 msgstr "Ваш перевод обрабатывается"
 
 #: src/sagas/helpers.js:147 src/screens/SendConfirmScreen.js:103
-#: src/screens/TokenSwapReview.js:203
+#: src/screens/TokenSwapReview.js:219
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Введите 6-значный PIN-код для авторизации операции"
 
 #: src/sagas/helpers.js:148 src/screens/SendConfirmScreen.js:104
-#: src/screens/TokenSwapReview.js:204
+#: src/screens/TokenSwapReview.js:220
 msgid "Authorize operation"
 msgstr "Авторизовать операцию"
 
@@ -1148,25 +1154,25 @@ msgstr ""
 msgid "Loading Token Swap"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:215
+#: src/screens/TokenSwapReview.js:231
 msgid "REVIEW TOKEN SWAP"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:221
+#: src/screens/TokenSwapReview.js:237
 msgid "Building the swap transaction for your review"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:239
+#: src/screens/TokenSwapReview.js:255
 msgid "Your swap was successful"
 msgstr ""
 
 #: src/components/Reown/CreateTokenRequest.js:130
 #: src/components/Reown/TransactionFees.js:55
-#: src/screens/TokenSwapReview.js:300
+#: src/screens/TokenSwapReview.js:316
 msgid "Network Fee"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:312
+#: src/screens/TokenSwapReview.js:328
 msgid "SWAP"
 msgstr ""
 

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -67,7 +67,7 @@ msgid "CREATE FEE TOKEN"
 msgstr ""
 
 #: src/screens/CreateTokenAmount.js:36
-#: src/screens/CreateTokenConfirm.js:84
+#: src/screens/CreateTokenConfirm.js:91
 #: src/screens/CreateTokenDepositNotice.js:42
 #: src/screens/CreateTokenTypeNotice.js:94
 #: src/utils.js:654
@@ -360,65 +360,71 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:34
+#: src/screens/CreateTokenConfirm.js:35
 msgid ""
 "You chose to create a **Deposit-Based Token**, which requires a 1% HTR "
 "deposit."
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:36
+#: src/screens/CreateTokenConfirm.js:37
 msgid ""
 "You chose to create a **Fee-Based Token**, so a small fee will be applied "
 "to each future transaction of this token."
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:140
-msgid "Creating token"
+#: src/screens/CreateTokenConfirm.js:134
+#.  Show a non-dismissable spinner immediately so the user gets feedback and the
+#.  Create token button is disabled while the transaction is being prepared.
+msgid "Building the transaction"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:155
+#: src/screens/CreateTokenConfirm.js:184
 msgid "Enter your 6-digit pin to create your token"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:156
+#: src/screens/CreateTokenConfirm.js:185
 msgid "Authorize token creation"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:158
+#: src/screens/CreateTokenConfirm.js:187
 #: src/screens/SendConfirmScreen.js:105
-#: src/screens/TokenSwapReview.js:205
+#: src/screens/TokenSwapReview.js:221
 msgid "Building transaction"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:216
+#: src/screens/CreateTokenConfirm.js:249
+msgid "Creating token"
+msgstr ""
+
+#: src/screens/CreateTokenConfirm.js:252
 #, javascript-format
 msgid "**${ name }** created successfully"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:229
+#: src/screens/CreateTokenConfirm.js:264
 msgid "Amount of ${ name }"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:238
+#: src/screens/CreateTokenConfirm.js:281
 msgid "Token name"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:244
+#: src/screens/CreateTokenConfirm.js:287
 #: src/screens/CreateTokenSymbol.js:71
 msgid "Token symbol"
 msgstr ""
 
 #: src/components/Reown/CreateTokenRequest.js:87
 #: src/components/Reown/CreateTokenRequest.js:129
-#: src/screens/CreateTokenConfirm.js:251
+#: src/screens/CreateTokenConfirm.js:294
 msgid "Deposit"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:259
+#: src/screens/CreateTokenConfirm.js:302
 msgid "Network fee"
 msgstr ""
 
-#: src/screens/CreateTokenConfirm.js:268
+#: src/screens/CreateTokenConfirm.js:311
 msgid "Create token"
 msgstr ""
 
@@ -993,25 +999,25 @@ msgid "SEND ${ tokenNameUpperCase }"
 msgstr ""
 
 #: src/screens/SendConfirmScreen.js:33
-#: src/screens/TokenSwapReview.js:304
+#: src/screens/TokenSwapReview.js:320
 msgid "No fee"
 msgstr ""
 
 #: src/screens/SendConfirmScreen.js:90
-#: src/screens/TokenSwapReview.js:189
+#: src/screens/TokenSwapReview.js:205
 #.  show loading modal
 msgid "Your transfer is being processed"
 msgstr ""
 
 #: src/sagas/helpers.js:147
 #: src/screens/SendConfirmScreen.js:103
-#: src/screens/TokenSwapReview.js:203
+#: src/screens/TokenSwapReview.js:219
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr ""
 
 #: src/sagas/helpers.js:148
 #: src/screens/SendConfirmScreen.js:104
-#: src/screens/TokenSwapReview.js:204
+#: src/screens/TokenSwapReview.js:220
 msgid "Authorize operation"
 msgstr ""
 
@@ -1157,25 +1163,25 @@ msgstr ""
 msgid "Loading Token Swap"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:215
+#: src/screens/TokenSwapReview.js:231
 msgid "REVIEW TOKEN SWAP"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:221
+#: src/screens/TokenSwapReview.js:237
 msgid "Building the swap transaction for your review"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:239
+#: src/screens/TokenSwapReview.js:255
 msgid "Your swap was successful"
 msgstr ""
 
 #: src/components/Reown/CreateTokenRequest.js:130
 #: src/components/Reown/TransactionFees.js:55
-#: src/screens/TokenSwapReview.js:300
+#: src/screens/TokenSwapReview.js:316
 msgid "Network Fee"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:312
+#: src/screens/TokenSwapReview.js:328
 msgid "SWAP"
 msgstr ""
 

--- a/src/components/SendTransactionFeedbackModal.js
+++ b/src/components/SendTransactionFeedbackModal.js
@@ -34,23 +34,69 @@ class SendTransactionFeedbackModal extends React.Component {
     errorMessage: '',
   }
 
+  // sendTransaction/promise can arrive after mount (while the tx is still being
+  // prepared); these flags ensure each subscription runs exactly once.
+  promiseSubscribed = false;
+
+  eventsSubscribed = false;
+
+  // The promise resolves independently of the listeners, so it can settle after
+  // unmount; this guards its handlers from calling setState on a dead component.
+  unmounted = false;
+
   componentDidMount = () => {
-    // Start event listeners
-    this.addSendTxEventHandlers();
+    // Props may arrive after mount, so subscriptions are attempted here and
+    // again in componentDidUpdate.
+    this.subscribeToPromise();
+    this.subscribeToSendTransaction();
+  }
+
+  componentDidUpdate = (prevProps) => {
+    if (prevProps.promise !== this.props.promise) {
+      this.subscribeToPromise();
+    }
+    if (prevProps.sendTransaction !== this.props.sendTransaction) {
+      this.subscribeToSendTransaction();
+    }
+  }
+
+  componentWillUnmount = () => {
+    this.unmounted = true;
+    if (this.props.sendTransaction) {
+      this.props.sendTransaction.removeListener('job-submitted', this.updateEstimation);
+      this.props.sendTransaction.removeListener('estimation-updated', this.updateEstimation);
+      this.props.sendTransaction.removeListener('job-done', this.jobDone);
+    }
   }
 
   /**
-   * Create event listeners for all sendTransaction events
+   * Subscribe to the promise that mines and propagates the tx. It also covers
+   * the building phase: a failure while preparing the tx rejects this promise
+   * and is shown as an error in this same modal.
    */
-  addSendTxEventHandlers = () => {
-    this.props.sendTransaction.on('job-submitted', this.updateEstimation);
-    this.props.sendTransaction.on('estimation-updated', this.updateEstimation);
-    this.props.sendTransaction.on('job-done', this.jobDone);
+  subscribeToPromise = () => {
+    if (this.promiseSubscribed || !this.props.promise) {
+      return;
+    }
+    this.promiseSubscribed = true;
     this.props.promise.then((tx) => {
       this.onSendSuccess(tx);
     }, (err) => {
       this.onSendError(err.message);
     });
+  }
+
+  /**
+   * Create event listeners for all sendTransaction mining events.
+   */
+  subscribeToSendTransaction = () => {
+    if (this.eventsSubscribed || !this.props.sendTransaction) {
+      return;
+    }
+    this.eventsSubscribed = true;
+    this.props.sendTransaction.on('job-submitted', this.updateEstimation);
+    this.props.sendTransaction.on('estimation-updated', this.updateEstimation);
+    this.props.sendTransaction.on('job-done', this.jobDone);
   }
 
   /**
@@ -60,6 +106,9 @@ class SendTransactionFeedbackModal extends React.Component {
    * @param {Object} tx Transaction data
    */
   onSendSuccess = (tx) => {
+    if (this.unmounted) {
+      return;
+    }
     this.setState({ sending: false, success: true, errorMessage: '' });
     if (this.props.onTxSuccess) {
       this.props.onTxSuccess(tx);
@@ -73,6 +122,9 @@ class SendTransactionFeedbackModal extends React.Component {
    * @param {String} message Error message
    */
   onSendError = (message) => {
+    if (this.unmounted) {
+      return;
+    }
     this.setState({ sending: false, success: false, errorMessage: message });
     if (this.props.onTxError) {
       this.props.onTxError(message);
@@ -174,20 +226,22 @@ class SendTransactionFeedbackModal extends React.Component {
 SendTransactionFeedbackModal.defaultProps = {
   // Defaults to not hide the modal
   hide: false,
+  sendTransaction: null,
+  promise: null,
 };
 
 SendTransactionFeedbackModal.propTypes = {
   // Text displayed on the first line of the modal
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
-  // lib object that handles the mining/propagation requests and emit events
+  // lib object that handles the mining/propagation requests and emits events
   sendTransaction: PropTypes.oneOfType([
     PropTypes.instanceOf(hathorLib.SendTransaction),
     PropTypes.instanceOf(hathorLib.SendTransactionWalletService)
-  ]).isRequired,
-  // promise that is mining the transaction using the sendTransaction instance above.
+  ]),
+  // promise that mines/propagates the tx using the sendTransaction instance above
   promise: PropTypes.shape({
     then: PropTypes.func.isRequired,
-  }).isRequired,
+  }),
   // optional method to be executed when the tx is mined and propagated with success
   onTxSuccess: PropTypes.func,
   // optional method to be executed when an error happens while sending the tx

--- a/src/screens/CreateTokenConfirm.js
+++ b/src/screens/CreateTokenConfirm.js
@@ -7,7 +7,6 @@
 
 import React, { useEffect, useState } from 'react';
 import {
-  Image,
   View,
 } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
@@ -20,13 +19,10 @@ import AmountTextInput from '../components/AmountTextInput';
 import InputLabel from '../components/InputLabel';
 import HathorHeader from '../components/HathorHeader';
 import OfflineBar from '../components/OfflineBar';
-import FeedbackModal from '../components/FeedbackModal';
-import Spinner from '../components/Spinner';
 import SendTransactionFeedbackModal from '../components/SendTransactionFeedbackModal';
 import TextFmt from '../components/TextFmt';
 import { updateSelectedToken } from '../actions';
 import { registerToken } from '../utils/tokens';
-import errorIcon from '../assets/images/icErrorBig.png';
 import { InfoCircleIcon } from '../components/Icons/InfoCircle';
 import { useNavigation, useParams } from '../hooks/navigation';
 import { getCreateTokenTitle } from '../utils';
@@ -80,10 +76,10 @@ const CreateTokenConfirm = () => {
   const nativeSymbol = wallet.storage.getNativeTokenData().symbol;
 
   // Component state
-  // Spinner while the tx is being prepared, and error feedback after a failure
-  const [showFeedbackModal, setFeedbackModal] = useState(null);
-  // Tracks mining/propagation once the tx is prepared
-  const [showSendTransactionModal, setSendTransactionModal] = useState(null);
+  // A single modal drives the whole flow: it mounts showing a spinner while the
+  // tx is prepared (sendTransaction/promise still null) and then tracks
+  // mining/propagation once they are ready. Shape: { text, sendTransaction, promise }
+  const [sendTransactionModal, setSendTransactionModal] = useState(null);
   // Disables the Create token button from the moment it's tapped until the screen
   // is interactive again, closing the window between the PinScreen dismissal and
   // the feedback modal render where the button would otherwise be tappable.
@@ -121,20 +117,14 @@ const CreateTokenConfirm = () => {
   }, [navigation]);
 
   /**
-   * Prepare data and execute create token
-   * If success when preparing, show feedback modal, otherwise show error
+   * Prepare and create the token. The promise built here covers the whole flow —
+   * prepare, then mine/propagate — so a failure while preparing surfaces as an
+   * error in the same feedback modal.
    *
-   * @param {String} pinCode User PIN
+   * @param {String} pin User PIN
    */
-  const executeCreate = async (pin) => {
-    // Show a non-dismissable spinner immediately so the user gets feedback and the
-    // Create token button is disabled while the transaction is being prepared.
-    setFeedbackModal({
-      icon: <Spinner />,
-      text: t`Building the transaction`,
-    });
-
-    try {
+  const executeCreate = (pin) => {
+    const promise = (async () => {
       if (useWalletService) {
         await wallet.validateAndRenewAuthToken(pin);
       }
@@ -147,29 +137,21 @@ const CreateTokenConfirm = () => {
         { address, pinCode: pin, tokenVersion }
       );
 
-      let sendTransaction;
-      if (useWalletService) {
-        sendTransaction = new hathorLib.SendTransactionWalletService(
-          wallet,
-          { transaction: tx }
-        );
-      } else {
-        sendTransaction = new hathorLib.SendTransaction(
-          { storage: wallet.storage, transaction: tx, pin }
-        );
-      }
+      const sendTransaction = useWalletService
+        ? new hathorLib.SendTransactionWalletService(wallet, { transaction: tx })
+        : new hathorLib.SendTransaction({ storage: wallet.storage, transaction: tx, pin });
 
-      const promise = sendTransaction.runFromMining();
+      // Hand the instance to the modal so it subscribes to mining events.
+      setSendTransactionModal((prev) => ({ ...prev, sendTransaction, text: t`Creating token` }));
 
-      // swap the spinner for the modal that tracks mining/propagation
-      setFeedbackModal(null);
-      setSendTransactionModal({
-        sendTransaction,
-        promise,
-      });
-    } catch (err) {
-      onError(err.message);
-    }
+      return sendTransaction.runFromMining();
+    })();
+
+    setSendTransactionModal({
+      text: t`Building the transaction`,
+      sendTransaction: null,
+      promise,
+    });
   };
 
   /**
@@ -201,20 +183,6 @@ const CreateTokenConfirm = () => {
   };
 
   /**
-   * Show error message if there is one while creating the token
-   *
-   * @param {String} message Error message
-   */
-  const onError = (message) => {
-    setSendTransactionModal(null);
-    setFeedbackModal({
-      icon: <Image source={errorIcon} style={{ height: 105, width: 105 }} resizeMode='contain' />,
-      text: message,
-      onDismiss: () => setFeedbackModal(null),
-    });
-  };
-
-  /**
    * Method executed after dismiss success modal
    */
   const exitScreen = () => {
@@ -223,10 +191,8 @@ const CreateTokenConfirm = () => {
   };
 
   // Keep the button disabled from the moment it's tapped (isSending) and while
-  // any modal (preparing spinner, mining progress or error) is on screen.
-  const isCreatingToken = isSending
-    || showFeedbackModal !== null
-    || showSendTransactionModal !== null;
+  // the feedback modal (building spinner, mining progress or error) is on screen.
+  const isCreatingToken = isSending || sendTransactionModal !== null;
 
   return (
     <View style={{ flex: 1 }}>
@@ -236,19 +202,11 @@ const CreateTokenConfirm = () => {
         onCancel={() => navigation.getParent().goBack()}
       />
 
-      {showFeedbackModal && (
-        <FeedbackModal
-          icon={showFeedbackModal.icon}
-          text={showFeedbackModal.text}
-          onDismiss={showFeedbackModal.onDismiss}
-        />
-      )}
-
-      {showSendTransactionModal && (
+      {sendTransactionModal && (
         <SendTransactionFeedbackModal
-          text={t`Creating token`}
-          sendTransaction={showSendTransactionModal.sendTransaction}
-          promise={showSendTransactionModal.promise}
+          text={sendTransactionModal.text}
+          sendTransaction={sendTransactionModal.sendTransaction}
+          promise={sendTransactionModal.promise}
           successText={<TextFmt>{t`**${name}** created successfully`}</TextFmt>}
           onTxSuccess={onTxSuccess}
           onDismissSuccess={exitScreen}

--- a/src/screens/CreateTokenConfirm.js
+++ b/src/screens/CreateTokenConfirm.js
@@ -21,6 +21,7 @@ import InputLabel from '../components/InputLabel';
 import HathorHeader from '../components/HathorHeader';
 import OfflineBar from '../components/OfflineBar';
 import FeedbackModal from '../components/FeedbackModal';
+import Spinner from '../components/Spinner';
 import SendTransactionFeedbackModal from '../components/SendTransactionFeedbackModal';
 import TextFmt from '../components/TextFmt';
 import { updateSelectedToken } from '../actions';
@@ -79,8 +80,14 @@ const CreateTokenConfirm = () => {
   const nativeSymbol = wallet.storage.getNativeTokenData().symbol;
 
   // Component state
-  const [modal, setModal] = useState(null);
-  const [modalType, setModalType] = useState(null);
+  // Spinner while the tx is being prepared, and error feedback after a failure
+  const [showFeedbackModal, setFeedbackModal] = useState(null);
+  // Tracks mining/propagation once the tx is prepared
+  const [showSendTransactionModal, setSendTransactionModal] = useState(null);
+  // Disables the Create token button from the moment it's tapped until the screen
+  // is interactive again, closing the window between the PinScreen dismissal and
+  // the feedback modal render where the button would otherwise be tappable.
+  const [isSending, setIsSending] = useState(false);
   const [title, setTitle] = useState(t`CREATE TOKEN`);
   const [deposit, setDeposit] = useState(null);
   const [networkFee, setNetworkFee] = useState(null);
@@ -102,6 +109,17 @@ const CreateTokenConfirm = () => {
     }
   }, [tokenVersion, amount]);
 
+  // Re-enable the Create token button whenever this screen regains focus. This
+  // covers the PinScreen being dismissed by cancel or hardware back (neither
+  // sets the feedback modal).
+  useEffect(() => {
+    const focusListener = navigation.addListener('focus', () => {
+      setIsSending(false);
+    });
+
+    return focusListener;
+  }, [navigation]);
+
   /**
    * Prepare data and execute create token
    * If success when preparing, show feedback modal, otherwise show error
@@ -109,17 +127,26 @@ const CreateTokenConfirm = () => {
    * @param {String} pinCode User PIN
    */
   const executeCreate = async (pin) => {
-    if (useWalletService) {
-      await wallet.validateAndRenewAuthToken(pin);
-    }
+    // Show a non-dismissable spinner immediately so the user gets feedback and the
+    // Create token button is disabled while the transaction is being prepared.
+    setFeedbackModal({
+      icon: <Spinner />,
+      text: t`Building the transaction`,
+    });
 
-    const { address } = await wallet.getCurrentAddress({ markAsUsed: true });
-    wallet.prepareCreateNewToken(
-      name,
-      symbol,
-      amount,
-      { address, pinCode: pin, tokenVersion }
-    ).then((tx) => {
+    try {
+      if (useWalletService) {
+        await wallet.validateAndRenewAuthToken(pin);
+      }
+
+      const { address } = await wallet.getCurrentAddress({ markAsUsed: true });
+      const tx = await wallet.prepareCreateNewToken(
+        name,
+        symbol,
+        amount,
+        { address, pinCode: pin, tokenVersion }
+      );
+
       let sendTransaction;
       if (useWalletService) {
         sendTransaction = new hathorLib.SendTransactionWalletService(
@@ -134,22 +161,24 @@ const CreateTokenConfirm = () => {
 
       const promise = sendTransaction.runFromMining();
 
-      // show loading modal
-      setModalType('SendTransactionFeedbackModal');
-      setModal({
-        text: t`Creating token`,
+      // swap the spinner for the modal that tracks mining/propagation
+      setFeedbackModal(null);
+      setSendTransactionModal({
         sendTransaction,
         promise,
       });
-    }, (err) => {
+    } catch (err) {
       onError(err.message);
-    });
+    }
   };
 
   /**
    * Executed when user clicks to create the token and opens the PIN screen
    */
   const onSendPress = () => {
+    // Disable the button before opening the PinScreen so it can't be tapped
+    // again while we return from it and build the feedback modal.
+    setIsSending(true);
     const pinParams = {
       cb: executeCreate,
       screenText: t`Enter your 6-digit pin to create your token`,
@@ -177,11 +206,11 @@ const CreateTokenConfirm = () => {
    * @param {String} message Error message
    */
   const onError = (message) => {
-    setModalType('FeedbackModal');
-    setModal({
+    setSendTransactionModal(null);
+    setFeedbackModal({
       icon: <Image source={errorIcon} style={{ height: 105, width: 105 }} resizeMode='contain' />,
       text: message,
-      onDismiss: () => setModal(null),
+      onDismiss: () => setFeedbackModal(null),
     });
   };
 
@@ -189,9 +218,15 @@ const CreateTokenConfirm = () => {
    * Method executed after dismiss success modal
    */
   const exitScreen = () => {
-    setModal(null);
+    setSendTransactionModal(null);
     navigation.navigate('CreateTokenDetail');
   };
+
+  // Keep the button disabled from the moment it's tapped (isSending) and while
+  // any modal (preparing spinner, mining progress or error) is on screen.
+  const isCreatingToken = isSending
+    || showFeedbackModal !== null
+    || showSendTransactionModal !== null;
 
   return (
     <View style={{ flex: 1 }}>
@@ -201,25 +236,25 @@ const CreateTokenConfirm = () => {
         onCancel={() => navigation.getParent().goBack()}
       />
 
-      {modal && (
-        modalType === 'FeedbackModal' ? (
-          <FeedbackModal
-            icon={modal.icon}
-            text={modal.text}
-            onDismiss={modal.onDismiss}
-          />
-        ) : (
-          <SendTransactionFeedbackModal
-            text={modal.text}
-            sendTransaction={modal.sendTransaction}
-            promise={modal.promise}
-            successText={<TextFmt>{t`**${name}** created successfully`}</TextFmt>}
-            onTxSuccess={onTxSuccess}
-            onDismissSuccess={exitScreen}
-            onDismissError={() => setModal(null)}
-            hide={isShowingPinScreen}
-          />
-        )
+      {showFeedbackModal && (
+        <FeedbackModal
+          icon={showFeedbackModal.icon}
+          text={showFeedbackModal.text}
+          onDismiss={showFeedbackModal.onDismiss}
+        />
+      )}
+
+      {showSendTransactionModal && (
+        <SendTransactionFeedbackModal
+          text={t`Creating token`}
+          sendTransaction={showSendTransactionModal.sendTransaction}
+          promise={showSendTransactionModal.promise}
+          successText={<TextFmt>{t`**${name}** created successfully`}</TextFmt>}
+          onTxSuccess={onTxSuccess}
+          onDismissSuccess={exitScreen}
+          onDismissError={() => setSendTransactionModal(null)}
+          hide={isShowingPinScreen}
+        />
       )}
 
       <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>
@@ -232,6 +267,14 @@ const CreateTokenConfirm = () => {
               editable={false}
               decimalPlaces={decimalPlaces}
               value={hathorLib.numberUtils.prettyValue(amount)}
+              // Stretch to the full column width so AmountTextInput's
+              // auto-shrink measures the available width instead of hugging
+              // its content. Inside this `alignItems: 'center'` column the
+              // input would otherwise size to its text, feeding a tiny width
+              // back into the shrink calc and collapsing the font to the
+              // minimum. This is the column-axis equivalent of the `flex: 1`
+              // used on the Send and Token Swap screens.
+              style={{ alignSelf: 'stretch' }}
             />
           </View>
           <SimpleInput
@@ -267,8 +310,7 @@ const CreateTokenConfirm = () => {
         <NewHathorButton
           title={t`Create token`}
           onPress={onSendPress}
-          // disable while modal is visible
-          disabled={modal !== null}
+          disabled={isCreatingToken}
         />
       </View>
       <OfflineBar />


### PR DESCRIPTION
### Acceptance Criteria
- preparing your transaction modal should appear right after the pin screen is dismissed (either success or cancel/error)
- amount size should be stable while interacting with the pin screen and the create token button

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

https://github.com/user-attachments/assets/64623b0d-b521-4f23-adc0-36470220f82d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with clearer error messages during token creation.
  * Fixed button disabled state management throughout the token creation workflow.

* **New Features**
  * Added visual feedback displaying transaction preparation status.
  * Enhanced transaction submission feedback with dedicated status modal.





* **Style**
  * Adjusted input field layout for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->