### PR TITLE
fix: persist registered nano contracts per network

### DIFF
--- a/__tests__/sagas/nanoContractPersistence.test.js
+++ b/__tests__/sagas/nanoContractPersistence.test.js
@@ -1,0 +1,301 @@
+import { put, call } from 'redux-saga/effects';
+import { jest, test, expect, beforeEach, describe } from '@jest/globals';
+import {
+  saveNetworkNanoContracts,
+  restoreNetworkNanoContracts,
+  updateNetworkNanoContractSnapshot,
+} from '../../src/sagas/nanoContract';
+import {
+  nanoContractsSavedForNetwork,
+  nanoContractRegisterSuccess,
+} from '../../src/actions';
+import { STORE } from '../../src/store';
+
+const GENESIS_HASH = 'abc123def456genesis';
+
+const contract1 = {
+  ncId: 'nc1', address: 'addr1', blueprintId: 'bp1', blueprintName: 'Blueprint One',
+};
+const contract2 = {
+  ncId: 'nc2', address: 'addr2', blueprintId: 'bp2', blueprintName: 'Blueprint Two',
+};
+// Map keyed by ncId, the shape persisted per-network.
+const mockContractsMap = { nc1: contract1, nc2: contract2 };
+// Array shape returned by getRegisteredNanoContracts(wallet).
+const mockContractsArray = [contract1, contract2];
+
+const mockWallet = {
+  isReady: () => true,
+  storage: {
+    isNanoContractRegistered: jest.fn(),
+    registerNanoContract: jest.fn(),
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  STORE.clearItems();
+});
+
+describe('saveNetworkNanoContracts', () => {
+  test('saves registered nano contracts when genesis hash is available', () => {
+    const gen = saveNetworkNanoContracts();
+
+    // select serverInfo
+    gen.next();
+    // feed serverInfo, then select wallet
+    gen.next({ genesis_block_hash: GENESIS_HASH });
+    // feed wallet, then call getRegisteredNanoContracts
+    gen.next(mockWallet);
+
+    // feed registered contracts array, expect call to STORE.saveNanoContractsForNetwork
+    // with the array flattened into a map keyed by ncId
+    const saveCall = gen.next(mockContractsArray);
+    expect(saveCall.value).toStrictEqual(
+      call([STORE, STORE.saveNanoContractsForNetwork], GENESIS_HASH, mockContractsMap),
+    );
+
+    // advance past save, should dispatch nanoContractsSavedForNetwork
+    const result = gen.next();
+    expect(result.value).toStrictEqual(put(nanoContractsSavedForNetwork()));
+
+    expect(gen.next().done).toBe(true);
+  });
+
+  test('dispatches nanoContractsSavedForNetwork even without genesis hash', () => {
+    const gen = saveNetworkNanoContracts();
+
+    // select serverInfo
+    gen.next();
+    // feed serverInfo with no genesis hash
+    const result = gen.next({ genesis_block_hash: null });
+
+    expect(result.value).toStrictEqual(put(nanoContractsSavedForNetwork()));
+    expect(gen.next().done).toBe(true);
+  });
+
+  test('dispatches nanoContractsSavedForNetwork even without wallet', () => {
+    const gen = saveNetworkNanoContracts();
+
+    // select serverInfo
+    gen.next();
+    // feed serverInfo, then select wallet
+    gen.next({ genesis_block_hash: GENESIS_HASH });
+    // feed null wallet
+    const result = gen.next(null);
+
+    expect(result.value).toStrictEqual(put(nanoContractsSavedForNetwork()));
+    expect(gen.next().done).toBe(true);
+  });
+});
+
+describe('restoreNetworkNanoContracts', () => {
+  test('restores nano contracts for current network and updates Redux', () => {
+    const gen = restoreNetworkNanoContracts();
+
+    // select isNanoContractsEnabled
+    gen.next();
+    // feed enabled=true, then select serverInfo
+    gen.next(true);
+    // feed serverInfo, expect call to STORE.getNanoContractsForNetwork
+    const getCall = gen.next({ genesis_block_hash: GENESIS_HASH });
+    expect(getCall.value).toStrictEqual(
+      call([STORE, STORE.getNanoContractsForNetwork], GENESIS_HASH),
+    );
+
+    // feed saved contracts, then select wallet
+    gen.next(mockContractsMap);
+
+    // feed wallet, then isNanoContractRegistered for nc1
+    const isRegCall1 = gen.next(mockWallet);
+    expect(isRegCall1.value).toStrictEqual(
+      call([mockWallet.storage, mockWallet.storage.isNanoContractRegistered], 'nc1'),
+    );
+
+    // feed isRegistered=false for nc1, expect registerNanoContract call
+    const registerCall1 = gen.next(false);
+    expect(registerCall1.value).toStrictEqual(
+      call([mockWallet.storage, mockWallet.storage.registerNanoContract], 'nc1', contract1),
+    );
+
+    // advance past registerNanoContract, expect nanoContractRegisterSuccess dispatch
+    const successPut1 = gen.next();
+    expect(successPut1.value).toStrictEqual(
+      put(nanoContractRegisterSuccess({ entryKey: 'nc1', entryValue: contract1 })),
+    );
+
+    // next loop iteration: isNanoContractRegistered for nc2
+    const isRegCall2 = gen.next();
+    expect(isRegCall2.value).toStrictEqual(
+      call([mockWallet.storage, mockWallet.storage.isNanoContractRegistered], 'nc2'),
+    );
+
+    // feed isRegistered=false for nc2, expect registerNanoContract call
+    const registerCall2 = gen.next(false);
+    expect(registerCall2.value).toStrictEqual(
+      call([mockWallet.storage, mockWallet.storage.registerNanoContract], 'nc2', contract2),
+    );
+
+    const successPut2 = gen.next();
+    expect(successPut2.value).toStrictEqual(
+      put(nanoContractRegisterSuccess({ entryKey: 'nc2', entryValue: contract2 })),
+    );
+
+    expect(gen.next().done).toBe(true);
+  });
+
+  test('skips already registered nano contracts', () => {
+    const gen = restoreNetworkNanoContracts();
+
+    // select isNanoContractsEnabled
+    gen.next();
+    // feed enabled, then select serverInfo
+    gen.next(true);
+    // feed serverInfo, expect STORE.getNanoContractsForNetwork call
+    gen.next({ genesis_block_hash: GENESIS_HASH });
+    // feed saved contracts with one contract
+    gen.next({ nc1: contract1 });
+    // feed wallet
+    gen.next(mockWallet);
+
+    // feed isNanoContractRegistered=true for nc1, saga should end
+    const result = gen.next(true);
+    expect(result.done).toBe(true);
+  });
+
+  test('does nothing when nano contracts feature is disabled', () => {
+    const gen = restoreNetworkNanoContracts();
+
+    // select isNanoContractsEnabled
+    gen.next();
+    // feed enabled=false, saga should end
+    const result = gen.next(false);
+    expect(result.done).toBe(true);
+  });
+
+  test('does nothing without genesis hash', () => {
+    const gen = restoreNetworkNanoContracts();
+
+    // select isNanoContractsEnabled
+    gen.next();
+    // feed enabled, then select serverInfo
+    gen.next(true);
+    // feed serverInfo with no genesis hash
+    const result = gen.next({ genesis_block_hash: null });
+    expect(result.done).toBe(true);
+  });
+
+  test('does nothing without saved contracts', () => {
+    const gen = restoreNetworkNanoContracts();
+
+    // select isNanoContractsEnabled
+    gen.next();
+    // feed enabled, then select serverInfo
+    gen.next(true);
+    // feed serverInfo
+    gen.next({ genesis_block_hash: GENESIS_HASH });
+    // feed null saved contracts
+    const result = gen.next(null);
+    expect(result.done).toBe(true);
+  });
+});
+
+describe('updateNetworkNanoContractSnapshot', () => {
+  test('updates snapshot when wallet start state is ready', () => {
+    const gen = updateNetworkNanoContractSnapshot();
+
+    // select walletStartState
+    gen.next();
+    // feed walletStartState='ready', then select wallet (guard)
+    gen.next('ready');
+    // feed wallet (guard passes), then select serverInfo (from persist)
+    gen.next(mockWallet);
+    // feed serverInfo, then select wallet (from persist)
+    gen.next({ genesis_block_hash: GENESIS_HASH });
+    // feed wallet, then call getRegisteredNanoContracts
+    gen.next(mockWallet);
+
+    // feed contracts array, expect call to STORE.saveNanoContractsForNetwork
+    const saveCall = gen.next(mockContractsArray);
+    expect(saveCall.value).toStrictEqual(
+      call([STORE, STORE.saveNanoContractsForNetwork], GENESIS_HASH, mockContractsMap),
+    );
+
+    expect(gen.next().done).toBe(true);
+  });
+
+  test('does nothing when walletStartState is not ready', () => {
+    const gen = updateNetworkNanoContractSnapshot();
+
+    // select walletStartState
+    gen.next();
+    // feed walletStartState='loading' — should exit early
+    const result = gen.next('loading');
+    expect(result.done).toBe(true);
+  });
+
+  test('does nothing without genesis hash', () => {
+    const gen = updateNetworkNanoContractSnapshot();
+
+    // select walletStartState
+    gen.next();
+    // feed walletStartState='ready', then select wallet (guard)
+    gen.next('ready');
+    // feed wallet (guard passes), then select serverInfo (from persist)
+    gen.next(mockWallet);
+    // feed serverInfo without genesis hash — should exit early
+    const result = gen.next({});
+    expect(result.done).toBe(true);
+  });
+
+  test('does nothing when wallet is not ready', () => {
+    const gen = updateNetworkNanoContractSnapshot();
+
+    // select walletStartState
+    gen.next();
+    // feed walletStartState='ready', then select wallet (guard)
+    gen.next('ready');
+    // feed wallet that is not ready — should exit early
+    const result = gen.next({ isReady: () => false });
+    expect(result.done).toBe(true);
+  });
+});
+
+describe('STORE network nano contracts persistence', () => {
+  test('saveNanoContractsForNetwork and getNanoContractsForNetwork roundtrip', () => {
+    expect(STORE.getNanoContractsForNetwork(GENESIS_HASH)).toBeNull();
+
+    STORE.saveNanoContractsForNetwork(GENESIS_HASH, mockContractsMap);
+    expect(STORE.getNanoContractsForNetwork(GENESIS_HASH))
+      .toStrictEqual(mockContractsMap);
+  });
+
+  test('different genesis hashes are independent', () => {
+    const otherHash = 'other_genesis_hash';
+    STORE.saveNanoContractsForNetwork(GENESIS_HASH, mockContractsMap);
+    STORE.saveNanoContractsForNetwork(otherHash, { nc3: { ncId: 'nc3' } });
+
+    expect(STORE.getNanoContractsForNetwork(GENESIS_HASH))
+      .toStrictEqual(mockContractsMap);
+    expect(STORE.getNanoContractsForNetwork(otherHash))
+      .toStrictEqual({ nc3: { ncId: 'nc3' } });
+  });
+
+  test('returns null for unknown genesis hash', () => {
+    expect(STORE.getNanoContractsForNetwork('unknown')).toBeNull();
+  });
+
+  test('returns null for null/undefined genesis hash', () => {
+    expect(STORE.getNanoContractsForNetwork(null)).toBeNull();
+    expect(STORE.getNanoContractsForNetwork(undefined)).toBeNull();
+  });
+
+  test('cleared on wallet reset', async () => {
+    STORE.saveNanoContractsForNetwork(GENESIS_HASH, mockContractsMap);
+    expect(STORE.getNanoContractsForNetwork(GENESIS_HASH))
+      .toStrictEqual(mockContractsMap);
+
+    await STORE.resetWallet();
+    expect(STORE.getNanoContractsForNetwork(GENESIS_HASH)).toBeNull();
+  });
+});

