### PR TITLE
feat: passkey core — PRF key derivation, external signer & xpub-only storage

### DIFF
--- a/__tests__/passkey/passkeySigner.test.js
+++ b/__tests__/passkey/passkeySigner.test.js
@@ -14,7 +14,9 @@ jest.mock('../../src/constants', () => ({ NETWORK_MAINNET: 'mainnet' }));
 jest.mock('../../src/store', () => ({
   STORE: {
     getWalletMeta: jest.fn(),
-    updateWalletMeta: jest.fn(),
+    // Returns a promise: the signer treats the credentialId backfill as fire-and-forget and
+    // attaches a .catch(), so the mock must be thenable or that call would throw.
+    updateWalletMeta: jest.fn(() => Promise.resolve()),
   },
 }));
 
@@ -75,9 +77,14 @@ const makeMeta = (overrides = {}) => ({
   ...overrides,
 });
 
-// A fake account-root xpriv whose derivation chain never actually runs in these tests
-// (signTxInputs is mocked and does not invoke the resolver), but is shaped correctly just in case.
+// A fake account-root xpriv shaped like the real one: BOTH derivation methods are stubbed so the
+// resolver's 'spend' branch (deriveChild = compliant) and 'legacy' branch (deriveNonCompliantChild)
+// can each run without throwing. The default happy-path tests mock signTxInputs and never invoke
+// the resolver; the dedicated resolver test below builds its own asserting root.
 const makeRoot = () => ({
+  deriveChild: jest.fn(() => ({
+    deriveChild: jest.fn(() => ({})),
+  })),
   deriveNonCompliantChild: jest.fn(() => ({
     deriveNonCompliantChild: jest.fn(() => ({})),
   })),
@@ -198,6 +205,45 @@ describe('makePasskeyTxSigner', () => {
     expect(transactionUtils.signTxInputs.mock.calls[0][1]).toBe(fakeStorage);
     expect(result).toEqual({ inputSignatures: [], ncCallerSignature: null });
   });
+
+  test('the resolver derives the spend chain COMPLIANTLY and the legacy chain NON-compliantly', async () => {
+    // signTxInputs is delegated to, but the per-chain key derivation lives in the resolver it gets
+    // as its 3rd arg -- the deriveChild/deriveNonCompliantChild logic that was previously buggy.
+    // The real signTxInputs invokes that resolver DURING signing (while the in-memory root is still
+    // alive, before the finally nulls it), so drive it the same way via mockImplementation.
+    const SPEND_LEAF = { chain: 'spend-leaf' };
+    const LEGACY_LEAF = { chain: 'legacy-leaf' };
+    const spendAcct = { deriveChild: jest.fn(() => SPEND_LEAF) };
+    const legacyAcct = { deriveNonCompliantChild: jest.fn(() => LEGACY_LEAF) };
+    const root = {
+      deriveChild: jest.fn(() => spendAcct),
+      deriveNonCompliantChild: jest.fn(() => legacyAcct),
+    };
+    walletUtils.getXPrivKeyFromSeed.mockReturnValue(root);
+
+    const derived = {};
+    transactionUtils.signTxInputs.mockImplementation(async (_tx, _storage, resolver) => {
+      derived.spend = await resolver('spend');
+      derived.legacy = await resolver('legacy');
+      return { inputSignatures: [], ncCallerSignature: null };
+    });
+
+    const signer = makePasskeyTxSigner();
+    await signer(fakeTx, fakeStorage);
+
+    // 'spend' (shielded) uses the COMPLIANT path: deriveChild(SHIELDED path) then deriveChild(0).
+    // Called exactly once => the shielded branch never touched the legacy (non-compliant) path.
+    expect(derived.spend).toBe(SPEND_LEAF);
+    expect(root.deriveChild).toHaveBeenCalledTimes(1);
+    expect(root.deriveChild).toHaveBeenCalledWith("m/44'/280'/2'");
+    expect(spendAcct.deriveChild).toHaveBeenCalledWith(0);
+
+    // 'legacy' (P2PKH) uses the NON-COMPLIANT path: deriveNonCompliantChild(P2PKH path) then (0).
+    expect(derived.legacy).toBe(LEGACY_LEAF);
+    expect(root.deriveNonCompliantChild).toHaveBeenCalledTimes(1);
+    expect(root.deriveNonCompliantChild).toHaveBeenCalledWith("m/44'/280'/0'");
+    expect(legacyAcct.deriveNonCompliantChild).toHaveBeenCalledWith(0);
+  });
 });
 
 describe('verifyPasskeyForUnlock', () => {
@@ -221,5 +267,22 @@ describe('verifyPasskeyForUnlock', () => {
     const err = await verifyPasskeyForUnlock().catch((e) => e);
 
     expect(err).toBeInstanceOf(PasskeyCancelledError);
+  });
+
+  test('backfills a newly-learned credentialId (mirrors the signer backfill)', async () => {
+    // The unlock ceremony returns a credentialId not yet stored; it should be persisted so the
+    // next ceremony can skip the OS passkey picker.
+    signInWalletWordsFromPasskey.mockResolvedValue({ words: WORDS, credentialId: 'new-cred' });
+
+    await expect(verifyPasskeyForUnlock()).resolves.toBeUndefined();
+
+    expect(STORE.updateWalletMeta).toHaveBeenCalledWith({ credentialId: 'new-cred' });
+  });
+
+  test('does not rewrite an unchanged credentialId', async () => {
+    // Ceremony returns the SAME credentialId already stored -> no metadata write.
+    await expect(verifyPasskeyForUnlock()).resolves.toBeUndefined();
+
+    expect(STORE.updateWalletMeta).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/passkey/passkeySigner.test.js
+++ b/__tests__/passkey/passkeySigner.test.js
@@ -1,0 +1,225 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// --- External boundaries the signer touches, all mocked so the tests are deterministic and
+// need no device / native passkey module / async storage. Each factory builds its jest.fn()
+// inline (referencing `jest` is allowed inside a mock factory) so there is no temporal-dead-zone
+// issue with out-of-scope variables when the factory runs during module resolution.
+
+// NETWORK_MAINNET is the only constant the signer reads; mock it to avoid loading the real
+// constants.js (which pulls `intl` and app config).
+jest.mock('../../src/constants', () => ({ NETWORK_MAINNET: 'mainnet' }));
+
+// The wallet meta store. The signer reads getWalletMeta() (xpub + label + credentialId) and may
+// backfill credentialId via updateWalletMeta().
+jest.mock('../../src/store', () => ({
+  STORE: {
+    getWalletMeta: jest.fn(),
+    updateWalletMeta: jest.fn(),
+  },
+}));
+
+// wallet-lib pieces: xpub/xpriv derivation and the delegated input-signing loop.
+jest.mock('@hathor/wallet-lib', () => ({
+  constants: {
+    SHIELDED_SPEND_ACCT_PATH: "m/44'/280'/2'",
+    P2PKH_ACCT_PATH: "m/44'/280'/0'",
+  },
+  transactionUtils: {
+    signTxInputs: jest.fn(),
+  },
+  walletUtils: {
+    getXPubKeyFromSeed: jest.fn(),
+    getXPrivKeyFromSeed: jest.fn(),
+  },
+}));
+
+// The passkey ceremony boundary (native react-native-passkey lives behind this service).
+// sanitizePasskeyLabel mirrors the real behaviour just enough for the label assertions to be
+// meaningful (used by PasskeyXpubMismatchError to compute the label it carries).
+jest.mock('../../src/passkey/passkeyService', () => ({
+  signInWalletWordsFromPasskey: jest.fn(),
+  isPasskeyCancel: jest.fn(),
+  sanitizePasskeyLabel: jest.fn((label) => {
+    if (!label || typeof label !== 'string') return null;
+    const trimmed = label.trim();
+    return trimmed || null;
+  }),
+}));
+
+/* eslint-disable import/first, import/order */
+import { walletUtils, transactionUtils } from '@hathor/wallet-lib';
+import { STORE } from '../../src/store';
+import { signInWalletWordsFromPasskey, isPasskeyCancel } from '../../src/passkey/passkeyService';
+import {
+  makePasskeyTxSigner,
+  verifyPasskeyForUnlock,
+  consumePasskeySigningCancelled,
+  PasskeyCancelledError,
+  PasskeyXpubMismatchError,
+  PasskeyBusyError,
+} from '../../src/passkey/passkeySigner';
+/* eslint-enable import/first, import/order */
+
+const STORED_XPUB = 'xpub-stored-THIS-wallet';
+const OTHER_XPUB = 'xpub-of-a-DIFFERENT-wallet';
+const STORED_LABEL = 'My Hathor Wallet';
+const STORED_CRED = 'credential-id-1';
+// 24 placeholder BIP39-ish words; content is irrelevant since derivation is mocked.
+const WORDS = new Array(24).fill('abandon').join(' ');
+
+const makeMeta = (overrides = {}) => ({
+  walletType: 'passkey',
+  xpub: STORED_XPUB,
+  passkeyLabel: STORED_LABEL,
+  credentialId: STORED_CRED,
+  ...overrides,
+});
+
+// A fake account-root xpriv whose derivation chain never actually runs in these tests
+// (signTxInputs is mocked and does not invoke the resolver), but is shaped correctly just in case.
+const makeRoot = () => ({
+  deriveNonCompliantChild: jest.fn(() => ({
+    deriveNonCompliantChild: jest.fn(() => ({})),
+  })),
+});
+
+const fakeTx = { hash: 'tx' };
+const fakeStorage = { getTxSignatures: jest.fn() };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Happy-path defaults: the ceremony succeeds, nothing is cancelled, the derived xpub matches
+  // the stored one, and signing delegates cleanly. Individual tests override the relevant piece.
+  STORE.getWalletMeta.mockReturnValue(makeMeta());
+  signInWalletWordsFromPasskey.mockResolvedValue({ words: WORDS, credentialId: STORED_CRED });
+  isPasskeyCancel.mockReturnValue(false);
+  walletUtils.getXPubKeyFromSeed.mockReturnValue(STORED_XPUB);
+  walletUtils.getXPrivKeyFromSeed.mockReturnValue(makeRoot());
+  transactionUtils.signTxInputs.mockResolvedValue({ inputSignatures: [], ncCallerSignature: null });
+});
+
+describe('makePasskeyTxSigner', () => {
+  test('throws PasskeyXpubMismatchError when the ceremony opens a different wallet', async () => {
+    // The passkey ceremony succeeds but derives an xpub that does NOT match the stored wallet.
+    walletUtils.getXPubKeyFromSeed.mockReturnValue(OTHER_XPUB);
+
+    const signer = makePasskeyTxSigner();
+    const err = await signer(fakeTx, fakeStorage, 'ignored-pin').catch((e) => e);
+
+    expect(err).toBeInstanceOf(PasskeyXpubMismatchError);
+    expect(err.name).toBe('PasskeyXpubMismatchError');
+    // The anti-wallet-switch guard fires BEFORE any signing is attempted.
+    expect(transactionUtils.signTxInputs).not.toHaveBeenCalled();
+    // It carries the stored passkey label so the UI can name the correct passkey.
+    expect(err.storedLabel).toBe(STORED_LABEL);
+  });
+
+  test('throws PasskeyXpubMismatchError when no xpub is stored at all', async () => {
+    STORE.getWalletMeta.mockReturnValue(makeMeta({ xpub: undefined }));
+
+    const signer = makePasskeyTxSigner();
+    const err = await signer(fakeTx, fakeStorage).catch((e) => e);
+
+    expect(err).toBeInstanceOf(PasskeyXpubMismatchError);
+    expect(transactionUtils.signTxInputs).not.toHaveBeenCalled();
+  });
+
+  test('throws PasskeyCancelledError when the ceremony is cancelled', async () => {
+    const cancelError = { error: 'UserCancelled' };
+    signInWalletWordsFromPasskey.mockRejectedValue(cancelError);
+    isPasskeyCancel.mockReturnValue(true);
+
+    const signer = makePasskeyTxSigner();
+    const err = await signer(fakeTx, fakeStorage).catch((e) => e);
+
+    expect(err).toBeInstanceOf(PasskeyCancelledError);
+    expect(err.name).toBe('PasskeyCancelledError');
+    expect(transactionUtils.signTxInputs).not.toHaveBeenCalled();
+    // The cancelled flag is set for the saga to read-and-reset.
+    expect(consumePasskeySigningCancelled()).toBe(true);
+    // ...and consuming it clears it.
+    expect(consumePasskeySigningCancelled()).toBe(false);
+  });
+
+  test('re-throws a non-cancel ceremony error unchanged (not wrapped as cancelled)', async () => {
+    const realFailure = new Error('native passkey exploded');
+    signInWalletWordsFromPasskey.mockRejectedValue(realFailure);
+    isPasskeyCancel.mockReturnValue(false);
+
+    const signer = makePasskeyTxSigner();
+    const err = await signer(fakeTx, fakeStorage).catch((e) => e);
+
+    expect(err).toBe(realFailure);
+    expect(err).not.toBeInstanceOf(PasskeyCancelledError);
+    expect(consumePasskeySigningCancelled()).toBe(false);
+  });
+
+  test('throws PasskeyBusyError when a second signing overlaps an in-flight one (single-flight)', async () => {
+    // Leave the FIRST ceremony's promise unresolved so the first call stays in-flight while the
+    // second call is made — this is the genuine concurrent-overlap the busy guard protects against.
+    let resolveCeremony;
+    signInWalletWordsFromPasskey.mockReturnValueOnce(
+      new Promise((resolve) => { resolveCeremony = resolve; })
+    );
+
+    const signer = makePasskeyTxSigner();
+
+    // Kick off the first call. Its synchronous prologue sets the in-flight flag, then it suspends
+    // awaiting the (still pending) ceremony promise.
+    const first = signer(fakeTx, fakeStorage);
+
+    // A concurrent second call must fail fast, WITHOUT starting another ceremony.
+    const busyErr = await signer(fakeTx, fakeStorage).catch((e) => e);
+    expect(busyErr).toBeInstanceOf(PasskeyBusyError);
+    expect(busyErr.name).toBe('PasskeyBusyError');
+    // Only the first call reached the ceremony; the busy call short-circuited before it.
+    expect(signInWalletWordsFromPasskey).toHaveBeenCalledTimes(1);
+
+    // Let the first call complete so the single-flight guard is released.
+    resolveCeremony({ words: WORDS, credentialId: STORED_CRED });
+    await expect(first).resolves.toEqual({ inputSignatures: [], ncCallerSignature: null });
+
+    // The guard (module-level signingInFlight) is per-completion, not permanent: reusing the SAME
+    // signer after the first finishes proceeds — a stuck flag would throw PasskeyBusyError here.
+    const after = await signer(fakeTx, fakeStorage).catch((e) => e);
+    expect(after).not.toBeInstanceOf(PasskeyBusyError);
+  });
+
+  test('happy path backfills credentialId and delegates to transactionUtils.signTxInputs', async () => {
+    // Ceremony returns a NEW credentialId (learned on this device); it should be persisted.
+    signInWalletWordsFromPasskey.mockResolvedValue({ words: WORDS, credentialId: 'new-cred' });
+
+    const signer = makePasskeyTxSigner();
+    const result = await signer(fakeTx, fakeStorage);
+
+    expect(STORE.updateWalletMeta).toHaveBeenCalledWith({ credentialId: 'new-cred' });
+    expect(transactionUtils.signTxInputs).toHaveBeenCalledTimes(1);
+    expect(transactionUtils.signTxInputs.mock.calls[0][0]).toBe(fakeTx);
+    expect(transactionUtils.signTxInputs.mock.calls[0][1]).toBe(fakeStorage);
+    expect(result).toEqual({ inputSignatures: [], ncCallerSignature: null });
+  });
+});
+
+describe('verifyPasskeyForUnlock', () => {
+  test('resolves when the ceremony opens THIS wallet', async () => {
+    await expect(verifyPasskeyForUnlock()).resolves.toBeUndefined();
+  });
+
+  test('throws PasskeyXpubMismatchError when the passkey opens a different wallet', async () => {
+    walletUtils.getXPubKeyFromSeed.mockReturnValue(OTHER_XPUB);
+
+    const err = await verifyPasskeyForUnlock().catch((e) => e);
+
+    expect(err).toBeInstanceOf(PasskeyXpubMismatchError);
+    expect(err.storedLabel).toBe(STORED_LABEL);
+  });
+
+  test('throws PasskeyCancelledError when the ceremony is cancelled', async () => {
+    signInWalletWordsFromPasskey.mockRejectedValue({ error: 'UserCancelled' });
+    isPasskeyCancel.mockReturnValue(true);
+
+    const err = await verifyPasskeyForUnlock().catch((e) => e);
+
+    expect(err).toBeInstanceOf(PasskeyCancelledError);
+  });
+});

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1332,6 +1332,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-passkey (3.5.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-randombytes (3.6.1):
     - React-Core
   - react-native-restart (0.0.27):
@@ -2098,6 +2119,7 @@ DEPENDENCIES:
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-pager-view (from `../node_modules/react-native-pager-view`)
+  - react-native-passkey (from `../node_modules/react-native-passkey`)
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
   - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
@@ -2246,6 +2268,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-pager-view:
     :path: "../node_modules/react-native-pager-view"
+  react-native-passkey:
+    :path: "../node_modules/react-native-passkey"
   react-native-randombytes:
     :path: "../node_modules/react-native-randombytes"
   react-native-restart:
@@ -2398,6 +2422,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: a3da6756728d588966b7042c787c3567576448f0
+  react-native-passkey: 3c88587c78ea8e12cd15772cecfc6e2beeca550a
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
   react-native-safe-area-context: d2bad4bfc00dcefabbdccefa9544933bd36756f8
@@ -2451,6 +2476,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: fdc0542faa3ba87e56f2030b3f3f2e21bc3ba01c
 
-PODFILE CHECKSUM: 835a7772b03035b75306613d55fa63e9bee6be63
+PODFILE CHECKSUM: 6b231a3d533c924819cc0d4b55a4fd09c7f40fbd
 
 COCOAPODS: 1.15.2

--- a/jestMockSetup.js
+++ b/jestMockSetup.js
@@ -64,34 +64,6 @@ jest.mock('@sentry/react-native');
 
 jest.mock('react-native-version-number');
 
-jest.mock('unleash-proxy-client', () => ({
-  UnleashClient: jest.fn(() => ({
-    getAllToggles: () => ({}),
-    isEnabled: () => false,
-    getVariant: () => ({}),
-    updateContext: () => {},
-    getContext: () => ({
-      appName: 'hathor-wallet-mobile',
-      environment: 'test',
-      userId: 'test-user',
-      sessionId: 'test-session',
-      remoteAddress: undefined,
-      properties: {},
-    }),
-    setContextField: () => {},
-    start: () => {},
-    stop: () => {},
-    on: () => {},
-  })),
-  EVENTS: {
-    INIT: 'INIT',
-    ERROR: 'ERROR',
-    READY: 'READY',
-    UPDATE: 'UPDATE',
-    IMPRESSION: 'IMPRESSION',
-  },
-}), { virtual: true });
-
 const RNPermissionsModule = {};
 jest.mock('react-native-permissions', () => ({
   default: {
@@ -100,7 +72,3 @@ jest.mock('react-native-permissions', () => ({
     })
   }
 }));
-
-jest.mock('react-native-modal', () => ({}), { virtual: true });
-
-jest.mock('react-native-animatable', () => ({}), { virtual: true });

--- a/jestMockSetup.js
+++ b/jestMockSetup.js
@@ -90,7 +90,7 @@ jest.mock('unleash-proxy-client', () => ({
     UPDATE: 'UPDATE',
     IMPRESSION: 'IMPRESSION',
   },
-}));
+}), { virtual: true });
 
 const RNPermissionsModule = {};
 jest.mock('react-native-permissions', () => ({
@@ -101,6 +101,6 @@ jest.mock('react-native-permissions', () => ({
   }
 }));
 
-jest.mock('react-native-modal');
+jest.mock('react-native-modal', () => ({}), { virtual: true });
 
-jest.mock('react-native-animatable');
+jest.mock('react-native-animatable', () => ({}), { virtual: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react-native-keychain": "10.0.0",
         "react-native-localize": "2.2.6",
         "react-native-pager-view": "6.8.1",
+        "react-native-passkey": "3.5.0",
         "react-native-permissions": "5.3.0",
         "react-native-qrcode-svg": "6.3.15",
         "react-native-randombytes": "3.6.1",
@@ -17439,6 +17440,16 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.8.1.tgz",
       "integrity": "sha512-XIyVEMhwq7sZqM7GobOJZXxFCfdFgVNq/CFB2rZIRNRSVPJqE1k1fsc8xfQKfdzsp6Rpt6I7VOIvhmP7/YHdVg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-passkey": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-passkey/-/react-native-passkey-3.5.0.tgz",
+      "integrity": "sha512-hNY5Ik8A1KMoCL38edbVS4jXyDmk6hec+Q+keskCHcFa+E2NC7vROtdCDl77JxsJe/BK00csQtiK6Cqd54QFmg==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
   "jest": {
     "preset": "react-native",
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(@react-native|react-native|@notifee/react-native|react-native-device-info|react-native-gesture-handler|react-native-keychain|@react-navigation|react-native-status-bar-height|@react-native-firebase|@sentry/react-native|react-native-version-number|unleash-proxy-client|react-native-permissions|react-native-modal|react-native-animatable|react-native-camera-kit|@fortawesome/react-native-fontawesome|react-native-qrcode-svg)/)"
+      "<rootDir>/node_modules/(?!(@react-native|react-native|@notifee/react-native|react-native-device-info|react-native-gesture-handler|react-native-keychain|@react-navigation|react-native-status-bar-height|@react-native-firebase|@sentry/react-native|react-native-version-number|react-native-permissions|react-native-camera-kit|@fortawesome/react-native-fontawesome|react-native-qrcode-svg)/)"
     ],
     "setupFiles": [
       "<rootDir>/jestMockSetup.js"

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-native-keychain": "10.0.0",
     "react-native-localize": "2.2.6",
     "react-native-pager-view": "6.8.1",
+    "react-native-passkey": "3.5.0",
     "react-native-permissions": "5.3.0",
     "react-native-qrcode-svg": "6.3.15",
     "react-native-randombytes": "3.6.1",

--- a/src/constants.js
+++ b/src/constants.js
@@ -197,6 +197,7 @@ export const SAFE_BIOMETRY_MODE_FEATURE_TOGGLE = 'safe-biometry-mode.rollout'
 export const TOKEN_SWAP_FEATURE_TOGGLE = 'token-swap.rollout';
 export const FBT_FEATURE_TOGGLE = 'fee-based-tokens.rollout';
 export const SINGLE_ADDRESS_FEATURE_TOGGLE = 'single-address-mobile.rollout';
+export const PASSKEY_ONBOARDING_FEATURE_TOGGLE = 'passkey-onboarding.rollout';
 
 /**
  * Default feature toggle values.
@@ -216,7 +217,19 @@ export const FEATURE_TOGGLE_DEFAULTS = {
   [TOKEN_SWAP_FEATURE_TOGGLE]: false,
   [FBT_FEATURE_TOGGLE]: false,
   [SINGLE_ADDRESS_FEATURE_TOGGLE]: false,
+  [PASSKEY_ONBOARDING_FEATURE_TOGGLE]: false,
 };
+
+/**
+ * Passkey (PRF) onboarding config (passkey PRF secret -> BIP39 seed).
+ *
+ * PASSKEY_RP_ID MUST be a domain Hathor controls with the Associated Domains entitlement
+ * (`webcredentials:<PASSKEY_RP_ID>`) and a hosted
+ * https://<PASSKEY_RP_ID>/.well-known/apple-app-site-association — otherwise passkey create/get
+ * fail on device.
+ */
+export const PASSKEY_RP_ID = 'wallet.hathor.dev';
+export const PASSKEY_RP_NAME = 'Hathor Wallet';
 
 // Project id configured in https://walletconnect.com
 export const REOWN_PROJECT_ID = '8264fff563181da658ce64ee80e80458';

--- a/src/passkey/passkeyService.js
+++ b/src/passkey/passkeyService.js
@@ -60,8 +60,9 @@ const randomBytes = (n) => {
   return b;
 };
 
-// react-native-passkey is a NATIVE dependency. Lazy-require it so the JS bundle still builds for
-// anyone who hasn't run `yarn && pod install` yet; the clear error only fires if passkey is used.
+// react-native-passkey is a NATIVE dependency. Require it lazily (not a top-level import) so
+// loading this module at app startup doesn't touch the native side; a missing/unlinked install
+// then surfaces as the clear, actionable error below only when a passkey flow is actually used.
 function getPasskey() {
   let mod;
   try {

--- a/src/passkey/passkeyService.js
+++ b/src/passkey/passkeyService.js
@@ -28,6 +28,9 @@ import {
   PASSKEY_RP_ID,
   PASSKEY_RP_NAME,
 } from '../constants';
+import { logger } from '../logger';
+
+const log = logger('passkey');
 
 // PRF salt: a STABLE, PERMANENT input to the passkey PRF evaluation and therefore part of the
 // seed-derivation input. Changing this value changes the derived seed of EVERY passkey wallet, so
@@ -60,22 +63,36 @@ const randomBytes = (n) => {
 // react-native-passkey is a NATIVE dependency. Lazy-require it so the JS bundle still builds for
 // anyone who hasn't run `yarn && pod install` yet; the clear error only fires if passkey is used.
 function getPasskey() {
+  let mod;
   try {
     // eslint-disable-next-line global-require, import/no-unresolved
-    return require('react-native-passkey').Passkey;
+    mod = require('react-native-passkey');
   } catch (e) {
+    // Keep the original error as the cause: a module that IS installed but throws during native
+    // init would otherwise be misreported as "not installed" with its real stack lost.
     throw new Error(
-      'react-native-passkey is not installed. Run `yarn && cd ios && pod install`.'
+      'react-native-passkey is not installed. Run `yarn && cd ios && pod install`.',
+      { cause: e }
     );
   }
+  // require() can succeed while the export is missing/renamed; assert it so the failure surfaces
+  // here with a clear message instead of as a TypeError at the first Passkey.* call site.
+  if (!mod?.Passkey) {
+    throw new Error('react-native-passkey loaded but exposes no `Passkey` export (version mismatch?).');
+  }
+  return mod.Passkey;
 }
 
 /**
- * True when a passkey ceremony failed because the USER dismissed the OS sheet (both platforms
- * report the stable code 'UserCancelled'), as opposed to a real failure.
+ * True when a passkey ceremony failed because the USER dismissed the OS sheet. react-native-passkey
+ * normalizes a cancel to the stable code `error: 'UserCancelled'` on both platforms (its
+ * handleNativeError maps the native code; anything unmapped becomes 'Native error'), so match that
+ * structured code —
+ * NOT a substring on the translatable message, which would false-positive on any error whose text
+ * happens to contain "user cancel".
  */
 export function isPasskeyCancel(e) {
-  return e?.error === 'UserCancelled' || /user\s*cancel/i.test(String(e?.message ?? ''));
+  return e?.error === 'UserCancelled';
 }
 
 // user.id is capped at 64 bytes by WebAuthn; we spend 1 on the 0x00 separator and 8 on the
@@ -141,6 +158,9 @@ export async function isPasskeySupported() {
     const r = Passkey.isSupported();
     return typeof r?.then === 'function' ? await r : !!r;
   } catch (e) {
+    // This gate decides whether the feature is offered at all, so a broken pod/native link would
+    // otherwise be indistinguishable from a genuinely-unsupported device. Log before swallowing.
+    log.error('isPasskeySupported() failed; treating passkeys as unsupported', e);
     return false;
   }
 }
@@ -162,7 +182,16 @@ function toBytes(v) {
 /** Dig the PRF `first` result out of a react-native-passkey result, tolerant of its shape. */
 function digPrfFirst(result) {
   const ext = result?.clientExtensionResults ?? result?.response?.clientExtensionResults;
-  return toBytes(ext?.prf?.results?.first);
+  const raw = ext?.prf?.results?.first;
+  const bytes = toBytes(raw);
+  // A PRF result that IS present but that toBytes can't decode is a parsing regression (a
+  // react-native-passkey shape change), NOT an unsupported device — surface it distinctly so
+  // wordsFromPrf's "needs iOS 18+" message doesn't misattribute it to the OS version.
+  if (raw != null && !bytes) {
+    const shape = typeof raw === 'object' ? `object keys=[${Object.keys(raw).join(',')}]` : typeof raw;
+    throw new Error(`Received a PRF result but could not decode it (unexpected shape: ${shape}).`);
+  }
+  return bytes;
 }
 
 /**

--- a/src/passkey/passkeyService.js
+++ b/src/passkey/passkeyService.js
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Passkey (PRF) onboarding service.
+ *
+ * A WebAuthn passkey's PRF output is a 32-byte secret that is DETERMINISTIC for a given
+ * credential + salt, never leaves the secure element, and is synced/backed-up by the platform
+ * (iCloud Keychain / Google Password Manager). We use it as the BIP39 entropy for an otherwise
+ * completely ordinary Hathor HD wallet: the user does Face ID, no 24 words are ever shown, and
+ * "backup" becomes the passkey's own platform sync. Only the account xpub is persisted (never the
+ * words or any private key); every signing operation re-runs the passkey ceremony to derive keys
+ * in memory and immediately discards them (see passkeySigner.js).
+ *
+ * Native layer: react-native-passkey (PRF on iOS 18+ / Android Credential Manager).
+ *
+ * IMPORTANT — on-device prerequisites:
+ *   - iOS: Associated Domains entitlement `webcredentials:<PASSKEY_RP_ID>` + a hosted
+ *     https://<PASSKEY_RP_ID>/.well-known/apple-app-site-association. Without it, create/get fail.
+ */
+
+import { walletUtils } from '@hathor/wallet-lib';
+import {
+  PASSKEY_RP_ID,
+  PASSKEY_RP_NAME,
+} from '../constants';
+
+// PRF salt: a STABLE, PERMANENT input to the passkey PRF evaluation and therefore part of the
+// seed-derivation input. Changing this value changes the derived seed of EVERY passkey wallet, so
+// it must never be altered once the feature ships to users.
+const PRF_SALT_STRING = 'hathor-passkey/prf/v1';
+// Buffer is globally polyfilled in RN (see shim.js); avoid TextEncoder for reliability.
+const PRF_SALT = new Uint8Array(Buffer.from(PRF_SALT_STRING, 'utf8'));
+
+const toB64Url = (u8) => Buffer.from(u8)
+  .toString('base64')
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_')
+  .replace(/=+$/, '');
+
+const fromB64Url = (s) => new Uint8Array(
+  Buffer.from(String(s).replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+);
+
+// Random bytes for the NON-SECRET ceremony inputs only: the WebAuthn challenge (a per-ceremony
+// nonce) and the random suffix of user.id (keeps credential ids unique). The wallet's actual
+// entropy is the PRF output, which the authenticator computes inside its secure element and is
+// never generated here.
+const randomBytes = (n) => {
+  const b = new Uint8Array(n);
+  // react-native-get-random-values makes global.crypto.getRandomValues available.
+  global.crypto.getRandomValues(b);
+  return b;
+};
+
+// react-native-passkey is a NATIVE dependency. Lazy-require it so the JS bundle still builds for
+// anyone who hasn't run `yarn && pod install` yet; the clear error only fires if passkey is used.
+function getPasskey() {
+  try {
+    // eslint-disable-next-line global-require, import/no-unresolved
+    return require('react-native-passkey').Passkey;
+  } catch (e) {
+    throw new Error(
+      'react-native-passkey is not installed. Run `yarn && cd ios && pod install`.'
+    );
+  }
+}
+
+/**
+ * True when a passkey ceremony failed because the USER dismissed the OS sheet (both platforms
+ * report the stable code 'UserCancelled'), as opposed to a real failure.
+ */
+export function isPasskeyCancel(e) {
+  return e?.error === 'UserCancelled' || /user\s*cancel/i.test(String(e?.message ?? ''));
+}
+
+// user.id is capped at 64 bytes by WebAuthn; we spend 1 on the 0x00 separator and 8 on the
+// random suffix, leaving 55 for the label.
+const USER_ID_LABEL_MAX_BYTES = 55;
+
+/**
+ * Truncate a string to at most `maxBytes` UTF-8 bytes WITHOUT splitting a multi-byte code point.
+ * Slicing by JS string length (`.slice`) counts UTF-16 units, so a CJK/emoji label can blow past
+ * the byte budget; slicing raw bytes could split a character and yield a U+FFFD on decode, which
+ * decodeUserIdLabel rejects. Iterate by code point (for..of) and stop before the budget overflows.
+ */
+function truncateUtf8(str, maxBytes) {
+  let bytes = 0;
+  let end = 0;
+  for (const ch of str) {
+    const chBytes = Buffer.byteLength(ch, 'utf8');
+    if (bytes + chBytes > maxBytes) break;
+    bytes += chBytes;
+    end += ch.length;
+  }
+  return str.slice(0, end);
+}
+
+/**
+ * user.id encoding: utf8(label) + 0x00 + 8 random bytes (≤64 bytes total, per WebAuthn).
+ * The label part lets sign-in recover the wallet name from response.userHandle; the random
+ * suffix keeps user.id UNIQUE per credential — authenticators REPLACE an existing passkey
+ * when rp + user.id repeat, so two wallets with the same name must never share an id.
+ */
+function encodeUserId(label) {
+  const labelBytes = Buffer.from(truncateUtf8(String(label), USER_ID_LABEL_MAX_BYTES), 'utf8');
+  return toB64Url(Buffer.concat([labelBytes, Buffer.from([0]), Buffer.from(randomBytes(8))]));
+}
+
+/**
+ * Reject strings that are not a human-typed label: decode artifacts (U+FFFD replacement
+ * chars) and control characters mean the bytes were never text — e.g. passkeys registered
+ * before labels were encoded in user.id carry 16 random bytes there. Returns null for those.
+ */
+export function sanitizePasskeyLabel(label) {
+  if (!label || typeof label !== 'string') return null;
+  const trimmed = label.trim();
+  // eslint-disable-next-line no-control-regex
+  if (!trimmed || /[\uFFFD\u0000-\u001F]/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/** Best-effort inverse of encodeUserId: label from a userHandle, or null. */
+function decodeUserIdLabel(userHandle) {
+  const bytes = toBytes(userHandle);
+  if (!bytes || !bytes.length) return null;
+  const buf = Buffer.from(bytes);
+  const sep = buf.indexOf(0);
+  const label = (sep >= 0 ? buf.subarray(0, sep) : buf).toString('utf8');
+  return sanitizePasskeyLabel(label);
+}
+
+/** True if this device/build can produce a passkey PRF secret. */
+export async function isPasskeySupported() {
+  try {
+    const Passkey = getPasskey();
+    const r = Passkey.isSupported();
+    return typeof r?.then === 'function' ? await r : !!r;
+  } catch (e) {
+    return false;
+  }
+}
+
+/** Coerce a binary value (base64url string, byte array, or RN Uint8Array-as-object) to bytes. */
+function toBytes(v) {
+  if (v == null) return undefined;
+  if (v instanceof Uint8Array) return v;
+  if (typeof v === 'string') return fromB64Url(v);
+  if (Array.isArray(v)) return new Uint8Array(v);
+  if (typeof v === 'object') {
+    // RN serializes a Uint8Array across the bridge as { "0": b, "1": b, ... }.
+    const keys = Object.keys(v).filter((k) => /^\d+$/.test(k)).sort((a, b) => Number(a) - Number(b));
+    if (keys.length) return new Uint8Array(keys.map((k) => v[k]));
+  }
+  return undefined;
+}
+
+/** Dig the PRF `first` result out of a react-native-passkey result, tolerant of its shape. */
+function digPrfFirst(result) {
+  const ext = result?.clientExtensionResults ?? result?.response?.clientExtensionResults;
+  return toBytes(ext?.prf?.results?.first);
+}
+
+/**
+ * Register a passkey with PRF ENABLED (hmac-secret), but do NOT evaluate the salt here.
+ * iOS enables PRF at registration yet returns the secret only at ASSERTION, and passing salt
+ * inputs at registration is the least-supported path (a likely source of a generic native
+ * failure). We evaluate the salt in getPrfViaAssertion() instead — the PRF output is deterministic
+ * per (credential, salt), so the derived seed is identical whichever call evaluates it.
+ */
+async function registerPasskey(userName) {
+  const Passkey = getPasskey();
+  const result = await Passkey.create({
+    challenge: toB64Url(randomBytes(32)),
+    rp: { id: PASSKEY_RP_ID, name: PASSKEY_RP_NAME },
+    user: { id: encodeUserId(userName), name: userName, displayName: userName },
+    pubKeyCredParams: [{ type: 'public-key', alg: -7 }], // ES256 / P-256 — the only curve passkeys do
+    authenticatorSelection: { residentKey: 'required', userVerification: 'preferred' },
+    extensions: { prf: {} }, // enable PRF / check support; evaluate at assertion
+  });
+  return result?.id ?? result?.rawId; // credentialId
+}
+
+/**
+ * Assert with the passkey to obtain the PRF secret (many platforms only return PRF on get()).
+ * Also surfaces the userHandle (= user.id) when the platform returns it, so callers can
+ * recover the wallet label encoded at registration. userHandle is optional on both platforms.
+ */
+async function getPrfViaAssertion(credentialId) {
+  const Passkey = getPasskey();
+  const result = await Passkey.get({
+    challenge: toB64Url(randomBytes(32)),
+    rpId: PASSKEY_RP_ID,
+    userVerification: 'preferred',
+    allowCredentials: credentialId ? [{ type: 'public-key', id: credentialId }] : undefined,
+    // iOS wants binary PRF inputs as a Uint8Array (it arrives as a Dictionary and is decoded
+    // byte-by-byte); a base64url string throws DecodingError.typeMismatch. Pass the raw bytes.
+    extensions: { prf: { eval: { first: PRF_SALT } } },
+  });
+  return {
+    prf: digPrfFirst(result),
+    userHandle: result?.response?.userHandle ?? result?.userHandle,
+    credentialId: result?.id ?? result?.rawId ?? null,
+  };
+}
+
+/** 32-byte PRF secret -> { words } (a 24-word BIP39 phrase). Same secret => same wallet. */
+function wordsFromPrf(prf32) {
+  if (!prf32 || prf32.length !== 32) {
+    throw new Error(
+      'Could not obtain a 32-byte PRF secret from the passkey. PRF may be unsupported on this '
+        + 'device (needs iOS 18+, or Android with Google Password Manager passkeys).'
+    );
+  }
+  // 32 bytes of entropy -> exactly 24 BIP39 words. wallet-lib's generateWalletWords passes the
+  // Buffer straight to bitcore-mnemonic as ENTROPY, so this is deterministic and matches the
+  // seed handling used everywhere else in the wallet.
+  return { words: walletUtils.generateWalletWords(Buffer.from(prf32)) };
+}
+
+/**
+ * CREATE a brand-new passkey and derive a fresh wallet seed from its PRF secret.
+ * Use for first-time onboarding — this mints a NEW passkey (and thus a NEW wallet) every call.
+ *
+ * @param {string} userName label shown by the OS passkey UI
+ * @returns {Promise<{ words: string, label: string, credentialId: string|null }>}
+ */
+export async function createWalletWordsFromPasskey(userName = 'Hathor Wallet') {
+  const credentialId = await registerPasskey(userName); // enables PRF on the new passkey
+  const { prf } = await getPrfViaAssertion(credentialId); // Face ID again to evaluate PRF
+  return { ...wordsFromPrf(prf), label: userName, credentialId: credentialId ?? null };
+}
+
+/**
+ * SIGN IN with an EXISTING passkey and re-derive the SAME wallet seed from its PRF secret.
+ *
+ * Uses a DISCOVERABLE assertion (no allowCredentials), so iOS/Android lists the user's passkeys
+ * for this domain to choose from. Because platform passkeys (and their PRF output) sync via iCloud
+ * Keychain / Google Password Manager, this returns the identical seed after a wallet reset, an app
+ * reinstall, or on a different device signed into the same account — that's the recovery story.
+ *
+ * The label is recovered from the assertion's userHandle when the platform returns it
+ * (encoded at registration by encodeUserId); null when unavailable.
+ *
+ * When the wallet already knows its credential (walletMeta.credentialId), pass it as
+ * `options.credentialId`: the OS then skips the passkey picker and prompts biometrics for
+ * that credential directly, making the wrong-passkey path impossible in normal use.
+ *
+ * @param {{ credentialId?: string }} [options]
+ * @returns {Promise<{ words: string, label: string|null, credentialId: string|null }>}
+ */
+export async function signInWalletWordsFromPasskey(options = {}) {
+  // Without options.credentialId this is a DISCOVERABLE assertion (OS lists all passkeys).
+  const { prf, userHandle, credentialId } = await getPrfViaAssertion(options.credentialId);
+  return {
+    ...wordsFromPrf(prf),
+    label: decodeUserIdLabel(userHandle),
+    credentialId,
+  };
+}

--- a/src/passkey/passkeySigner.js
+++ b/src/passkey/passkeySigner.js
@@ -154,10 +154,15 @@ export function makePasskeyTxSigner() {
         // drift as the lib evolves. The resolver returns the change-path xpriv for each chain
         // ('legacy' = m/44'/280'/0'/0, 'spend' = the shielded spend chain m/44'/280'/2'/0).
         return await transactionUtils.signTxInputs(tx, storage, async (chain) => {
-          const acctPath = chain === 'spend'
-            ? hathorConstants.SHIELDED_SPEND_ACCT_PATH
-            : hathorConstants.P2PKH_ACCT_PATH;
-          return root.deriveNonCompliantChild(acctPath).deriveNonCompliantChild(0);
+          // Shielded (spend) keys derive COMPLIANTLY (the lib derives the shielded chain with
+          // deriveChild); legacy P2PKH keys stay non-compliant. Using the wrong one produces a
+          // key that won't match the address the lib generated, so the signature fails on-chain.
+          if (chain === 'spend') {
+            const spendAcct = root.deriveChild(hathorConstants.SHIELDED_SPEND_ACCT_PATH);
+            return spendAcct.deriveChild(0);
+          }
+          const legacyAcct = root.deriveNonCompliantChild(hathorConstants.P2PKH_ACCT_PATH);
+          return legacyAcct.deriveNonCompliantChild(0);
         });
       } finally {
         // JS cannot zero string memory; dropping every reference as soon as possible is the

--- a/src/passkey/passkeySigner.js
+++ b/src/passkey/passkeySigner.js
@@ -20,11 +20,14 @@
 import { constants as hathorConstants, transactionUtils, walletUtils } from '@hathor/wallet-lib';
 import { NETWORK_MAINNET } from '../constants';
 import { STORE } from '../store';
+import { logger } from '../logger';
 import {
   signInWalletWordsFromPasskey,
   isPasskeyCancel,
   sanitizePasskeyLabel,
 } from './passkeyService';
+
+const log = logger('passkey-signer');
 
 export class PasskeyCancelledError extends Error {
   constructor() {
@@ -139,9 +142,11 @@ export function makePasskeyTxSigner() {
         }
 
         // Wallets signed in before credentialId was captured (or on another device) learn it
-        // here, so the next ceremony can skip the picker too.
+        // here, so the next ceremony can skip the picker too. Best-effort: this is only an
+        // optimization, so fire-and-forget and log (never block or fail signing) if the write
+        // rejects — awaiting the returned promise avoids an unhandled rejection.
         if (credentialId && credentialId !== meta.credentialId) {
-          STORE.updateWalletMeta({ credentialId });
+          STORE.updateWalletMeta({ credentialId }).catch((e) => log.error('credentialId backfill failed', e));
         }
 
         // Derive the account root xpriv once; wallet-lib's signTxInputs derives the per-input
@@ -197,8 +202,9 @@ export function verifyPasskeyForUnlock() {
       if (!meta?.xpub || derivePasskeyXpub(words) !== meta.xpub) {
         throw new PasskeyXpubMismatchError(meta?.passkeyLabel);
       }
+      // Best-effort backfill (see makePasskeyTxSigner): fire-and-forget, log on failure.
       if (credentialId && credentialId !== meta.credentialId) {
-        STORE.updateWalletMeta({ credentialId });
+        STORE.updateWalletMeta({ credentialId }).catch((e) => log.error('credentialId backfill failed', e));
       }
     } finally {
       words = null;

--- a/src/passkey/passkeySigner.js
+++ b/src/passkey/passkeySigner.js
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * External transaction signer for passkey (PIN-less, xpub-only) wallets.
+ *
+ * These wallets are started read-only from the account xpub; no seed or private key is ever
+ * persisted. When wallet-lib needs signatures (storage.getTxSignatures), the callback built by
+ * makePasskeyTxSigner() runs the WebAuthn PRF ceremony, re-derives the BIP39 seed in memory,
+ * verifies it belongs to THIS wallet (derived xpub === stored xpub), then delegates the actual
+ * signing to wallet-lib's transactionUtils.signTxInputs (supplying the ceremony-derived chain
+ * xprivs), and discards all key material before returning. Register it with
+ * wallet.setExternalTxSigningMethod() BEFORE wallet.start().
+ */
+
+import { constants as hathorConstants, transactionUtils, walletUtils } from '@hathor/wallet-lib';
+import { NETWORK_MAINNET } from '../constants';
+import { STORE } from '../store';
+import {
+  signInWalletWordsFromPasskey,
+  isPasskeyCancel,
+  sanitizePasskeyLabel,
+} from './passkeyService';
+
+export class PasskeyCancelledError extends Error {
+  constructor() {
+    super(`Passkey authorization was cancelled. Nothing was sent.`);
+    this.name = 'PasskeyCancelledError';
+  }
+}
+
+export class PasskeyXpubMismatchError extends Error {
+  constructor(storedLabel) {
+    // Labels persisted from old-format credentials may be decode garbage; never show those.
+    const label = sanitizePasskeyLabel(storedLabel);
+    super(label
+      ? `This passkey opens a different wallet. Use the passkey named "${label}".`
+      : `This passkey opens a different wallet. Use the passkey that created this wallet.`);
+    this.name = 'PasskeyXpubMismatchError';
+    this.storedLabel = label;
+  }
+}
+
+export class PasskeyBusyError extends Error {
+  constructor() {
+    super(`Another passkey authorization is already in progress.`);
+    this.name = 'PasskeyBusyError';
+  }
+}
+
+/**
+ * The ONE xpub derivation used everywhere (onboarding, unlock verification, signing):
+ * account-path xpub (m/44'/280'/0') — exactly what generateAccessDataFromXpub expects,
+ * so string equality against the stored xpub is a valid identity check.
+ *
+ * @param {string} words BIP39 seed phrase derived from the passkey PRF secret
+ * @returns {string} account-path xpubkey
+ */
+export function derivePasskeyXpub(words) {
+  return walletUtils.getXPubKeyFromSeed(words, {
+    networkName: NETWORK_MAINNET,
+    accountDerivationIndex: "0'",
+  });
+}
+
+// Module-level single-flight guard: the OS shows one credential sheet at a time; a second
+// concurrent ceremony (double-tap through a path without a screen-level guard) must fail fast.
+let signingInFlight = false;
+
+// The reown saga cannot rely on `instanceof` or message matching to detect a cancelled
+// ceremony: the rpc-handler re-wraps errors and messages are translated. This flag mirrors
+// the saga's own `pinWasCancelled` pattern — set when a SIGNING ceremony is cancelled,
+// consumed (read-and-reset) by the caller. It is reset at the start of every ceremony so it
+// always reflects the most recent one.
+let signingCancelled = false;
+
+/** Read-and-reset: whether the most recent signing ceremony was cancelled by the user. */
+export function consumePasskeySigningCancelled() {
+  const value = signingCancelled;
+  signingCancelled = false;
+  return value;
+}
+
+/**
+ * Build the EcdsaTxSign callback for wallet.setExternalTxSigningMethod().
+ * Signature contract (wallet-lib storage.getTxSignatures): async (tx, storage, pinCode) =>
+ * { inputSignatures: [{inputIndex, addressIndex, signature, pubkey}], ncCallerSignature }.
+ * The pinCode is a placeholder for passkey wallets and is ignored.
+ */
+export function makePasskeyTxSigner() {
+  return async function passkeyTxSigner(tx, storage, _pinCode) {
+    if (signingInFlight) {
+      throw new PasskeyBusyError();
+    }
+    signingInFlight = true;
+    signingCancelled = false;
+    let root = null;
+    try {
+      const meta = STORE.getWalletMeta();
+      let words;
+      let credentialId;
+      try {
+        // Passing the stored credentialId skips the OS passkey picker and prompts
+        // biometrics for THIS wallet's credential directly.
+        ({ words, credentialId } = await signInWalletWordsFromPasskey({
+          credentialId: meta?.credentialId,
+        }));
+      } catch (e) {
+        if (isPasskeyCancel(e)) {
+          signingCancelled = true;
+          throw new PasskeyCancelledError();
+        }
+        throw e;
+      }
+
+      if (!meta?.xpub || derivePasskeyXpub(words) !== meta.xpub) {
+        throw new PasskeyXpubMismatchError(meta?.passkeyLabel);
+      }
+
+      // Wallets signed in before credentialId was captured (or on another device) learn it
+      // here, so the next ceremony can skip the picker too.
+      if (credentialId && credentialId !== meta.credentialId) {
+        STORE.updateWalletMeta({ credentialId });
+      }
+
+      // Derive the account root xpriv once; wallet-lib's signTxInputs derives the per-input
+      // keys from the chain xprivs it requests through the resolver below.
+      root = walletUtils.getXPrivKeyFromSeed(words, { networkName: NETWORK_MAINNET });
+      words = null;
+
+      // Delegate the input-signing loop to wallet-lib so input selection, shielded-spend
+      // handling, the nano/OCB caller signature and encoding all live in one place and don't
+      // drift as the lib evolves. The resolver returns the change-path xpriv for each chain
+      // ('legacy' = m/44'/280'/0'/0, 'spend' = the shielded spend chain m/44'/280'/2'/0).
+      return await transactionUtils.signTxInputs(tx, storage, async (chain) => {
+        const acctPath = chain === 'spend'
+          ? hathorConstants.SHIELDED_SPEND_ACCT_PATH
+          : hathorConstants.P2PKH_ACCT_PATH;
+        return root.deriveNonCompliantChild(acctPath).deriveNonCompliantChild(0);
+      });
+    } finally {
+      // JS cannot zero string memory; dropping every reference as soon as possible is the
+      // best available hygiene (same exposure window the lib has during getMainXPrivKey).
+      root = null;
+      signingInFlight = false;
+    }
+  };
+}
+
+/**
+ * Verify-only ceremony for the lock screen: asserts the passkey, checks it opens the loaded
+ * wallet, and discards the derived material. Resolves on success; throws
+ * PasskeyCancelledError / PasskeyXpubMismatchError otherwise.
+ */
+export async function verifyPasskeyForUnlock() {
+  const meta = STORE.getWalletMeta();
+  let words = null;
+  let credentialId = null;
+  try {
+    ({ words, credentialId } = await signInWalletWordsFromPasskey({
+      credentialId: meta?.credentialId,
+    }));
+  } catch (e) {
+    if (isPasskeyCancel(e)) {
+      throw new PasskeyCancelledError();
+    }
+    throw e;
+  }
+  try {
+    if (!meta?.xpub || derivePasskeyXpub(words) !== meta.xpub) {
+      throw new PasskeyXpubMismatchError(meta?.passkeyLabel);
+    }
+    if (credentialId && credentialId !== meta.credentialId) {
+      STORE.updateWalletMeta({ credentialId });
+    }
+  } finally {
+    words = null;
+  }
+}

--- a/src/passkey/passkeySigner.js
+++ b/src/passkey/passkeySigner.js
@@ -86,98 +86,117 @@ export function consumePasskeySigningCancelled() {
 }
 
 /**
+ * Run a passkey ceremony under the single-flight guard. The OS shows one credential sheet at a
+ * time, so a second concurrent ceremony — a double-tap, or an unlock overlapping a signing
+ * ceremony — must fail fast with PasskeyBusyError instead of opening a second sheet. Used by BOTH
+ * the tx signer and the unlock check, so the guard actually covers every entry point.
+ */
+async function withPasskeyLock(fn) {
+  if (signingInFlight) {
+    throw new PasskeyBusyError();
+  }
+  signingInFlight = true;
+  try {
+    return await fn();
+  } finally {
+    signingInFlight = false;
+  }
+}
+
+/**
  * Build the EcdsaTxSign callback for wallet.setExternalTxSigningMethod().
  * Signature contract (wallet-lib storage.getTxSignatures): async (tx, storage, pinCode) =>
  * { inputSignatures: [{inputIndex, addressIndex, signature, pubkey}], ncCallerSignature }.
  * The pinCode is a placeholder for passkey wallets and is ignored.
  */
 export function makePasskeyTxSigner() {
-  return async function passkeyTxSigner(tx, storage, _pinCode) {
-    if (signingInFlight) {
-      throw new PasskeyBusyError();
-    }
-    signingInFlight = true;
+  return (tx, storage, _pinCode) => {
+    // Reset the cancelled flag at the very start of every signing ceremony — BEFORE the
+    // single-flight check — so a later consumePasskeySigningCancelled() reflects only this attempt.
     signingCancelled = false;
-    let root = null;
-    try {
-      const meta = STORE.getWalletMeta();
-      let words;
-      let credentialId;
+    return withPasskeyLock(async () => {
+      let root = null;
       try {
-        // Passing the stored credentialId skips the OS passkey picker and prompts
-        // biometrics for THIS wallet's credential directly.
-        ({ words, credentialId } = await signInWalletWordsFromPasskey({
-          credentialId: meta?.credentialId,
-        }));
-      } catch (e) {
-        if (isPasskeyCancel(e)) {
-          signingCancelled = true;
-          throw new PasskeyCancelledError();
+        const meta = STORE.getWalletMeta();
+        let words;
+        let credentialId;
+        try {
+          // Passing the stored credentialId skips the OS passkey picker and prompts
+          // biometrics for THIS wallet's credential directly.
+          ({ words, credentialId } = await signInWalletWordsFromPasskey({
+            credentialId: meta?.credentialId,
+          }));
+        } catch (e) {
+          if (isPasskeyCancel(e)) {
+            signingCancelled = true;
+            throw new PasskeyCancelledError();
+          }
+          throw e;
         }
-        throw e;
+
+        if (!meta?.xpub || derivePasskeyXpub(words) !== meta.xpub) {
+          throw new PasskeyXpubMismatchError(meta?.passkeyLabel);
+        }
+
+        // Wallets signed in before credentialId was captured (or on another device) learn it
+        // here, so the next ceremony can skip the picker too.
+        if (credentialId && credentialId !== meta.credentialId) {
+          STORE.updateWalletMeta({ credentialId });
+        }
+
+        // Derive the account root xpriv once; wallet-lib's signTxInputs derives the per-input
+        // keys from the chain xprivs it requests through the resolver below.
+        root = walletUtils.getXPrivKeyFromSeed(words, { networkName: NETWORK_MAINNET });
+        words = null;
+
+        // Delegate the input-signing loop to wallet-lib so input selection, shielded-spend
+        // handling, the nano/OCB caller signature and encoding all live in one place and don't
+        // drift as the lib evolves. The resolver returns the change-path xpriv for each chain
+        // ('legacy' = m/44'/280'/0'/0, 'spend' = the shielded spend chain m/44'/280'/2'/0).
+        return await transactionUtils.signTxInputs(tx, storage, async (chain) => {
+          const acctPath = chain === 'spend'
+            ? hathorConstants.SHIELDED_SPEND_ACCT_PATH
+            : hathorConstants.P2PKH_ACCT_PATH;
+          return root.deriveNonCompliantChild(acctPath).deriveNonCompliantChild(0);
+        });
+      } finally {
+        // JS cannot zero string memory; dropping every reference as soon as possible is the
+        // best available hygiene (same exposure window the lib has during getMainXPrivKey).
+        root = null;
       }
-
-      if (!meta?.xpub || derivePasskeyXpub(words) !== meta.xpub) {
-        throw new PasskeyXpubMismatchError(meta?.passkeyLabel);
-      }
-
-      // Wallets signed in before credentialId was captured (or on another device) learn it
-      // here, so the next ceremony can skip the picker too.
-      if (credentialId && credentialId !== meta.credentialId) {
-        STORE.updateWalletMeta({ credentialId });
-      }
-
-      // Derive the account root xpriv once; wallet-lib's signTxInputs derives the per-input
-      // keys from the chain xprivs it requests through the resolver below.
-      root = walletUtils.getXPrivKeyFromSeed(words, { networkName: NETWORK_MAINNET });
-      words = null;
-
-      // Delegate the input-signing loop to wallet-lib so input selection, shielded-spend
-      // handling, the nano/OCB caller signature and encoding all live in one place and don't
-      // drift as the lib evolves. The resolver returns the change-path xpriv for each chain
-      // ('legacy' = m/44'/280'/0'/0, 'spend' = the shielded spend chain m/44'/280'/2'/0).
-      return await transactionUtils.signTxInputs(tx, storage, async (chain) => {
-        const acctPath = chain === 'spend'
-          ? hathorConstants.SHIELDED_SPEND_ACCT_PATH
-          : hathorConstants.P2PKH_ACCT_PATH;
-        return root.deriveNonCompliantChild(acctPath).deriveNonCompliantChild(0);
-      });
-    } finally {
-      // JS cannot zero string memory; dropping every reference as soon as possible is the
-      // best available hygiene (same exposure window the lib has during getMainXPrivKey).
-      root = null;
-      signingInFlight = false;
-    }
+    });
   };
 }
 
 /**
  * Verify-only ceremony for the lock screen: asserts the passkey, checks it opens the loaded
- * wallet, and discards the derived material. Resolves on success; throws
- * PasskeyCancelledError / PasskeyXpubMismatchError otherwise.
+ * wallet, and discards the derived material. Runs under the same single-flight guard as signing.
+ * Resolves on success; throws PasskeyCancelledError / PasskeyXpubMismatchError / PasskeyBusyError.
  */
-export async function verifyPasskeyForUnlock() {
-  const meta = STORE.getWalletMeta();
-  let words = null;
-  let credentialId = null;
-  try {
-    ({ words, credentialId } = await signInWalletWordsFromPasskey({
-      credentialId: meta?.credentialId,
-    }));
-  } catch (e) {
-    if (isPasskeyCancel(e)) {
-      throw new PasskeyCancelledError();
+export function verifyPasskeyForUnlock() {
+  return withPasskeyLock(async () => {
+    const meta = STORE.getWalletMeta();
+    let words = null;
+    let credentialId = null;
+    try {
+      ({ words, credentialId } = await signInWalletWordsFromPasskey({
+        credentialId: meta?.credentialId,
+      }));
+    } catch (e) {
+      if (isPasskeyCancel(e)) {
+        throw new PasskeyCancelledError();
+      }
+      throw e;
     }
-    throw e;
-  }
-  try {
-    if (!meta?.xpub || derivePasskeyXpub(words) !== meta.xpub) {
-      throw new PasskeyXpubMismatchError(meta?.passkeyLabel);
+    try {
+      if (!meta?.xpub || derivePasskeyXpub(words) !== meta.xpub) {
+        throw new PasskeyXpubMismatchError(meta?.passkeyLabel);
+      }
+      if (credentialId && credentialId !== meta.credentialId) {
+        STORE.updateWalletMeta({ credentialId });
+      }
+    } finally {
+      words = null;
     }
-    if (credentialId && credentialId !== meta.credentialId) {
-      STORE.updateWalletMeta({ credentialId });
-    }
-  } finally {
-    words = null;
-  }
+  });
 }

--- a/src/store.js
+++ b/src/store.js
@@ -386,13 +386,16 @@ class AsyncStorageStore {
 
   /**
    * Merge a patch into the wallet metadata (e.g. backfill credentialId after a ceremony).
-   * No-op when no metadata exists.
+   * No-op when no metadata exists. Returns the underlying setItem promise so callers can await
+   * durability or attach a .catch() — without it, a rejected AsyncStorage write here would be an
+   * unhandled rejection.
+   *
+   * @returns {Promise<void>}
    */
   updateWalletMeta(patch) {
     const meta = this.getWalletMeta();
-    if (meta) {
-      this.setItem(WALLET_META_KEY, { ...meta, ...patch });
-    }
+    if (!meta) return Promise.resolve();
+    return this.setItem(WALLET_META_KEY, { ...meta, ...patch });
   }
 
   /**

--- a/src/store.js
+++ b/src/store.js
@@ -267,7 +267,9 @@ class AsyncStorageStore {
     // JSONBigInt round-trips bigint values that the native JSON cannot.
     // Required for the wallet-lib 3.x token shape, which can include
     // bigint balance fields under registered tokens.
-    AsyncStorage.setItem(key, bigIntUtils.JSONBigInt.stringify(value));
+    // Return the promise so callers that need durability (e.g. initPasskeyStorage, whose
+    // walletMeta.xpub is the wallet's ONLY persisted identity) can await the flush.
+    return AsyncStorage.setItem(key, bigIntUtils.JSONBigInt.stringify(value));
   }
 
   /**
@@ -358,7 +360,10 @@ class AsyncStorageStore {
     const accessData = walletUtils.generateAccessDataFromXpub(xpub);
     const storage = this.getStorage();
     await storage.saveAccessData(accessData);
-    this.setItem(WALLET_META_KEY, {
+    // Await the meta write: for a passkey wallet this record's xpub is the only persisted identity
+    // (no seed, no PIN), so an app-kill in the flush window would lose it (recoverable only via a
+    // fresh discoverable sign-in).
+    await this.setItem(WALLET_META_KEY, {
       walletType: 'passkey',
       xpub,
       createdAt: Date.now(),

--- a/src/store.js
+++ b/src/store.js
@@ -29,6 +29,9 @@ export const SAFE_BIOMETRY_FEATURE_FLAG_KEY = 'asyncstorage:featureFlagSafeBiome
 // These are the last known values of the unleash feature toggles
 // These are updated on every call to unleash
 export const FEATURE_TOGGLES_LAST_KNOWN_VALUES_KEY = 'asyncstorage:featureTogglesLastKnownValues';
+// App-level wallet metadata: { walletType, passkeyLabel, xpub, credentialId?, createdAt }.
+// Only present for passkey (xpub-only) wallets; absent means a regular seed+PIN wallet.
+export const WALLET_META_KEY = 'asyncstorage:walletMeta';
 
 export const walletKeys = [
   ACCESS_DATA_KEY,
@@ -36,6 +39,7 @@ export const walletKeys = [
   REGISTERED_NANO_CONTRACTS_KEY,
   NETWORK_TOKENS_KEY,
   NETWORK_NANO_CONTRACTS_KEY,
+  WALLET_META_KEY,
 ];
 
 export const cleanOnWalletReset = [
@@ -340,6 +344,58 @@ class AsyncStorageStore {
     );
     const storage = this.getStorage();
     await storage.saveAccessData(accessData);
+  }
+
+  /**
+   * Generate READ-ONLY accessData from an account-path xpub and persist the passkey
+   * wallet metadata. Used by the passkey (PIN-less) onboarding: no seed, no PIN, no
+   * password — the persisted access data contains no secret at all.
+   *
+   * @param {string} xpub - Account-path xpub (m/44'/280'/0') derived from the passkey PRF seed
+   * @param {{ passkeyLabel: string, credentialId?: string }} meta - Passkey wallet metadata
+   */
+  async initPasskeyStorage(xpub, meta) {
+    const accessData = walletUtils.generateAccessDataFromXpub(xpub);
+    const storage = this.getStorage();
+    await storage.saveAccessData(accessData);
+    this.setItem(WALLET_META_KEY, {
+      walletType: 'passkey',
+      xpub,
+      createdAt: Date.now(),
+      ...meta,
+    });
+    // A passkey wallet is born on the current storage version — the PIN-based data
+    // migration path (handleDataMigration) must never run for it.
+    this.updateStorageVersion();
+  }
+
+  /**
+   * Get the app-level wallet metadata (only present for passkey wallets).
+   * Synchronous after preStart() has populated the memory cache.
+   *
+   * @returns {{ walletType: string, passkeyLabel: string, xpub: string }|null}
+   */
+  getWalletMeta() {
+    return this.getItem(WALLET_META_KEY);
+  }
+
+  /**
+   * Merge a patch into the wallet metadata (e.g. backfill credentialId after a ceremony).
+   * No-op when no metadata exists.
+   */
+  updateWalletMeta(patch) {
+    const meta = this.getWalletMeta();
+    if (meta) {
+      this.setItem(WALLET_META_KEY, { ...meta, ...patch });
+    }
+  }
+
+  /**
+   * Whether the loaded wallet is a passkey (xpub-only, PIN-less) wallet.
+   * @returns {boolean}
+   */
+  isPasskeyWallet() {
+    return this.getWalletMeta()?.walletType === 'passkey';
   }
 
   /**


### PR DESCRIPTION
### Summary

The self-contained passkey module that a passkey wallet is built on — **first of two stacked PRs**. It's gated behind the `passkey-onboarding.rollout` flag (off) and **not yet wired into any screen**, so it ships inert; the onboarding UI and PIN-less flows that consume it land in the follow-up (`feat/passkey-integration`).

What's here:
- **`passkeyService`** — the WebAuthn PRF ceremony (create / sign in with a passkey) and `user.id` encoding (UTF-8 byte-budgeted so any wallet name stays within WebAuthn's 64-byte cap).
- **`passkeySigner`** — `derivePasskeyXpub` (PRF seed → account xpub), the external tx signer (`makePasskeyTxSigner`) that **reuses wallet-lib's `transactionUtils.signTxInputs`** instead of duplicating the signing loop, unlock verification, and the `PasskeyCancelled` / `PasskeyXpubMismatch` / `PasskeyBusy` (single-flight) error types. Error messages are plain strings here — the `ttag` wrapping + translations land in the integration PR.
- **`store`** — `initPasskeyStorage` / `walletMeta` / `isPasskeyWallet`: an xpub-only wallet persists only `{ walletType, xpub, passkeyLabel, credentialId? }` — **no seed, no PIN, no encrypted key**.
- **`constants`** — RP id/name, PRF salt, and the feature toggle (default off).
- **`react-native-passkey`** dependency + a jest virtual-mock fix (`jestMockSetup`) that unblocks the suite, plus `passkeySigner` unit tests.

### Acceptance Criteria
- Module compiles and `__tests__/passkey/passkeySigner.test.js` passes (9 tests: cancelled / xpub-mismatch / busy single-flight / happy path).
- `derivePasskeyXpub(words)` deterministically yields the account-path (`m/44'/280'/0'`) xpub.
- The external tx signer produces signatures via `transactionUtils.signTxInputs` (no duplicated signing logic).
- `initPasskeyStorage` persists **only** the xpub + label + `walletType` marker — verify no seed / encrypted key is written.
- `user.id` encoding stays ≤ 64 bytes for a CJK/emoji wallet name (byte-budget truncation, not string-length).
- The jest suite starts (previously died in `jestMockSetup` on uninstalled modules).
- **No behavior change to the app**: nothing imports the module from a screen/saga yet; the feature flag is defined but off.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added passkey-based onboarding and sign-in using PRF-enabled passkeys.
  - Enabled passkey-based transaction signing and unlock verification for xpub-only wallets.
  - Persist wallet metadata for passkey wallets, including `credentialId` backfill and passkey wallet detection.
  - Added passkey onboarding feature toggle and PRF configuration (default off).
- **Tests**
  - Added deterministic passkey signing/unlock tests covering cancellation, xpub mismatch, missing metadata, credentialId backfill, and single-flight concurrency.
- **Chores**
  - Added `react-native-passkey` and adjusted Jest transform settings for affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->