### PR TITLE
feat(decimal): decimal precision on send/swap, and amount input display fix

### DIFF
--- a/src/components/AmountDisplay.js
+++ b/src/components/AmountDisplay.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Text } from 'react-native';
+import {
+  computeAmountFontFit,
+  AMOUNT_FONT_BASE_SIZE,
+  AMOUNT_FONT_MIN_SIZE,
+  AMOUNT_MAX_LINES,
+} from '../utils';
+
+// Line height as a fraction of font size; matches AmountTextInput's
+// LINE_HEIGHT_RATIO so input and read-only display wrap identically.
+const LINE_HEIGHT_RATIO = 1.2;
+
+/**
+ * Read-only counterpart to AmountTextInput (transaction detail balance, home
+ * balance, ...), using the same shrink-first-then-wrap ladder (`computeAmountFontFit`).
+ *
+ * Intentionally NOT `<Text adjustsFontSizeToFit numberOfLines={3}>`: on iOS that
+ * wraps at the base size WITHOUT shrinking, so a long amount fills three full-size lines.
+ *
+ * Measures its own width via `onLayout`, so callers MUST let it stretch (defaults to
+ * `alignSelf: 'stretch'`); sizing to content instead feeds the measurement back on itself.
+ *
+ * @param {Object} props
+ * @param {string} props.children - The amount string to render (value plus symbol)
+ * @param {Object} [props.style] - Additional text styles (color, fontWeight, ...)
+ * @param {number} [props.baseFontSize] - Starting (largest) font size
+ * @param {number} [props.minFontSize] - Floor font size before wrapping
+ * @returns {React.ReactElement}
+ */
+const AmountDisplay = ({
+  children,
+  style,
+  baseFontSize = AMOUNT_FONT_BASE_SIZE,
+  minFontSize = AMOUNT_FONT_MIN_SIZE,
+  ...rest
+}) => {
+  const [availableWidth, setAvailableWidth] = useState(0);
+  const content = children == null ? '' : String(children);
+  const { fontSize } = computeAmountFontFit(
+    content.length,
+    availableWidth,
+    baseFontSize,
+    minFontSize,
+  );
+  const lineHeight = Math.round(fontSize * LINE_HEIGHT_RATIO);
+
+  return (
+    <Text
+      numberOfLines={AMOUNT_MAX_LINES}
+      onLayout={(e) => setAvailableWidth(e.nativeEvent.layout.width)}
+      style={[
+        { alignSelf: 'stretch', textAlign: 'center' },
+        style,
+        { fontSize, lineHeight },
+      ]}
+      {...rest}
+    >
+      {content}
+    </Text>
+  );
+};
+
+export default AmountDisplay;