--- a/locale/da/texts.po
+++ b/locale/da/texts.po
@@ -384,7 +384,7 @@ msgid "Authorize token creation"
 msgstr "Autoriser oprettelse af token"
 
 #: src/screens/CreateTokenConfirm.js:158 src/screens/SendConfirmScreen.js:105
-#: src/screens/TokenSwapReview.js:205
+#: src/screens/TokenSwapReview.js:221
 msgid "Building transaction"
 msgstr ""
 
@@ -985,22 +985,22 @@ msgstr[1] ""
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "SEND ${ tokenNameUpperCase }"
 
-#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:304
+#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:320
 msgid "No fee"
 msgstr ""
 
 #.  show loading modal
-#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:189
+#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:205
 msgid "Your transfer is being processed"
 msgstr "Din overførsel behandles"
 
 #: src/sagas/helpers.js:147 src/screens/SendConfirmScreen.js:103
-#: src/screens/TokenSwapReview.js:203
+#: src/screens/TokenSwapReview.js:219
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Indtast din 6-cifrede pin for at godkende overførslen"
 
 #: src/sagas/helpers.js:148 src/screens/SendConfirmScreen.js:104
-#: src/screens/TokenSwapReview.js:204
+#: src/screens/TokenSwapReview.js:220
 msgid "Authorize operation"
 msgstr "Autoriserer overførslen"
 
@@ -1145,25 +1145,25 @@ msgstr ""
 msgid "Loading Token Swap"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:215
+#: src/screens/TokenSwapReview.js:231
 msgid "REVIEW TOKEN SWAP"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:221
+#: src/screens/TokenSwapReview.js:237
 msgid "Building the swap transaction for your review"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:239
+#: src/screens/TokenSwapReview.js:255
 msgid "Your swap was successful"
 msgstr ""
 
 #: src/components/Reown/CreateTokenRequest.js:130
 #: src/components/Reown/TransactionFees.js:55
-#: src/screens/TokenSwapReview.js:300
+#: src/screens/TokenSwapReview.js:316
 msgid "Network Fee"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:312
+#: src/screens/TokenSwapReview.js:328
 msgid "SWAP"
 msgstr ""
 
@@ -1537,71 +1537,71 @@ msgstr ""
 msgid "Contract successfully registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:92
+#: src/sagas/nanoContract.js:95
 msgid "Nano Contract already registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:93
+#: src/sagas/nanoContract.js:96
 msgid "Wallet is not ready yet to register a Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:94
+#: src/sagas/nanoContract.js:97
 msgid "The informed address does not belong to the wallet."
 msgstr ""
 
-#: src/sagas/nanoContract.js:95
+#: src/sagas/nanoContract.js:98
 msgid "Nano Contract not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:96
+#: src/sagas/nanoContract.js:99
 msgid "Error while trying to register Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:97
+#: src/sagas/nanoContract.js:100
 msgid "Invalid transaction to register as Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:98
+#: src/sagas/nanoContract.js:101
 msgid "Blueprint not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:99
+#: src/sagas/nanoContract.js:102
 msgid "Couldn't get Blueprint info."
 msgstr ""
 
-#: src/sagas/nanoContract.js:100
+#: src/sagas/nanoContract.js:103
 msgid "Nano Contract not registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:101
+#: src/sagas/nanoContract.js:104
 msgid "Error while trying to download Nano Contract transactions history."
 msgstr ""
 
-#: src/sagas/networkSettings.js:87
+#: src/sagas/networkSettings.js:88
 msgid "Custom Network Settings cannot be empty."
 msgstr ""
 
-#: src/sagas/networkSettings.js:94
+#: src/sagas/networkSettings.js:95
 msgid "explorerUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:101
+#: src/sagas/networkSettings.js:102
 msgid "explorerServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:108
+#: src/sagas/networkSettings.js:109
 msgid "txMiningServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:115
+#: src/sagas/networkSettings.js:116
 msgid "nodeUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:122
+#: src/sagas/networkSettings.js:123
 msgid "walletServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:129
+#: src/sagas/networkSettings.js:130
 msgid "walletServiceWsUrl should be a valid URL."
 msgstr ""
 

--- a/locale/pt-br/texts.po
+++ b/locale/pt-br/texts.po
@@ -401,7 +401,7 @@ msgid "Authorize token creation"
 msgstr "Autorizar criação de token"
 
 #: src/screens/CreateTokenConfirm.js:158 src/screens/SendConfirmScreen.js:105
-#: src/screens/TokenSwapReview.js:205
+#: src/screens/TokenSwapReview.js:221
 msgid "Building transaction"
 msgstr "Criando transação"
 
@@ -1014,22 +1014,22 @@ msgstr[1] "${ amountAndToken } disponíveis"
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "ENVIAR ${ tokenNameUpperCase }"
 
-#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:304
+#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:320
 msgid "No fee"
 msgstr "Sem taxa"
 
 #.  show loading modal
-#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:189
+#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:205
 msgid "Your transfer is being processed"
 msgstr "Sua transferência está sendo processada"
 
 #: src/sagas/helpers.js:147 src/screens/SendConfirmScreen.js:103
-#: src/screens/TokenSwapReview.js:203
+#: src/screens/TokenSwapReview.js:219
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Digite seu PIN de 6 dígitos para autorizar a operação"
 
 #: src/sagas/helpers.js:148 src/screens/SendConfirmScreen.js:104