--- a/src/components/AmountTextInput.js
+++ b/src/components/AmountTextInput.js
@@ -7,23 +7,13 @@
 
 import React, { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
 import { StyleSheet, TextInput } from 'react-native';
-import { getAmountParsed, getIntegerAmount } from '../utils';
+import { getAmountParsed, getIntegerAmount, computeAmountFontFit, AMOUNT_MAX_LINES } from '../utils';
+import { MAX_DECIMAL_PLACES } from '../constants';
 import { COLORS } from '../styles/themes';
 
-// Auto-shrink lower bound: never scale the font below this fraction of
-// the base size, so very long amounts stay readable even when scaled.
-const MIN_FONT_SCALE = 0.5;
-
-// Average glyph width as a fraction of fontSize for the bold sans-serif
-// AmountTextInput uses. We don't measure rendered text (an earlier
-// implementation that did caused a Folly F14Set assertion crash on
-// iOS 26.1 + Fabric due to the extra hidden <Text> re-rendering on
-// every keystroke), so we estimate width as
-// `length * fontSize * GLYPH_RATIO`. Slightly conservative for digits
-// and slightly generous for `,` / `.` — net effect is the font shrinks
-// a hair sooner than strictly necessary, which is preferable to letting
-// the value clip behind the token selector.
-const GLYPH_RATIO = 0.55;
+// Rendered line height as a fraction of the font size, reserving room for the
+// wrapped lines without clipping the bold glyphs.
+const LINE_HEIGHT_RATIO = 1.2;
 
 /**
  * Text input component specifically for handling token amounts with BigInt validation.
@@ -37,7 +27,9 @@ const GLYPH_RATIO = 0.55;
  *                                                   (no decimals)
  * @param {Object} [props.style] - Additional styles for the TextInput
  * @param {boolean} [props.autoFocus] - Whether the input should be focused on mount
- * @param {number} [props.decimalPlaces] - Number of decimal places to use
+ * @param {number} [props.decimalPlaces] - Number of decimal places for the token's value scale
+ * @param {number} [props.fontSize] - Explicit display font size in px (parent-controlled mode)
+ * @param {boolean} [props.singleLine] - Pin the input to a fixed one-line height (no wrapping)
  * @param {React.Ref} ref - Forwarded ref, exposes the focus() method
  * @returns {React.ReactElement} A formatted amount input component
  */
@@ -46,21 +38,8 @@ const AmountTextInput = forwardRef((props, ref) => {
   const [text, setText] = useState(props.value || '');
   const { decimalPlaces } = props;
 
-  // Auto-shrink-to-fit: amounts can grow long enough to overflow the
-  // input's column (e.g. `957,791,973.79`). We capture the column
-  // width via the TextInput's `onLayout` and scale `fontSize` down
-  // when the estimated text width (length × fontSize × GLYPH_RATIO)
-  // exceeds it. When the user shortens the value, the estimate drops
-  // and the font scales back up to the base size.
-  //
-  // IMPORTANT: `onLayout` measures this TextInput's OWN box, so callers
-  // MUST give it a parent-determined width — `flex: 1` when it shares a
-  // row (e.g. with a TokenBox), or `alignSelf: 'stretch'` / an explicit
-  // width when it sits alone in an `alignItems: 'center'` column. Without
-  // that the input sizes to its content; since `fontSize` (which this
-  // logic controls) also drives the content width, the measurement feeds
-  // back into itself and the font collapses to `minFontSize`, flickering
-  // on the way down.
+  // Self-measure: the input's own column width, captured via onLayout, drives the
+  // font ladder. Unused when the parent passes an explicit fontSize.
   const [containerWidth, setContainerWidth] = useState(0);
 
   // Expose the focus method to parent components
@@ -98,14 +77,18 @@ const AmountTextInput = forwardRef((props, ref) => {
       return;
     }
 
-    let parsedText = newText;
+    // The numeric keyboard shouldn't emit newlines, but a multiline input can
+    // receive them via paste; strip so they never reach the parser.
+    let parsedText = newText.replace(/[\n\r]/g, '');
     let bigIntValue;
     if (props.allowOnlyInteger) {
       // We allow only integers for NFT
       parsedText = parsedText.replace(/[^0-9]/g, '');
     }
 
-    parsedText = getAmountParsed(parsedText, decimalPlaces);
+    // Accept up to MAX_DECIMAL_PLACES typed decimals regardless of the token's
+    // precision; the value below is still scaled to the token's decimalPlaces.
+    parsedText = getAmountParsed(parsedText, MAX_DECIMAL_PLACES);
 
     // There is no NaN in BigInt, it either returns a valid bigint or throws
     // an error.
@@ -135,36 +118,40 @@ const AmountTextInput = forwardRef((props, ref) => {
     placeholder = `0.${zeros}`;
   }
 
-  const { style: customStyle, textAlign, ...restProps } = props;
+  const { style: customStyle, textAlign, fontSize, singleLine, ...restProps } = props;
 
-  // Resolve the base (unscaled) font size from the merged style chain
-  // so callers that override fontSize via `customStyle` still get
-  // correct scaling math.
-  const flatStyle = StyleSheet.flatten([style.input, customStyle]) || {};
-  const baseFontSize = flatStyle.fontSize ?? 32;
-  const minFontSize = Math.max(14, Math.floor(baseFontSize * MIN_FONT_SCALE));
+  const isControlledSize = fontSize != null;
   const displayed = text || placeholder;
-  const estimatedWidth = displayed.length * baseFontSize * GLYPH_RATIO;
-  const scaledFontSize = (containerWidth > 0 && estimatedWidth > containerWidth)
-    ? Math.max(
-      minFontSize,
-      Math.floor(baseFontSize * (containerWidth / estimatedWidth)),
-    )
-    : baseFontSize;
+  const resolvedFontSize = isControlledSize
+    ? fontSize
+    : computeAmountFontFit(displayed.length, containerWidth).fontSize;
+  const lineHeight = Math.round(resolvedFontSize * LINE_HEIGHT_RATIO);
+  const heightStyle = singleLine
+    ? { height: lineHeight }
+    : { maxHeight: lineHeight * AMOUNT_MAX_LINES };
 
   return (
     <TextInput
       ref={inputRef}
-      style={[style.input, customStyle, { fontSize: scaledFontSize }]}
+      style={[
+        style.input,
+        customStyle,
+        { fontSize: resolvedFontSize, lineHeight },
+        heightStyle,
+      ]}
       onChangeText={onChangeText}
       value={text}
+      multiline
+      scrollEnabled={false}
       textAlign={textAlign || 'center'}
-      textAlignVertical='bottom'
+      textAlignVertical='center'
       keyboardAppearance='dark'
       keyboardType='numeric'
       placeholder={placeholder}
       placeholderTextColor={COLORS.midContrastDetail}
-      onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
+      onLayout={isControlledSize
+        ? undefined
+        : (e) => setContainerWidth(e.nativeEvent.layout.width)}
       {...restProps}
     />
   );
@@ -172,9 +159,6 @@ const AmountTextInput = forwardRef((props, ref) => {
 
 const style = StyleSheet.create({
   input: {
-    height: 38,
-    lineHeight: 38,
-    fontSize: 32,
     fontWeight: 'bold',
     paddingVertical: 0,
     color: COLORS.textColor,

--- a/src/components/TokenBox.js
+++ b/src/components/TokenBox.js
@@ -16,7 +16,7 @@ import { COLORS } from '../styles/themes';
 
 const TokenBox = (props) => (
   <TouchableWithoutFeedback onPress={props.onPress}>
-    <View style={styles.wrapper}>
+    <View style={[styles.wrapper, props.style]}>
       <Text style={styles.label}>{props.label}</Text>
       <FontAwesomeIcon
         icon={faSortDown}

--- a/src/components/TxDetailsModal.js
+++ b/src/components/TxDetailsModal.js
@@ -16,6 +16,7 @@ import { t } from 'ttag';
 
 import { TokenVersion } from '@hathor/wallet-lib';
 import { getShortContent, getShortHash, getTokenLabel, renderValue } from '../utils';
+import AmountDisplay from './AmountDisplay';
 import { ListItem } from './HathorList';
 import SlideIndicatorBar from './SlideIndicatorBar';
 import CopyClipboard from './CopyClipboard';
@@ -153,7 +154,6 @@ class BalanceView extends Component {
       paddingRight: 54,
     },
     balance: {
-      fontSize: 32,
       fontWeight: 'bold',
     },
     text1: {
@@ -169,14 +169,9 @@ class BalanceView extends Component {
     const balanceStr = renderValue(tx.balance, isNFT, decimalPlaces, amountFormat);
     return (
       <View style={this.style.view}>
-        <Text
-          style={this.style.balance}
-          adjustsFontSizeToFit
-          minimumFontScale={0.5}
-          numberOfLines={1}
-        >
+        <AmountDisplay style={this.style.balance}>
           {`${balanceStr} ${this.props.token.symbol}`}
-        </Text>
+        </AmountDisplay>
         <Text style={this.style.text1}>{t`Amount`}</Text>
       </View>
     );

--- a/src/constants.js
+++ b/src/constants.js
@@ -159,6 +159,10 @@ export const AMOUNT_FORMAT_DEFAULT = AMOUNT_FORMAT.EXPANDED;
 // 'wallet:' prefix: STORE.clearItems(true) sweeps it on resetWallet, so it resets to Expanded.
 export const AMOUNT_FORMAT_KEY = 'wallet:amount_format';
 
+// Max decimal places the amount input accepts, independent of the token's own
+// precision — the value is still scaled to the token's decimal_places downstream.
+export const MAX_DECIMAL_PLACES = 8;
+
 /**
  * this is the message key for localization of new transaction when show amount is enabled
  */

--- a/src/screens/CreateTokenAmount.js
+++ b/src/screens/CreateTokenAmount.js
@@ -198,6 +198,7 @@ const CreateTokenAmount = () => {
                 decimalPlaces={decimalPlaces}
                 onAmountUpdate={onAmountChange}
                 value={amountText}
+                style={{ alignSelf: 'stretch' }}
               />
               {error && (
                 <Text style={{ color: COLORS.errorTextColor, marginTop: 8, textAlign: 'center' }}>

--- a/src/screens/MainScreen.js
+++ b/src/screens/MainScreen.js
@@ -25,6 +25,7 @@ import IconTabBar from '../icon-font';
 import HathorHeader from '../components/HathorHeader';
 import SimpleButton from '../components/SimpleButton';
 import TxDetailsModal from '../components/TxDetailsModal';
+import AmountDisplay from '../components/AmountDisplay';
 import OfflineBar from '../components/OfflineBar';
 import { HathorList } from '../components/HathorList';
 import {
@@ -531,11 +532,9 @@ class BalanceView extends React.Component {
     },
     balanceLocked: {
       marginTop: 24,
-      fontSize: 18,
       fontWeight: 'bold',
     },
     balanceAvailable: {
-      fontSize: 32,
       fontWeight: 'bold',
     },
     text1: {
@@ -571,23 +570,13 @@ class BalanceView extends React.Component {
     const { style } = this;
     return (
       <View style={style.center}>
-        <Text
-          style={style.balanceAvailable}
-          adjustsFontSizeToFit
-          minimumFontScale={0.5}
-          numberOfLines={1}
-        >
+        <AmountDisplay style={style.balanceAvailable}>
           {`${availableStr} ${token.symbol}`}
-        </Text>
+        </AmountDisplay>
         <Text style={style.text1}>{t`Available Balance`}</Text>
-        <Text
-          style={style.balanceLocked}
-          adjustsFontSizeToFit
-          minimumFontScale={0.5}
-          numberOfLines={1}
-        >
+        <AmountDisplay style={style.balanceLocked} baseFontSize={18} minFontSize={12}>
           {`${lockedStr} ${token.symbol}`}
-        </Text>
+        </AmountDisplay>
         <Text style={style.text1}>{t`Locked`}</Text>
         <Image style={style.expandButton} source={chevronUp} width={12} height={7} />
       </View>
@@ -605,14 +594,9 @@ class BalanceView extends React.Component {
     const { style } = this;
     return (
       <View style={style.center}>
-        <Text
-          style={style.balanceAvailable}
-          adjustsFontSizeToFit
-          minimumFontScale={0.5}
-          numberOfLines={1}
-        >
+        <AmountDisplay style={style.balanceAvailable}>
           {`${availableStr} ${token.symbol}`}
-        </Text>
+        </AmountDisplay>
         <Text style={style.text1}>{t`Available Balance`}</Text>
         <Image style={style.expandButton} source={chevronDown} width={12} height={7} />
       </View>

--- a/src/screens/SendAmountInput.js
+++ b/src/screens/SendAmountInput.js
@@ -20,7 +20,7 @@ import { t, ngettext, msgid } from 'ttag';
 import { get } from 'lodash';
 
 import { IS_MULTI_TOKEN } from '../constants';
-import { renderValue, isTokenNFT } from '../utils';
+import { renderValue, isTokenNFT, computeAmountFontFit } from '../utils';
 import NewHathorButton from '../components/NewHathorButton';
 import AmountTextInput from '../components/AmountTextInput';
 import InputLabel from '../components/InputLabel';
@@ -46,6 +46,7 @@ const SendAmountInput = () => {
   const [amountValue, setAmountValue] = useState(null);
   const [token, setToken] = useState(selectedToken);
   const [error, setError] = useState(null);
+  const [amountAreaWidth, setAmountAreaWidth] = useState(0);
   const inputRef = useRef(null);
 
   useEffect(() => {
@@ -118,7 +119,7 @@ const SendAmountInput = () => {
       locked: 0n,
     });
     const { available } = balance;
-    const amountAndToken = `${renderValue(available, isNFT())} ${token.symbol}`;
+    const amountAndToken = `${renderValue(available, isNFT(), decimalPlaces)} ${token.symbol}`;
     const availableCount = Number(available);
     return ngettext(msgid`${amountAndToken} available`, `${amountAndToken} available`, availableCount);
   };
@@ -128,6 +129,17 @@ const SendAmountInput = () => {
   );
 
   const tokenNameUpperCase = token.name.toUpperCase();
+
+  // 170 = ghost spacer (80) + token box (90).
+  const TOKEN_BOX_ROW_RESERVED = 170;
+  const placeholderString = isNFT() ? '0' : `0.${'0'.repeat(decimalPlaces)}`;
+  const displayedAmount = amount || placeholderString;
+  const inlineWidth = amountAreaWidth > 0 ? amountAreaWidth - TOKEN_BOX_ROW_RESERVED : 0;
+  // Size against the width beside the token box so it shrinks to fit there before wrapping.
+  const { fontSize: amountFontSize, wraps: isStacked } = computeAmountFontFit(
+    displayedAmount.length,
+    inlineWidth,
+  );
 
   return (
     <View style={{ flex: 1 }}>
@@ -140,11 +152,16 @@ const SendAmountInput = () => {
         <KeyboardAvoidingView behavior='padding' style={{ flex: 1 }} keyboardVerticalOffset={getStatusBarHeight()}>
           <View style={{ flex: 1, padding: 16, justifyContent: 'space-between' }}>
             <View>
-              <View style={{
-                flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 40,
-              }}
+              <View
+                onLayout={(e) => setAmountAreaWidth(e.nativeEvent.layout.width)}
+                style={{
+                  flexDirection: isStacked ? 'column' : 'row',
+                  alignItems: 'center',
+                  justifyContent: isStacked ? 'flex-start' : 'space-between',
+                  marginTop: 40,
+                }}
               >
-                {renderGhostElement()}
+                {!isStacked && renderGhostElement()}
                 <AmountTextInput
                   ref={inputRef}
                   autoFocus
@@ -152,13 +169,21 @@ const SendAmountInput = () => {
                   value={amount}
                   allowOnlyInteger={isNFT()}
                   decimalPlaces={decimalPlaces}
-                  style={{ flex: 1 }} // we need this so the placeholder doesn't break in android
-                // devices after erasing the text
-                // https://github.com/facebook/react-native/issues/30666
+                  fontSize={amountFontSize}
+                  singleLine={!isStacked}
+                  // flex:1 (row) also keeps the android placeholder from breaking
+                  // after erasing text: https://github.com/facebook/react-native/issues/30666
+                  style={isStacked ? { alignSelf: 'stretch' } : { flex: 1 }}
                 />
                 {IS_MULTI_TOKEN
-                  ? <TokenBox onPress={onTokenBoxPress} label={token.symbol} />
-                  : renderGhostElement()}
+                  ? (
+                    <TokenBox
+                      onPress={onTokenBoxPress}
+                      label={token.symbol}
+                      style={isStacked ? { marginTop: 8 } : undefined}
+                    />
+                  )
+                  : (!isStacked && renderGhostElement())}
               </View>
               <InputLabel style={{ textAlign: 'center', marginTop: 8 }}>
                 {getAvailableString()}

--- a/src/screens/SendConfirmScreen.js
+++ b/src/screens/SendConfirmScreen.js
@@ -66,6 +66,7 @@ const SendConfirmScreen = () => {
   const tokenMetadata = useSelector((state) => state.tokenMetadata);
   const isShowingPinScreen = useSelector((state) => state.isShowingPinScreen);
   const isCameraAvailable = useSelector((state) => state.isCameraAvailable);
+  const decimalPlaces = useSelector((state) => state.serverInfo?.decimal_places);
 
   const navigation = useNavigation();
   const params = useParams();
@@ -73,7 +74,7 @@ const SendConfirmScreen = () => {
   // Parse and store navigation params
   const { amount, address, token } = params;
   const isNFT = isTokenNFT(token.uid, tokenMetadata);
-  const amountAndToken = `${renderValue(amount, isNFT)} ${token.symbol}`;
+  const amountAndToken = `${renderValue(amount, isNFT, decimalPlaces)} ${token.symbol}`;
 
   const [phase, setPhase] = useState(PHASE.BUILDING);
   const [sendTx, setSendTx] = useState(null);
@@ -85,7 +86,8 @@ const SendConfirmScreen = () => {
   // the feedback modal render where the button would otherwise be tappable.
   const [isSending, setIsSending] = useState(false);
 
-  const nativeSymbol = hathorLib.constants.DEFAULT_NATIVE_TOKEN_CONFIG.symbol;
+  const nativeSymbol = useSelector((state) => state.serverInfo?.native_token?.symbol)
+    ?? hathorLib.constants.DEFAULT_NATIVE_TOKEN_CONFIG.symbol;
 
   // Build the transaction on mount (without inputs — let the lib auto-select
   // FBT and HTR UTXOs). This produces the exact fee the user will pay, which
@@ -231,7 +233,7 @@ const SendConfirmScreen = () => {
     const balance = tokensBalance[token.uid].data;
     const available = balance ? balance.available : 0;
     const availableCount = Number(available);
-    const availablePretty = renderValue(available, isNFT);
+    const availablePretty = renderValue(available, isNFT, decimalPlaces);
     return ngettext(msgid`${availablePretty} available`, `${availablePretty} available`, availableCount);
   };
 
@@ -268,12 +270,12 @@ const SendConfirmScreen = () => {
 
   const renderNetworkFeeValue = () => {
     if (networkFee === null) {
-      return <Text style={{ color: COLORS.textColorShadow }}>{t`Loading...`}</Text>;
+      return <Text style={[styles.summaryValue, { color: COLORS.textColorShadow }]}>{t`Loading...`}</Text>;
     }
     if (networkFee > 0n) {
       return (
-        <Text>
-          {renderValue(networkFee, false)} {nativeSymbol}
+        <Text style={styles.summaryValue}>
+          {renderValue(networkFee, false, decimalPlaces)} {nativeSymbol}
         </Text>
       );
     }
@@ -348,7 +350,7 @@ const SendConfirmScreen = () => {
                   <Text>{address.substr(0, 7)}...{address.substr(-7)}</Text>
                 </View>
                 <View style={styles.summaryItem}>
-                  <View style={{ flex: 2, flexDirection: 'row', alignItems: 'center' }}>
+                  <View style={styles.feeLabel}>
                     <TextFmt>{t`**Network Fee**`}</TextFmt>
                     <TouchableOpacity onPress={handleFeeInfoPress} style={{ marginLeft: 4 }}>
                       <InfoCircleIcon size={16} />
@@ -358,7 +360,12 @@ const SendConfirmScreen = () => {
                 </View>
                 <View style={styles.summaryItem}>
                   <TextFmt>{t`**Total**`}</TextFmt>
-                  <Text>{`${amountAndToken}${networkFee ? ` + ${renderValue(networkFee, false)} ${nativeSymbol}` : ''}`}</Text>
+                  <View style={styles.summaryValueBlock}>
+                    <Text style={styles.summaryValueLine}>{amountAndToken}</Text>
+                    {networkFee ? (
+                      <Text style={styles.summaryValueLine}>{`+ ${renderValue(networkFee, false, decimalPlaces)} ${nativeSymbol}`}</Text>
+                    ) : null}
+                  </View>
                 </View>
               </View>
             </View>
@@ -391,6 +398,24 @@ const styles = StyleSheet.create({
     padding: 10,
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  feeLabel: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexShrink: 0,
+  },
+  summaryValue: {
+    flex: 1,
+    textAlign: 'right',
+    marginLeft: 8,
+  },
+  summaryValueBlock: {
+    flex: 1,
+    marginLeft: 8,
+  },
+  summaryValueLine: {
+    textAlign: 'right',
   },
   nofee: {
     flexDirection: 'row',

--- a/src/screens/TokenSwap.js
+++ b/src/screens/TokenSwap.js
@@ -167,9 +167,9 @@ const TokenSwap = () => {
   useEffect(() => {
     setShowQuote(!!quote);
     if (quote) {
-      setInputTokenAmountStr(renderValue(quote.amount_in));
+      setInputTokenAmountStr(renderValue(quote.amount_in, false, decimalPlaces));
       setInputTokenAmount(quote.amount_in);
-      setOutputTokenAmountStr(renderValue(quote.amount_out));
+      setOutputTokenAmountStr(renderValue(quote.amount_out, false, decimalPlaces));
       setOutputTokenAmount(quote.amount_out);
     }
   }, [quote]);
@@ -329,7 +329,7 @@ const TokenSwap = () => {
       return '';
     }
     const available = getAvailableAmount(token, tokensBalance);
-    const amount = `${renderValue(available, false)}`;
+    const amount = `${renderValue(available, false, decimalPlaces)}`;
     return t`Balance: ${amount}`;
   };
 
@@ -362,18 +362,18 @@ const TokenSwap = () => {
             <View>
               <View style={styles.card}>
                 <View style={styles.tokenCard}>
-                  <AmountTextInput
-                    onAmountUpdate={onInputAmountChange}
-                    onEndEditing={onInputAmountEndEditing}
-                    onFocus={() => onFocus('input')}
-                    value={inputTokenAmountStr}
-                    allowOnlyInteger={false}
-                    decimalPlaces={decimalPlaces}
-                    style={swapDirection === 'output' ? styles.amountInputTextFaded : styles.amountInputText}
-                    editable={editing !== 'output'}
-                    textAlign='left'
-                  />
-                  <View>
+                  <View style={styles.amountRow}>
+                    <AmountTextInput
+                      onAmountUpdate={onInputAmountChange}
+                      onEndEditing={onInputAmountEndEditing}
+                      onFocus={() => onFocus('input')}
+                      value={inputTokenAmountStr}
+                      allowOnlyInteger={false}
+                      decimalPlaces={decimalPlaces}
+                      style={swapDirection === 'output' ? styles.amountInputTextFaded : styles.amountInputText}
+                      editable={editing !== 'output'}
+                      textAlign='left'
+                    />
                     <View style={styles.tokenSelectorWrapper}>
                       { inputToken ? (
                         <TokenBox onPress={onInputTokenBoxPress} label={inputToken.symbol} />
@@ -381,10 +381,10 @@ const TokenSwap = () => {
                         <TokenBox label='' />
                       )}
                     </View>
-                    <InputLabel style={styles.amountAvailable}>
-                      {getAvailableString(inputToken)}
-                    </InputLabel>
                   </View>
+                  <InputLabel style={styles.amountAvailable}>
+                    {getAvailableString(inputToken)}
+                  </InputLabel>
                 </View>
               </View>
 
@@ -392,18 +392,18 @@ const TokenSwap = () => {
 
               <View style={styles.card}>
                 <View style={styles.tokenCard}>
-                  <AmountTextInput
-                    onAmountUpdate={onOutputAmountChange}
-                    onEndEditing={onOutputAmountEndEditing}
-                    onFocus={() => onFocus('output')}
-                    value={outputTokenAmountStr}
-                    allowOnlyInteger={false}
-                    decimalPlaces={decimalPlaces}
-                    style={swapDirection === 'input' ? styles.amountInputTextFaded : styles.amountInputText}
-                    editable={editing !== 'input'}
-                    textAlign='left'
-                  />
-                  <View>
+                  <View style={styles.amountRow}>
+                    <AmountTextInput
+                      onAmountUpdate={onOutputAmountChange}
+                      onEndEditing={onOutputAmountEndEditing}
+                      onFocus={() => onFocus('output')}
+                      value={outputTokenAmountStr}
+                      allowOnlyInteger={false}
+                      decimalPlaces={decimalPlaces}
+                      style={swapDirection === 'input' ? styles.amountInputTextFaded : styles.amountInputText}
+                      editable={editing !== 'input'}
+                      textAlign='left'
+                    />
                     <View style={styles.tokenSelectorWrapper}>
                       { outputToken ? (
                         <TokenBox onPress={onOutputTokenBoxPress} label={outputToken.symbol} />
@@ -411,10 +411,10 @@ const TokenSwap = () => {
                         <TokenBox label='' />
                       )}
                     </View>
-                    <InputLabel style={styles.amountAvailable}>
-                      {getAvailableString(outputToken)}
-                    </InputLabel>
                   </View>
+                  <InputLabel style={styles.amountAvailable}>
+                    {getAvailableString(outputToken)}
+                  </InputLabel>
                 </View>
               </View>
 
@@ -423,7 +423,7 @@ const TokenSwap = () => {
                   <View style={styles.quoteRow}>
                     <Text style={styles.quoteHeader}>Conversion rate</Text>
                     <Text style={styles.quoteValue}>
-                      {renderConversionRate(quote, inputToken, outputToken)}
+                      {renderConversionRate(quote, inputToken, outputToken, decimalPlaces)}
                     </Text>
                   </View>
                   <View style={styles.quoteRow}>
@@ -437,13 +437,13 @@ const TokenSwap = () => {
                   { quote.direction === 'input' && (
                     <View style={styles.quoteRow}>
                       <Text style={styles.quoteHeader}>Minimum received</Text>
-                      <Text style={styles.quoteValue}>{renderAmountAndSymbolWithSlippage('input', quote.amount_out, outputToken, TOKEN_SWAP_SLIPPAGE)}</Text>
+                      <Text style={styles.quoteValue}>{renderAmountAndSymbolWithSlippage('input', quote.amount_out, outputToken, TOKEN_SWAP_SLIPPAGE, decimalPlaces)}</Text>
                     </View>
                   )}
                   { quote.direction === 'output' && (
                     <View style={styles.quoteRow}>
                       <Text style={styles.quoteHeader}>Maximum to deposit</Text>
-                      <Text style={styles.quoteValue}>{renderAmountAndSymbolWithSlippage('output', quote.amount_in, inputToken, TOKEN_SWAP_SLIPPAGE)}</Text>
+                      <Text style={styles.quoteValue}>{renderAmountAndSymbolWithSlippage('output', quote.amount_in, inputToken, TOKEN_SWAP_SLIPPAGE, decimalPlaces)}</Text>
                     </View>
                   )}
                 </View>
@@ -518,23 +518,25 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     marginRight: 10,
   },
-  amountAvailable: {
-    marginTop: 8,
-    marginBottom: 4,
-  },
-  amountInputText: { // https://github.com/facebook/react-native/issues/30666
-    flex: 1,
-    marginBottom: 30,
-  },
-  amountInputTextFaded: {
-    flex: 1,
-    marginBottom: 30,
-    color: COLORS.lightShadow,
-  },
-  tokenCard: {
+  amountRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+  },
+  amountAvailable: {
+    marginTop: 8,
+    marginBottom: 4,
+    textAlign: 'right',
+  },
+  amountInputText: { // https://github.com/facebook/react-native/issues/30666
+    flex: 1,
+  },
+  amountInputTextFaded: {
+    flex: 1,
+    color: COLORS.lightShadow,
+  },
+  tokenCard: {
+    flexDirection: 'column',
     marginTop: 30,
     paddingVertical: 8,
     paddingLeft: 24,
@@ -559,6 +561,7 @@ const styles = StyleSheet.create({
   quoteRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'flex-start',
     paddingVertical: 8,
   },
   quoteHeader: {

--- a/src/screens/TokenSwapReview.js
+++ b/src/screens/TokenSwapReview.js
@@ -61,6 +61,9 @@ const TokenSwapReview = () => {
   const useWalletService = useSelector((state) => state.useWalletService);
   const isShowingPinScreen = useSelector((state) => state.isShowingPinScreen);
   const contractId = useSelector(selectTokenSwapContractId);
+  const decimalPlaces = useSelector((state) => state.serverInfo?.decimal_places);
+  const nativeSymbol = useSelector((state) => state.serverInfo?.native_token?.symbol)
+    ?? hathorLib.constants.DEFAULT_NATIVE_TOKEN_CONFIG.symbol;
 
   const { quote, tokenIn, tokenOut } = useParams();
 
@@ -268,7 +271,7 @@ const TokenSwapReview = () => {
                 <View style={styles.tokenContainer}>
                   <Text style={styles.tokenHeader}>Swapping</Text>
                   <Text style={styles.tokenValue}>
-                    {renderAmountAndSymbol(quote.amount_in, tokenIn)}
+                    {renderAmountAndSymbol(quote.amount_in, tokenIn, decimalPlaces)}
                   </Text>
                 </View>
                 <View style={styles.iconContainer}>
@@ -277,7 +280,7 @@ const TokenSwapReview = () => {
                 <View style={styles.tokenContainer}>
                   <Text style={styles.tokenHeader}>To</Text>
                   <Text style={styles.tokenValue}>
-                    {renderAmountAndSymbol(quote.amount_out, tokenOut)}
+                    {renderAmountAndSymbol(quote.amount_out, tokenOut, decimalPlaces)}
                   </Text>
                 </View>
               </View>
@@ -289,7 +292,7 @@ const TokenSwapReview = () => {
                 <View style={styles.quoteRow}>
                   <Text style={styles.quoteHeader}>Conversion rate</Text>
                   <Text style={styles.quoteValue}>
-                    {renderConversionRate(quote, tokenIn, tokenOut)}
+                    {renderConversionRate(quote, tokenIn, tokenOut, decimalPlaces)}
                   </Text>
                 </View>
                 <View style={styles.quoteRow}>
@@ -303,20 +306,20 @@ const TokenSwapReview = () => {
                 { quote.direction === 'input' && (
                   <View style={styles.quoteRow}>
                     <Text style={styles.quoteHeader}>Minimum received</Text>
-                    <Text style={styles.quoteValue}>{renderAmountAndSymbolWithSlippage('input', quote.amount_out, tokenOut, TOKEN_SWAP_SLIPPAGE)}</Text>
+                    <Text style={styles.quoteValue}>{renderAmountAndSymbolWithSlippage('input', quote.amount_out, tokenOut, TOKEN_SWAP_SLIPPAGE, decimalPlaces)}</Text>
                   </View>
                 )}
                 { quote.direction === 'output' && (
                   <View style={styles.quoteRow}>
                     <Text style={styles.quoteHeader}>Maximum to deposit</Text>
-                    <Text style={styles.quoteValue}>{renderAmountAndSymbolWithSlippage('output', quote.amount_in, tokenIn, TOKEN_SWAP_SLIPPAGE)}</Text>
+                    <Text style={styles.quoteValue}>{renderAmountAndSymbolWithSlippage('output', quote.amount_in, tokenIn, TOKEN_SWAP_SLIPPAGE, decimalPlaces)}</Text>
                   </View>
                 )}
                 <View style={styles.quoteRow}>
                   <Text style={styles.quoteHeader}>{t`Network Fee`}</Text>
                   <Text style={styles.quoteValue}>
                     {networkFee != null && networkFee > 0n
-                      ? `${renderValue(networkFee, false)} ${hathorLib.constants.DEFAULT_NATIVE_TOKEN_CONFIG.symbol}`
+                      ? `${renderValue(networkFee, false, decimalPlaces)} ${nativeSymbol}`
                       : t`No fee`}
                   </Text>
                 </View>
@@ -391,14 +394,19 @@ const styles = StyleSheet.create({
   quoteRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'flex-start',
     paddingVertical: 8,
     paddingHorizontal: 4,
   },
   quoteHeader: {
     fontWeight: '500',
+    flexShrink: 0,
   },
   quoteValue: {
     fontWeight: '300',
+    flex: 1,
+    textAlign: 'right',
+    marginLeft: 8,
   },
 });
 

--- a/src/screens/TokenSwapTokenList.js
+++ b/src/screens/TokenSwapTokenList.js
@@ -29,6 +29,7 @@ export default function TokenSwapTokenList(direction) {
     const tokenMetadata = useSelector((state) => state.tokenMetadata);
     const tokensBalance = useSelector((state) => state.tokensBalance);
     const allowedTokens = useSelector(selectTokenSwapAllowedTokens);
+    const decimalPlaces = useSelector((state) => state.serverInfo?.decimal_places);
 
     const onItemPress = (item) => {
       if (direction === 'input') {
@@ -51,6 +52,7 @@ export default function TokenSwapTokenList(direction) {
         tokens={allowedTokens}
         tokensBalance={tokensBalance}
         tokenMetadata={tokenMetadata}
+        decimalPlaces={decimalPlaces}
       />
     );
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -461,6 +461,56 @@ export const renderValue = (
   return formatted;
 };
 
+// Amount display sizing: amounts can reach ~28 chars, so computeAmountFontFit
+// shrinks the font before wrapping.
+export const AMOUNT_FONT_BASE_SIZE = 32;
+export const AMOUNT_FONT_MIN_SIZE = 20;
+export const AMOUNT_MAX_LINES = 3;
+
+// Glyph width as a fraction of fontSize, used to estimate text width instead of
+// measuring it: a prior hidden-<Text> measurer crashed (Folly F14Set, iOS 26.1 +
+// Fabric). Biased high so the amount shrinks a hair early rather than clipping.
+const AMOUNT_GLYPH_RATIO = 0.68;
+
+/**
+ * Shrink-first-then-wrap sizing ladder for the amount display.
+ *
+ * Given the displayed length and the width available on a single line, it:
+ *   1. keeps the base size while the text fits on one line;
+ *   2. shrinks the font (base -> floor) to keep the text on one line as it grows;
+ *   3. once even the floor size can't fit the text on one line, pins the font at
+ *      the floor and reports `wraps: true` so the caller lets it flow across up
+ *      to AMOUNT_MAX_LINES lines (and, on the Send screen, drops the token box
+ *      below the amount).
+ *
+ * Because the font is already at the floor when `wraps` flips to true, callers
+ * that switch layout at that point (Send) see no font-size jump at the switch.
+ *
+ * @param {number} textLength Length of the displayed amount (value or placeholder)
+ * @param {number} availableWidth Single-line width available for the amount, in px
+ * @param {number} [baseFontSize] Starting (largest) font size; defaults to the amount base
+ * @param {number} [minFontSize] Floor font size below which it wraps instead of shrinking
+ * @return {{ fontSize: number, wraps: boolean }}
+ */
+export const computeAmountFontFit = (
+  textLength,
+  availableWidth,
+  baseFontSize = AMOUNT_FONT_BASE_SIZE,
+  minFontSize = AMOUNT_FONT_MIN_SIZE,
+) => {
+  if (!availableWidth || availableWidth <= 0 || !textLength) {
+    return { fontSize: baseFontSize, wraps: false };
+  }
+  const oneLineFontSize = availableWidth / (textLength * AMOUNT_GLYPH_RATIO);
+  if (oneLineFontSize >= baseFontSize) {
+    return { fontSize: baseFontSize, wraps: false };
+  }
+  if (oneLineFontSize >= minFontSize) {
+    return { fontSize: Math.floor(oneLineFontSize), wraps: false };
+  }
+  return { fontSize: minFontSize, wraps: true };
+};
+
 /**
  * Home display precision rule: cap the shown fractional digits by the value's
  * integer magnitude — < 1 -> 8, 1-999 -> 4, 1000-9999 -> 3, >= 10000 -> 2.


### PR DESCRIPTION
Builds on #891 (amount format foundation) and extends the decimal-places fix to the send and token-swap screens. Aligns the amount input and amount displays with the [Amounts Update Figma](https://www.figma.com/design/2xRserWXaSJAgkbiQlPzhr/Amounts-Update).

### Acceptance Criteria
- The amount input accepts up to 8 decimal places, independent of the selected token's precision — the value is still scaled to the token's `decimal_places` when the transaction is built.
- Long amounts shrink to stay on one line and, once they reach the minimum size, wrap across up to 3 lines instead of shrinking indefinitely.
- On the Send screen the token selector drops below the amount when it wraps, with no font-size jump at the transition.
- Read-only balances (transaction details, home available and locked) shrink and wrap the same way — previously they stayed at full size and only wrapped on iOS.
- The send flow (amount input and confirmation) and token swap (swap, review and token picker) render amounts using the network's `decimal_places` instead of the wallet-lib default of 2, extending the #891 decimal fix to these screens.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

### Screenshots
Token swap
<img width="368" height="761" alt="image" src="https://github.com/user-attachments/assets/49191b07-1a7f-47de-9693-5e3708aa68e8" />
<img width="362" height="765" alt="image" src="https://github.com/user-attachments/assets/54d52587-dcdc-4dfe-9f88-30e92327c129" />
<img width="366" height="762" alt="image" src="https://github.com/user-attachments/assets/7cd02183-d06d-4ec6-a0b8-648ba726a47d" />

Send transaction


https://github.com/user-attachments/assets/3dc1e814-04d4-4213-887c-5504a6810a48


<img width="361" height="760" alt="image" src="https://github.com/user-attachments/assets/72088f7c-b276-4ca6-b1cd-a0290b09d81d" />
<img width="366" height="762" alt="image" src="https://github.com/user-attachments/assets/03dc438e-7ffb-4306-85dd-a65be19d5a58" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added responsive amount displays that shrink or wrap values to fit available space.
- Amount inputs now support controlled font sizing and optional single-line layouts.
- Amount formatting consistently respects server-provided decimal precision across transfers, balances, fees, and swaps.

## Bug Fixes
- Improved amount layouts to prevent overflow across balance, token creation, and send screens.
- Pasted line breaks are handled more reliably, with support for up to 8 decimal places.
- External styling now applies correctly to token containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->