-#: src/screens/TokenSwapReview.js:204
+#: src/screens/TokenSwapReview.js:220
 msgid "Authorize operation"
 msgstr "Autorizar operação"
 
@@ -1174,25 +1174,25 @@ msgstr "Ocorreu um erro ao carregar o protocolo de troca de tokens."
 msgid "Loading Token Swap"
 msgstr "Carregando troca de tokens"
 
-#: src/screens/TokenSwapReview.js:215
+#: src/screens/TokenSwapReview.js:231
 msgid "REVIEW TOKEN SWAP"
 msgstr "REVISAR TROCA DE TOKENS"
 
-#: src/screens/TokenSwapReview.js:221
+#: src/screens/TokenSwapReview.js:237
 msgid "Building the swap transaction for your review"
 msgstr "Criando transação de swap para ser revisada"
 
-#: src/screens/TokenSwapReview.js:239
+#: src/screens/TokenSwapReview.js:255
 msgid "Your swap was successful"
 msgstr "Sua troca foi bem-sucedida"
 
 #: src/components/Reown/CreateTokenRequest.js:130
 #: src/components/Reown/TransactionFees.js:55
-#: src/screens/TokenSwapReview.js:300
+#: src/screens/TokenSwapReview.js:316
 msgid "Network Fee"
 msgstr "Taxa de Rede"
 
-#: src/screens/TokenSwapReview.js:312
+#: src/screens/TokenSwapReview.js:328
 msgid "SWAP"
 msgstr "TROCAR"
 
@@ -1580,71 +1580,71 @@ msgstr "Transação do Nano Contract"
 msgid "Contract successfully registered."
 msgstr "Nano Contract registrado com sucesso."
 
-#: src/sagas/nanoContract.js:92
+#: src/sagas/nanoContract.js:95
 msgid "Nano Contract already registered."
 msgstr "Nano Contract já registrado."
 
-#: src/sagas/nanoContract.js:93
+#: src/sagas/nanoContract.js:96
 msgid "Wallet is not ready yet to register a Nano Contract."
 msgstr "A wallet não está pronta ainda para registrar Nano Contracts."
 
-#: src/sagas/nanoContract.js:94
+#: src/sagas/nanoContract.js:97
 msgid "The informed address does not belong to the wallet."
 msgstr "O endereço informado não pertence a esta carteira."
 
-#: src/sagas/nanoContract.js:95
+#: src/sagas/nanoContract.js:98
 msgid "Nano Contract not found."
 msgstr "Nano Contract não encontrado."
 
-#: src/sagas/nanoContract.js:96
+#: src/sagas/nanoContract.js:99
 msgid "Error while trying to register Nano Contract."
 msgstr "Erro ao tentar registrar o Nano Contract."
 
-#: src/sagas/nanoContract.js:97
+#: src/sagas/nanoContract.js:100
 msgid "Invalid transaction to register as Nano Contract."
 msgstr "Nano Contract inválido."
 
-#: src/sagas/nanoContract.js:98
+#: src/sagas/nanoContract.js:101
 msgid "Blueprint not found."
 msgstr "Blueprint não encontrado."
 
-#: src/sagas/nanoContract.js:99
+#: src/sagas/nanoContract.js:102
 msgid "Couldn't get Blueprint info."
 msgstr "Não foi possível carregar informações do Blueprint."
 
-#: src/sagas/nanoContract.js:100
+#: src/sagas/nanoContract.js:103
 msgid "Nano Contract not registered."
 msgstr "Nano Contract não registrado."
 
-#: src/sagas/nanoContract.js:101
+#: src/sagas/nanoContract.js:104
 msgid "Error while trying to download Nano Contract transactions history."
 msgstr "Error ao fazer download do histórico de transações do Nano Contract."
 
-#: src/sagas/networkSettings.js:87
+#: src/sagas/networkSettings.js:88
 msgid "Custom Network Settings cannot be empty."
 msgstr "As Configurações de Rede não podem estar vazias."
 
-#: src/sagas/networkSettings.js:94
+#: src/sagas/networkSettings.js:95
 msgid "explorerUrl should be a valid URL."
 msgstr "explorerUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:101
+#: src/sagas/networkSettings.js:102
 msgid "explorerServiceUrl should be a valid URL."
 msgstr "explorerServiceUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:108
+#: src/sagas/networkSettings.js:109
 msgid "txMiningServiceUrl should be a valid URL."
 msgstr "txMiningServiceUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:115
+#: src/sagas/networkSettings.js:116
 msgid "nodeUrl should be a valid URL."
 msgstr "nodeUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:122
+#: src/sagas/networkSettings.js:123
 msgid "walletServiceUrl should be a valid URL."
 msgstr "walletServiceUrl deve ser uma URL válida."
 
-#: src/sagas/networkSettings.js:129
+#: src/sagas/networkSettings.js:130
 msgid "walletServiceWsUrl should be a valid URL."
 msgstr "walletServiceWsUrl deve ser uma URL válida."
 

--- a/locale/ru-ru/texts.po
+++ b/locale/ru-ru/texts.po
@@ -385,7 +385,7 @@ msgid "Authorize token creation"
 msgstr "Авторизовать создание токена"
 
 #: src/screens/CreateTokenConfirm.js:158 src/screens/SendConfirmScreen.js:105
-#: src/screens/TokenSwapReview.js:205
+#: src/screens/TokenSwapReview.js:221
 msgid "Building transaction"
 msgstr ""
 
@@ -987,22 +987,22 @@ msgstr[2] ""
 msgid "SEND ${ tokenNameUpperCase }"
 msgstr "ОТПРАВИТЬ ${ tokenNameUpperCase }"
 
-#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:304
+#: src/screens/SendConfirmScreen.js:33 src/screens/TokenSwapReview.js:320
 msgid "No fee"
 msgstr ""
 
 #.  show loading modal
-#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:189
+#: src/screens/SendConfirmScreen.js:90 src/screens/TokenSwapReview.js:205
 msgid "Your transfer is being processed"
 msgstr "Ваш перевод обрабатывается"
 
 #: src/sagas/helpers.js:147 src/screens/SendConfirmScreen.js:103
-#: src/screens/TokenSwapReview.js:203
+#: src/screens/TokenSwapReview.js:219
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr "Введите 6-значный PIN-код для авторизации операции"
 
 #: src/sagas/helpers.js:148 src/screens/SendConfirmScreen.js:104
-#: src/screens/TokenSwapReview.js:204
+#: src/screens/TokenSwapReview.js:220
 msgid "Authorize operation"
 msgstr "Авторизовать операцию"
 
@@ -1148,25 +1148,25 @@ msgstr ""
 msgid "Loading Token Swap"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:215
+#: src/screens/TokenSwapReview.js:231
 msgid "REVIEW TOKEN SWAP"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:221
+#: src/screens/TokenSwapReview.js:237
 msgid "Building the swap transaction for your review"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:239
+#: src/screens/TokenSwapReview.js:255
 msgid "Your swap was successful"
 msgstr ""
 
 #: src/components/Reown/CreateTokenRequest.js:130
 #: src/components/Reown/TransactionFees.js:55
-#: src/screens/TokenSwapReview.js:300
+#: src/screens/TokenSwapReview.js:316
 msgid "Network Fee"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:312
+#: src/screens/TokenSwapReview.js:328
 msgid "SWAP"
 msgstr ""
 
@@ -1542,71 +1542,71 @@ msgstr ""
 msgid "Contract successfully registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:92
+#: src/sagas/nanoContract.js:95
 msgid "Nano Contract already registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:93
+#: src/sagas/nanoContract.js:96
 msgid "Wallet is not ready yet to register a Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:94
+#: src/sagas/nanoContract.js:97
 msgid "The informed address does not belong to the wallet."
 msgstr ""
 
-#: src/sagas/nanoContract.js:95
+#: src/sagas/nanoContract.js:98
 msgid "Nano Contract not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:96
+#: src/sagas/nanoContract.js:99
 msgid "Error while trying to register Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:97
+#: src/sagas/nanoContract.js:100
 msgid "Invalid transaction to register as Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:98
+#: src/sagas/nanoContract.js:101
 msgid "Blueprint not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:99
+#: src/sagas/nanoContract.js:102
 msgid "Couldn't get Blueprint info."
 msgstr ""
 
-#: src/sagas/nanoContract.js:100
+#: src/sagas/nanoContract.js:103
 msgid "Nano Contract not registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:101
+#: src/sagas/nanoContract.js:104
 msgid "Error while trying to download Nano Contract transactions history."
 msgstr ""
 
-#: src/sagas/networkSettings.js:87
+#: src/sagas/networkSettings.js:88
 msgid "Custom Network Settings cannot be empty."
 msgstr ""
 
-#: src/sagas/networkSettings.js:94
+#: src/sagas/networkSettings.js:95
 msgid "explorerUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:101
+#: src/sagas/networkSettings.js:102
 msgid "explorerServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:108
+#: src/sagas/networkSettings.js:109
 msgid "txMiningServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:115
+#: src/sagas/networkSettings.js:116
 msgid "nodeUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:122
+#: src/sagas/networkSettings.js:123
 msgid "walletServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:129
+#: src/sagas/networkSettings.js:130
 msgid "walletServiceWsUrl should be a valid URL."
 msgstr ""
 

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -386,7 +386,7 @@ msgstr ""
 
 #: src/screens/CreateTokenConfirm.js:158
 #: src/screens/SendConfirmScreen.js:105
-#: src/screens/TokenSwapReview.js:205
+#: src/screens/TokenSwapReview.js:221
 msgid "Building transaction"
 msgstr ""
 
@@ -993,25 +993,25 @@ msgid "SEND ${ tokenNameUpperCase }"
 msgstr ""
 
 #: src/screens/SendConfirmScreen.js:33
-#: src/screens/TokenSwapReview.js:304
+#: src/screens/TokenSwapReview.js:320
 msgid "No fee"
 msgstr ""
 
 #: src/screens/SendConfirmScreen.js:90
-#: src/screens/TokenSwapReview.js:189
+#: src/screens/TokenSwapReview.js:205
 #.  show loading modal
 msgid "Your transfer is being processed"
 msgstr ""
 
 #: src/sagas/helpers.js:147
 #: src/screens/SendConfirmScreen.js:103
-#: src/screens/TokenSwapReview.js:203
+#: src/screens/TokenSwapReview.js:219
 msgid "Enter your 6-digit pin to authorize operation"
 msgstr ""
 
 #: src/sagas/helpers.js:148
 #: src/screens/SendConfirmScreen.js:104
-#: src/screens/TokenSwapReview.js:204
+#: src/screens/TokenSwapReview.js:220
 msgid "Authorize operation"
 msgstr ""
 
@@ -1157,25 +1157,25 @@ msgstr ""
 msgid "Loading Token Swap"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:215
+#: src/screens/TokenSwapReview.js:231
 msgid "REVIEW TOKEN SWAP"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:221
+#: src/screens/TokenSwapReview.js:237
 msgid "Building the swap transaction for your review"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:239
+#: src/screens/TokenSwapReview.js:255
 msgid "Your swap was successful"
 msgstr ""
 
 #: src/components/Reown/CreateTokenRequest.js:130
 #: src/components/Reown/TransactionFees.js:55
-#: src/screens/TokenSwapReview.js:300
+#: src/screens/TokenSwapReview.js:316
 msgid "Network Fee"
 msgstr ""
 
-#: src/screens/TokenSwapReview.js:312
+#: src/screens/TokenSwapReview.js:328
 msgid "SWAP"
 msgstr ""
 
@@ -1551,71 +1551,71 @@ msgstr ""
 msgid "Contract successfully registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:92
+#: src/sagas/nanoContract.js:95
 msgid "Nano Contract already registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:93
+#: src/sagas/nanoContract.js:96
 msgid "Wallet is not ready yet to register a Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:94
+#: src/sagas/nanoContract.js:97
 msgid "The informed address does not belong to the wallet."
 msgstr ""
 
-#: src/sagas/nanoContract.js:95
+#: src/sagas/nanoContract.js:98
 msgid "Nano Contract not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:96
+#: src/sagas/nanoContract.js:99
 msgid "Error while trying to register Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:97
+#: src/sagas/nanoContract.js:100
 msgid "Invalid transaction to register as Nano Contract."
 msgstr ""
 
-#: src/sagas/nanoContract.js:98
+#: src/sagas/nanoContract.js:101
 msgid "Blueprint not found."
 msgstr ""
 
-#: src/sagas/nanoContract.js:99
+#: src/sagas/nanoContract.js:102
 msgid "Couldn't get Blueprint info."
 msgstr ""
 
-#: src/sagas/nanoContract.js:100
+#: src/sagas/nanoContract.js:103
 msgid "Nano Contract not registered."
 msgstr ""
 
-#: src/sagas/nanoContract.js:101
+#: src/sagas/nanoContract.js:104
 msgid "Error while trying to download Nano Contract transactions history."
 msgstr ""
 
-#: src/sagas/networkSettings.js:87
+#: src/sagas/networkSettings.js:88
 msgid "Custom Network Settings cannot be empty."
 msgstr ""
 
-#: src/sagas/networkSettings.js:94
+#: src/sagas/networkSettings.js:95
 msgid "explorerUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:101
+#: src/sagas/networkSettings.js:102
 msgid "explorerServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:108
+#: src/sagas/networkSettings.js:109
 msgid "txMiningServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:115
+#: src/sagas/networkSettings.js:116
 msgid "nodeUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:122
+#: src/sagas/networkSettings.js:123
 msgid "walletServiceUrl should be a valid URL."
 msgstr ""
 
-#: src/sagas/networkSettings.js:129
+#: src/sagas/networkSettings.js:130
 msgid "walletServiceWsUrl should be a valid URL."
 msgstr ""
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -171,6 +171,10 @@ export const types = {
   NANOCONTRACT_UNREGISTER_SUCCESS: 'NANOCONTRACT_UNREGISTER_SUCCESS',
   /* It initiates a process to change the address on registered Nano Contract. */
   NANOCONTRACT_ADDRESS_CHANGE_REQUEST: 'NANOCONTRACT_ADDRESS_CHANGE_REQUEST',
+  /* It asks the nano contract saga to snapshot the current registered contracts for the active network. */
+  SAVE_NANO_CONTRACTS_FOR_NETWORK: 'SAVE_NANO_CONTRACTS_FOR_NETWORK',
+  /* It signals the registered nano contracts were snapshotted for the active network. */
+  NANO_CONTRACTS_SAVED_FOR_NETWORK: 'NANO_CONTRACTS_SAVED_FOR_NETWORK',
   /* It triggers a process to fetch blueprint info. */
   NANOCONTRACT_BLUEPRINTINFO_REQUEST: 'NANOCONTRACT_BLUEPRINTINFO_REQUEST',
   /* It signals a failure on fetch blueprint info. */
@@ -1214,6 +1218,22 @@ export const networkSettingsUpdateReady = () => ({
  */
 export const nanoContractInit = () => ({
   type: types.NANOCONTRACT_INIT,
+});
+
+/**
+ * Ask the nano contract saga to snapshot the currently registered nano
+ * contracts for the active network before the storage is wiped on a
+ * network change.
+ */
+export const saveNanoContractsForNetwork = () => ({
+  type: types.SAVE_NANO_CONTRACTS_FOR_NETWORK,
+});
+
+/**
+ * Signals the registered nano contracts were snapshotted for the active network.
+ */
+export const nanoContractsSavedForNetwork = () => ({
+  type: types.NANO_CONTRACTS_SAVED_FOR_NETWORK,
 });
 
 /**

--- a/src/sagas/helpers.js
+++ b/src/sagas/helpers.js
@@ -214,6 +214,20 @@ export async function getRegisteredNanoContracts(wallet) {
 }
 
 /**
+ * Get the genesis block hash from serverInfo in redux state.
+ *
+ * The genesis block hash uniquely identifies a network (mainnet, testnet or a
+ * custom one), so it is used as the partition key for per-network snapshots of
+ * registered entries (tokens, nano contracts).
+ *
+ * @param {{ genesis_block_hash?: string }} [serverInfo] serverInfo redux state
+ * @returns {string|null} The genesis block hash or null when unavailable
+ */
+export function getGenesisHash(serverInfo) {
+  return serverInfo?.genesis_block_hash || null;
+}
+
+/**
  * Flat registered tokens to uid.
  * @param {{ tokens: Object }} Map of registered tokens by uid
  * @returns {string[]} Array of token uid

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -21,7 +21,9 @@ import {
 } from 'redux-saga/effects';
 import { t } from 'ttag';
 import { NanoRequest404Error } from '@hathor/wallet-lib/lib/errors';
-import { getRegisteredNanoContracts, safeEffect } from './helpers';
+import { getGenesisHash, getRegisteredNanoContracts, safeEffect } from './helpers';
+import { WALLET_STATUS } from './wallet';
+import { STORE } from '../store';
 import {
   nanoContractBlueprintInfoFailure,
   nanoContractBlueprintInfoSuccess,
@@ -31,6 +33,7 @@ import {
   nanoContractHistorySuccess,
   nanoContractRegisterFailure,
   nanoContractRegisterSuccess,
+  nanoContractsSavedForNetwork,
   nanoContractUnregisterSuccess,
   onExceptionCaptured,
   types,
@@ -133,6 +136,106 @@ export function* init() {
     yield put(nanoContractRegisterSuccess({ entryKey: contract.ncId, entryValue: contract }));
   }
   log.debug('Registered Nano Contracts loaded.');
+}
+
+/**
+ * Persist the current registered nano contracts to storage keyed by the
+ * current network's genesis hash.
+ *
+ * Registered nano contracts live in a single working cache that is wiped on
+ * every network change. This snapshot is what survives the wipe, so a contract
+ * registered on a given network reappears when the wallet returns to it,
+ * analogous to how registered tokens behave.
+ */
+function* persistNanoContractsForCurrentNetwork() {
+  const serverInfo = yield select((state) => state.serverInfo);
+  const genesisHash = getGenesisHash(serverInfo);
+  if (!genesisHash) return;
+
+  const wallet = yield select((state) => state.wallet);
+  if (!wallet) return;
+
+  const registeredContracts = yield call(getRegisteredNanoContracts, wallet);
+  const contracts = {};
+  for (const contract of registeredContracts) {
+    contracts[contract.ncId] = contract;
+  }
+  yield call([STORE, STORE.saveNanoContractsForNetwork], genesisHash, contracts);
+}
+
+/**
+ * Save the current registered nano contracts for the active network.
+ *
+ * Dispatched by the networkSettings saga before it wipes nano contract storage.
+ * Always dispatches nanoContractsSavedForNetwork() when done.
+ */
+export function* saveNetworkNanoContracts() {
+  try {
+    yield* persistNanoContractsForCurrentNetwork();
+  } catch (e) {
+    log.error('Error saving nano contracts for network:', e);
+  } finally {
+    yield put(nanoContractsSavedForNetwork());
+  }
+}
+
+/**
+ * Restore previously saved nano contracts for the current network after the
+ * wallet starts successfully.
+ */
+export function* restoreNetworkNanoContracts() {
+  try {
+    const isEnabled = yield select(isNanoContractsEnabled);
+    if (!isEnabled) return;
+
+    const serverInfo = yield select((state) => state.serverInfo);
+    const genesisHash = getGenesisHash(serverInfo);
+    if (!genesisHash) return;
+
+    const savedContracts = yield call([STORE, STORE.getNanoContractsForNetwork], genesisHash);
+    if (!savedContracts) return;
+
+    const wallet = yield select((state) => state.wallet);
+    if (!wallet) return;
+
+    for (const contract of Object.values(savedContracts)) {
+      const isRegistered = yield call(
+        [wallet.storage, wallet.storage.isNanoContractRegistered],
+        contract.ncId,
+      );
+      if (!isRegistered) {
+        yield call(
+          [wallet.storage, wallet.storage.registerNanoContract],
+          contract.ncId,
+          contract,
+        );
+        yield put(nanoContractRegisterSuccess({
+          entryKey: contract.ncId,
+          entryValue: contract,
+        }));
+      }
+    }
+  } catch (e) {
+    log.error('Error restoring nano contracts for network:', e);
+  }
+}
+
+/**
+ * Update the persisted nano contract snapshot whenever the registered set
+ * changes (register, unregister or address change).
+ */
+export function* updateNetworkNanoContractSnapshot() {
+  try {
+    const walletStartState = yield select((state) => state.walletStartState);
+    if (walletStartState !== WALLET_STATUS.READY) return;
+
+    const wallet = yield select((state) => state.wallet);
+    if (!wallet || !wallet.isReady()) return;
+
+    yield* persistNanoContractsForCurrentNetwork();
+  } catch (e) {
+    log.error('Error updating network nano contract snapshot:', e);
+  }
 }
 
 /**
@@ -531,6 +634,10 @@ export function* requestNanoContractAddressChange({ payload }) {
     newAddress,
   );
   log.debug(`Success persisting Nano Contract address update. ncId = ${ncId}`);
+
+  // Keep the per-network snapshot in sync with the updated address so it
+  // survives a network change.
+  yield* updateNetworkNanoContractSnapshot();
 }
 
 /**
@@ -563,6 +670,10 @@ export function* requestBlueprintInfo({ payload }) {
 export function* saga() {
   yield all([
     debounce(500, [[types.START_WALLET_SUCCESS, types.NANOCONTRACT_INIT]], init),
+    takeEvery(types.SAVE_NANO_CONTRACTS_FOR_NETWORK, saveNetworkNanoContracts),
+    takeEvery(types.START_WALLET_SUCCESS, restoreNetworkNanoContracts),
+    takeEvery(types.NANOCONTRACT_REGISTER_SUCCESS, updateNetworkNanoContractSnapshot),
+    takeEvery(types.NANOCONTRACT_UNREGISTER_SUCCESS, updateNetworkNanoContractSnapshot),
     takeEvery(
       types.NANOCONTRACT_REGISTER_REQUEST,
       safeEffect(registerNanoContract, registerNanoContractOnError)

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -196,23 +196,27 @@ export function* restoreNetworkNanoContracts() {
     if (!savedContracts) return;
 
     const wallet = yield select((state) => state.wallet);
-    if (!wallet) return;
+    if (!wallet || !wallet.isReady()) return;
 
     for (const contract of Object.values(savedContracts)) {
-      const isRegistered = yield call(
-        [wallet.storage, wallet.storage.isNanoContractRegistered],
-        contract.ncId,
-      );
-      if (!isRegistered) {
-        yield call(
-          [wallet.storage, wallet.storage.registerNanoContract],
+      try {
+        const isRegistered = yield call(
+          [wallet.storage, wallet.storage.isNanoContractRegistered],
           contract.ncId,
-          contract,
         );
-        yield put(nanoContractRegisterSuccess({
-          entryKey: contract.ncId,
-          entryValue: contract,
-        }));
+        if (!isRegistered) {
+          yield call(
+            [wallet.storage, wallet.storage.registerNanoContract],
+            contract.ncId,
+            contract,
+          );
+          yield put(nanoContractRegisterSuccess({
+            entryKey: contract.ncId,
+            entryValue: contract,
+          }));
+        }
+      } catch (e) {
+        log.error(`Error restoring nano contract ${contract.ncId} for network:`, e);
       }
     }
   } catch (e) {

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -14,6 +14,7 @@ import {
   networkChanged,
   setFullNodeNetworkName,
   saveTokensForNetwork,
+  saveNanoContractsForNetwork,
 } from '../actions';
 import {
   NETWORK_MAINNET,
@@ -275,12 +276,22 @@ export function* persistNetworkSettings(action) {
     return;
   }
 
-  // Ask the tokens saga to save current tokens before we wipe them
+  // Ask the tokens and nano contract sagas to snapshot their current
+  // registered entries before we wipe storage. Both snapshots are keyed by the
+  // network's genesis hash so they can be restored when the wallet returns to
+  // this network. We wait for both concurrently so a single 5s timeout applies.
   yield put(saveTokensForNetwork());
-  yield race({
-    saved: take(types.TOKENS_SAVED_FOR_NETWORK),
-    timeout: delay(5000),
-  });
+  yield put(saveNanoContractsForNetwork());
+  yield all([
+    race({
+      saved: take(types.TOKENS_SAVED_FOR_NETWORK),
+      timeout: delay(5000),
+    }),
+    race({
+      saved: take(types.NANO_CONTRACTS_SAVED_FOR_NETWORK),
+      timeout: delay(5000),
+    }),
+  ]);
 
   const wallet = yield select((state) => state.wallet);
 

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -21,6 +21,7 @@ import { get } from 'lodash';
 import {
   specificTypeAndPayload,
   dispatchAndWait,
+  getGenesisHash,
   getRegisteredTokenUids,
   getNetworkSettings,
   getRegisteredTokens,
@@ -465,13 +466,6 @@ export function* fetchTokenData(tokenId, force = false) {
   if (fetchHistoryResponse.failure || fetchBalanceResponse.failure) {
     throw new Error(`Error loading HTR history or balance for token ${tokenId}`);
   }
-}
-
-/**
- * Get the genesis hash from serverInfo in redux state.
- */
-function getGenesisHash(serverInfo) {
-  return serverInfo?.genesis_block_hash || null;
 }
 
 /**

--- a/src/store.js
+++ b/src/store.js
@@ -15,6 +15,7 @@ export const REGISTERED_TOKENS_KEY = 'asyncstorage:registeredTokens';
 export const STORE_VERSION_KEY = 'asyncstorage:version';
 export const REGISTERED_NANO_CONTRACTS_KEY = 'asyncstorage:registeredNanoContracts';
 export const NETWORK_TOKENS_KEY = 'asyncstorage:networkTokens';
+export const NETWORK_NANO_CONTRACTS_KEY = 'asyncstorage:networkNanoContracts';
 export const PIN_BACKUP_KEY = 'asyncstorage:pinBackup';
 // Wheather old biometry mode is active (by the user request)
 export const IS_OLD_BIOMETRY_ENABLED_KEY = 'mobile:isBiometryEnabled';
@@ -34,6 +35,7 @@ export const walletKeys = [
   REGISTERED_TOKENS_KEY,
   REGISTERED_NANO_CONTRACTS_KEY,
   NETWORK_TOKENS_KEY,
+  NETWORK_NANO_CONTRACTS_KEY,
 ];
 
 export const cleanOnWalletReset = [
@@ -562,6 +564,31 @@ class AsyncStorageStore {
     if (!genesisHash) return null;
     const networkTokens = this.getItem(NETWORK_TOKENS_KEY) || {};
     return networkTokens[genesisHash] || null;
+  }
+
+  /**
+   * Save registered nano contracts for a specific network identified by genesis block hash.
+   *
+   * @param {string} genesisHash The genesis block hash identifying the network
+   * @param {Object} contracts Nano contracts map to save (keyed by ncId)
+   */
+  saveNanoContractsForNetwork(genesisHash, contracts) {
+    if (!genesisHash) return;
+    const networkNanoContracts = this.getItem(NETWORK_NANO_CONTRACTS_KEY) || {};
+    networkNanoContracts[genesisHash] = contracts;
+    this.setItem(NETWORK_NANO_CONTRACTS_KEY, networkNanoContracts);
+  }
+
+  /**
+   * Get saved nano contracts for a specific network identified by genesis block hash.
+   *
+   * @param {string} genesisHash The genesis block hash identifying the network
+   * @returns {Object|null} Saved nano contracts map or null
+   */
+  getNanoContractsForNetwork(genesisHash) {
+    if (!genesisHash) return null;
+    const networkNanoContracts = this.getItem(NETWORK_NANO_CONTRACTS_KEY) || {};
+    return networkNanoContracts[genesisHash] || null;
   }
 
   /**


### PR DESCRIPTION
### Acceptance Criteria
- Persist registered nano contracts per network so they survive switching networks (testnet ↔ mainnet, and testnet → a custom network without wallet-service)
- Nano contract registration now behaves like token registration: a contract registered on a network reappears when returning to that network, and does not show up on other networks

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nano contracts are now automatically saved and restored on a per-network basis, ensuring your contracts persist when switching between different networks.

* **Tests**
  * Added comprehensive test suite for nano contract persistence and restoration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->